### PR TITLE
Remove countdown and update button text on PulumiUP landing page

### DIFF
--- a/themes/default/layouts/page/pulumi-up.html
+++ b/themes/default/layouts/page/pulumi-up.html
@@ -15,14 +15,7 @@
                         playing-text="PAUSE THE VIBE"
                         url="https://www.pulumi.com/uploads/pulumiup-background-loop.mp4"
                     ></pulumi-audio>
-                    <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-orange orange-neon inline-block ml-8">Join Now</a>
-                </div>
-                <div class="lg:mt-16">
-                    <pulumi-date-countdown
-                        value-label-class="text-2xl"
-                        text-class="date-countdown"
-                        date-string="{{ .Params.countdown_date }}"
-                    ></pulumi-date-countdown>
+                    <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-orange orange-neon inline-block ml-8">Watch Now</a>
                 </div>
             </div>
         </div>
@@ -39,7 +32,7 @@
                             the future of building on the cloud.
                         </p>
                         <div class="text-center">
-                            <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-lg btn-orange orange-neon">Join Now</a>
+                            <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-lg btn-orange orange-neon">Watch Now</a>
                         </div>
                     </div>
                     <div data-title="The Plan" class="neon-callout-box-green p-16 pt-4">
@@ -73,7 +66,7 @@
                                     </div>
                                 {{ end }}
                                 <div class="my-12 text-center">
-                                    <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-lg btn-orange">Join Now</a>
+                                    <a href="https://www.bigmarker.com/pulumi/PulumiUP" target="_blank" rel="noreferrer noopener" class="btn btn-lg btn-orange">Watch Now</a>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Just as the title states. Now that the event is over we should remove the countdown.