### PR TITLE
Fixed dereference issue in K8s Getting Started tutorial

### DIFF
--- a/themes/default/content/docs/get-started/kubernetes/modify-program.md
+++ b/themes/default/content/docs/get-started/kubernetes/modify-program.md
@@ -233,7 +233,10 @@ func main() {
 
         if isMinikube {
             ip = frontend.Spec.ApplyT(func(val *corev1.ServiceSpec) string {
-                return *val.ClusterIP
+                if val.ClusterIP != nil {
+				    return *val.ClusterIP
+			    }
+			    return ""
             }).(pulumi.StringOutput)
         } else {
             ip = frontend.Status.ApplyT(func(val *corev1.ServiceStatus) string {


### PR DESCRIPTION
Got a nil pointer dereference runtime error when running through the tutorial with the new ApplyT changes, so I added in this check.

Note: I wasn't sure what to return if the minikube `ClusterIP` value is nil, so I just return an empty string. Happy to change it to whatever the best practice is.