### PR TITLE
Bump Hugo to 0.82

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.81.0'
+          hugo-version: '0.82.0'
           extended: true
 
       - name: Check out branch

--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -5,7 +5,7 @@ set -o errexit -o pipefail
 source ./scripts/common.sh
 
 REQUIRED_GO="1.16"
-REQUIRED_HUGO="0.81"
+REQUIRED_HUGO="0.82"
 REQUIRED_NODE="$(cat .nvmrc)"
 
 # Check for the required versions of Go, Hugo, Node, and Yarn.


### PR DESCRIPTION
To align with https://github.com/pulumi/docs/pull/5671, which upgrades Hugo to 0.82 as well.

https://github.com/gohugoio/hugo/releases