### PR TITLE
Make sure exported property matches Python naming conventions

### DIFF
--- a/themes/default/content/docs/get-started/azure/modify-program.md
+++ b/themes/default/content/docs/get-started/azure/modify-program.md
@@ -204,7 +204,7 @@ Finally, at the end of `__main__.py`, export the resulting storage container's e
 
 ```python
 # Web endpoint to the website
-pulumi.export("staticEndpoint", account.primary_endpoints.web)
+pulumi.export("static_endpoint", account.primary_endpoints.web)
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Ported from https://github.com/pulumi/docs/pull/5598

In addition to matching Python naming conventions, this fix also ensures the `curl` statement on https://www.pulumi.com/docs/get-started/azure/deploy-changes/ executes successfully when choosing Python as the language for the tutorial.