### PR TITLE
Python s3.BucketObject takes source argument, not content

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -188,7 +188,7 @@ bucketObject = s3.BucketObject(
     acl='public-read',
     content_type='text/html',
     bucket=bucket,
-    content=pulumi.FileAsset('index.html'),
+    source=pulumi.FileAsset('index.html'),
 )
 ```
 


### PR DESCRIPTION
Using content will result in this error:

    Diagnostics:
      aws:s3:BucketObject (index.html):
        error: unexpected asset content