### PR TITLE
Fix some broken links

### DIFF
--- a/themes/default/content/blog/automation-api-python/index.md
+++ b/themes/default/content/blog/automation-api-python/index.md
@@ -20,7 +20,7 @@ Today, we are excited to announce Python support for this powerful feature, open
 
 The Automation API is a subpackage in Pulumi’s language-specific SDKs that provides a programmable interface for creating and managing [Stacks]({{< relref "/docs/intro/concepts/stack" >}}) and performing infrastructure updates, refresh, previews, and destroy. You can define a Pulumi program as a function within your codebase and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine.
 
-To use Automation API, install the Pulumi CLI, which bundles and distributes the core engine. Today it’s available for [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/x/automation), [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation) and [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
+To use Automation API, install the Pulumi CLI, which bundles and distributes the core engine. Today it’s available for [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation) and [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
 
 ## Automation Use Cases
 

--- a/themes/default/content/blog/automation-api-python/index.md
+++ b/themes/default/content/blog/automation-api-python/index.md
@@ -20,7 +20,7 @@ Today, we are excited to announce Python support for this powerful feature, open
 
 The Automation API is a subpackage in Pulumi’s language-specific SDKs that provides a programmable interface for creating and managing [Stacks]({{< relref "/docs/intro/concepts/stack" >}}) and performing infrastructure updates, refresh, previews, and destroy. You can define a Pulumi program as a function within your codebase and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine.
 
-To use Automation API, install the Pulumi CLI, which bundles and distributes the core engine. Today it’s available for [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation) and [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
+To use Automation API, install the Pulumi CLI, which bundles and distributes the core engine. Today it’s available for [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/automation) and [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/auto), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
 
 ## Automation Use Cases
 

--- a/themes/default/content/blog/automation-api/index.md
+++ b/themes/default/content/blog/automation-api/index.md
@@ -34,7 +34,7 @@ So far, our users have applied the Pulumi Automation API to these scenarios:
 
 The Automation API is a new subpackage in each of Pulumi’s language-specific SDKs that provides APIs to create and manage Stacks and perform lifecycle operations like update, refresh, preview, and destroy. It is a strongly typed and safe way to use Pulumi in embedded contexts such as web servers without having to shell out to a CLI.
 
-You can define a Pulumi program as a function within your codebase rather than in a separate project and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine. It still requires a Pulumi CLI installation, as this is how we bundle and distribute the core engine. Today it’s available in preview for [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation), [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto) and [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/x/automation), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
+You can define a Pulumi program as a function within your codebase rather than in a separate project and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine. It still requires a Pulumi CLI installation, as this is how we bundle and distribute the core engine. Today it’s available in preview for [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation), [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto) and [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
 
 ## Platform APIs
 
@@ -626,7 +626,7 @@ The Automation API is your tool to tame Cloud Engineering complexity and give yo
 
 - [Go documentation](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto)
 - [JavaScript/TypeScript documentation](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation/)
-- [Python documentation](https://www.pulumi.com/docs/reference/pkg/python/pulumi/#module-pulumi.x.automation)  
+- [Python documentation](https://www.pulumi.com/docs/reference/pkg/python/pulumi/#module-pulumi.x.automation)
 - [The Automation API examples repo](https://github.com/pulumi/automation-api-examples)
 - The list of [known issues](https://github.com/pulumi/pulumi/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fautomation-api). Please [file more](https://github.com/pulumi/pulumi/issues/new?assignees=&labels=needs-triage&template=bug_report.md&title=) as you find them!
 - [The Pulumi Kubernetes Operator](https://github.com/pulumi/pulumi-kubernetes-operator)

--- a/themes/default/content/blog/automation-api/index.md
+++ b/themes/default/content/blog/automation-api/index.md
@@ -34,7 +34,7 @@ So far, our users have applied the Pulumi Automation API to these scenarios:
 
 The Automation API is a new subpackage in each of Pulumi’s language-specific SDKs that provides APIs to create and manage Stacks and perform lifecycle operations like update, refresh, preview, and destroy. It is a strongly typed and safe way to use Pulumi in embedded contexts such as web servers without having to shell out to a CLI.
 
-You can define a Pulumi program as a function within your codebase rather than in a separate project and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine. It still requires a Pulumi CLI installation, as this is how we bundle and distribute the core engine. Today it’s available in preview for [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation), [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto) and [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
+You can define a Pulumi program as a function within your codebase rather than in a separate project and use methods to get and set configuration parameters programmatically. The Automation API uses a gRPC interface to execute programs that control and communicate with the core Pulumi engine. It still requires a Pulumi CLI installation, as this is how we bundle and distribute the core engine. Today it’s available in preview for [TypeScript/JavaScript](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/automation), [Go](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/auto) and [Python](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/automation), with support for [C#](https://github.com/pulumi/pulumi/compare/auto/dotnet) under active development.
 
 ## Platform APIs
 
@@ -624,8 +624,8 @@ Our VM provisioner uses Automation API, backed by Pulumi’s desired state model
 
 The Automation API is your tool to tame Cloud Engineering complexity and give your team the leverage to automate your cloud infrastructure. It is completely open source and available today for TypeScript/JavaScript, Go and Python. Want to learn more? Come hang out with us in the [#automation-api community slack channel](https://pulumi-community.slack.com/archives/C019YSXN04B). Download the latest Pulumi release and check out these resources to get started:
 
-- [Go documentation](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/x/auto)
-- [JavaScript/TypeScript documentation](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/x/automation/)
+- [Go documentation](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/auto)
+- [JavaScript/TypeScript documentation](https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/automation)
 - [Python documentation](https://www.pulumi.com/docs/reference/pkg/python/pulumi/#module-pulumi.x.automation)
 - [The Automation API examples repo](https://github.com/pulumi/automation-api-examples)
 - The list of [known issues](https://github.com/pulumi/pulumi/issues?q=is%3Aissue+is%3Aopen+label%3Aarea%2Fautomation-api). Please [file more](https://github.com/pulumi/pulumi/issues/new?assignees=&labels=needs-triage&template=bug_report.md&title=) as you find them!

--- a/themes/default/content/blog/getting-started-with-pac/index.md
+++ b/themes/default/content/blog/getting-started-with-pac/index.md
@@ -94,7 +94,7 @@ CrossGuard validated the desired state of the S3 bucket against the `no-public-r
 
 ## Exposed Databases
 
-Like S3 buckets, exposed services are another source of data breaches. Misconfigured databases, failing to set passwords, or dev services open to the public are responsible for releases of Personal Identifiable Information (PII) that range well into the millions of customers. Many of these breaches were due to misconfigured Elasticsearch instances that were public and not secured with a password, such as the recent exposure of a [Microsoft customer service database](https://siliconangle.com/2020/01/22/microsoft-exposes-250m-customer-service-records-via-misconfigured-elasticsearch-database/).
+Like S3 buckets, exposed services are another source of data breaches. Misconfigured databases, failing to set passwords, or dev services open to the public are responsible for releases of Personal Identifiable Information (PII) that range well into the millions of customers. Many of these breaches were due to misconfigured Elasticsearch instances that were public and not secured with a password, such as the recent exposure of a Microsoft customer service database.
 
 We’ll take the same approach that we used to secure S3 buckets. First, we'll create an Elasticsearch deployment, write a policy, then apply it.
 

--- a/themes/default/content/case-studies/credijusto.md
+++ b/themes/default/content/case-studies/credijusto.md
@@ -9,7 +9,7 @@ meta_desc: |
 
 customer_name: Credijusto
 customer_logo: /logos/customers/credijusto_logo.svg
-customer_url: https://www.credijusto.com
+customer_url: https://credijusto.com
 
 exec_summary: |
     Founded in 2015, [Credijusto](https://credijusto.com/) provides asset-backed loans and

--- a/themes/default/content/product/_index.md
+++ b/themes/default/content/product/_index.md
@@ -35,7 +35,7 @@ key_features:
               icon: puzzle
               icon_color: yellow
               description:
-                Deploy and configure cloud infrastructure with  [Pulumi Packages](/docs/docs/guides/pulumi-packages/), which can be
+                Deploy and configure cloud infrastructure with  [Pulumi Packages](/docs/guides/pulumi-packages/), which can be
                 shared and reused by anyone and in any language.
 
         - description: Deploy cloud infrastructure and applications together
@@ -51,7 +51,7 @@ key_features:
               icon: gear
               icon_color: salmon
               description: |
-                Run deployments from your application code at runtime with [Automation API](/docs/docs/guides/automation-api/). Create infrastructure APIs, custom platforms, and CLIs.
+                Run deployments from your application code at runtime with [Automation API](/docs/guides/automation-api/). Create infrastructure APIs, custom platforms, and CLIs.
 
             - title: Preview and test changes
               icon: eye


### PR DESCRIPTION
Fixes some errors from today's link-check run:

• /case-studies/credijusto/ → https://www.credijusto.com/ (HTTP_308)
• /case-studies/credijusto/ → https://www.credijusto.com/ (HTTP_308)
• /blog/automation-api/ → https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/x/automation (HTTP_404)
• /blog/automation-api-python/ → https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/pulumi/x/automation (HTTP_404)
• /blog/getting-started-with-pac/ → https://siliconangle.com/2020/01/22/microsoft-exposes-250m-customer-service-records-via-misconfigured-elasticsearch-database/ (HTTP_500)
• /product/ → https://www.pulumi.com/docs/docs/guides/pulumi-packages/ (HTTP_403)
• /product/ → https://www.pulumi.com/docs/docs/guides/automation-api/ (HTTP_403)