### PR TITLE
Add docs to ensure users know Fish completions are supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 resources
 themes/*/resources
 public
+.idea/

--- a/themes/default/content/docs/reference/cli/_index.md
+++ b/themes/default/content/docs/reference/cli/_index.md
@@ -107,3 +107,19 @@ Then reload your shell:
 ```shell
 exec $SHELL -l
 ```
+  
+### Fish
+
+The `pulumi gen-completion fish` command self-generates its own CLI script. You can save the output to a file or use it in the current session:
+
+```shell
+pulumi gen-completion fish | source
+```
+
+To load the completions for each session, you need to save the completion to a file:
+
+```bash
+pulumi gen-completion fish > ~/.config/fish/completions/yourprogram.fish
+```
+
+Finally, after saving the `pulumi` fish completion script, you need to reopen your terminal for the scripts to take effect.


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/5668

Also ignores .idea folders to ensure these don't get checked in by something

We should standardise (in another PR) for what should go in a .gitignore)