### PR TITLE
Add max height for homepage hero

### DIFF
--- a/themes/default/assets/sass/_hero.scss
+++ b/themes/default/assets/sass/_hero.scss
@@ -68,6 +68,7 @@
         // 145px is the combined height of nav and header
         height: calc(50vh - 145px);
         min-height: 400px;
+        max-height: 600px;
     }
 
     .dot-overlay {


### PR DESCRIPTION
This addresses https://github.com/pulumi/pulumi-hugo/issues/86, to decrease the gap between the homepage hero and content on especially tall screens.

With this change, for a screen height of 2150:
<img width="657" alt="Screen Shot 2021-04-20 at 12 40 17 PM" src="https://user-images.githubusercontent.com/25756367/115454544-bca57c80-a1d5-11eb-9959-c2fde091cfdb.png">
 