### PR TITLE
Add comma after last arg for go example in AWS quickstart

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -219,7 +219,7 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
     ContentType: pulumi.String("text/html"),
     Bucket:      bucket.ID(),
-    Source:      pulumi.NewFileAsset("index.html")
+    Source:      pulumi.NewFileAsset("index.html"),
 })
 ```
 

--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -111,7 +111,7 @@ In `main.go`, create the `BucketObject` right after creating the bucket itself.
 ```go
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket:  bucket.ID(),
-    Source: pulumi.NewFileAsset("index.html")
+    Source: pulumi.NewFileAsset("index.html"),
 })
 if err != nil {
     return err


### PR DESCRIPTION
Without the last comma, go is unhappy

Signed-off-by: Matt Stratton <matt.stratton@hey.com>