### PR TITLE
Remove warning about unchecking gRPC FUSE warning

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -73,11 +73,6 @@ Regardless of the quickstart option you choose below, `run-ee.sh` will be the wa
 
 ### Quickstart Option #1 - Using the all-in-one approach
 
-{{% notes type="warning" %}}
-If you are running this option on a macOS, then ensure that the experimental feature "Use gRPC FUSE for file sharing" is
-not enabled. You can find this setting in your Docker Desktop's preferences window under Experimental Features.
-{{% /notes %}}
-
 If you would like to use Pulumi’s all-in-one solution, you just need to run the run-ee.sh like this: `run-ee.sh -f ./all-in-one/docker-compose.yml`.
 This will start all components using working defaults, including a DB container that is migrated using our DB scripts.
 


### PR DESCRIPTION
We had a warning about a Docker x macOS bug. However, it has since been fixed. (Or at the very least, we cannot reproduce the problems you encounter if you have that option checked.) So removing it from the docs.

<img width="802" alt="image" src="https://user-images.githubusercontent.com/4029847/115442235-a04e1380-a1c6-11eb-807c-559c7aa8c102.png">

cc https://github.com/pulumi/pulumi-ee/issues/10