### PR TITLE
Add link to self-managed backend on self-hosted pages.

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -8,7 +8,9 @@ meta_desc: Pulumi Enterprise Edition gives you the option to self-host Pulumi wi
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+
+For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 This guide walks you through the components that are required to get the Pulumi Service running in your own environment.

--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -8,9 +8,9 @@ meta_desc: Pulumi Enterprise Edition gives you the option to self-host Pulumi wi
 ---
 
 {{% notes type="info" %}}
-This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
-For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
+To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 This guide walks you through the components that are required to get the Pulumi Service running in your own environment.

--- a/themes/default/content/docs/guides/self-hosted/api.md
+++ b/themes/default/content/docs/guides/self-hosted/api.md
@@ -9,9 +9,9 @@ meta_desc: Pulumi API is one of the components required for self-hosting Pulumi.
 ---
 
 {{% notes type="info" %}}
-This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
-For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
+To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 The Pulumi API is one of the components required for self-hosting Pulumi in your organization's environment. It provides the necessary APIs for both the CLI and the [Console]({{< relref "console" >}}).

--- a/themes/default/content/docs/guides/self-hosted/api.md
+++ b/themes/default/content/docs/guides/self-hosted/api.md
@@ -9,7 +9,9 @@ meta_desc: Pulumi API is one of the components required for self-hosting Pulumi.
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+
+For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 The Pulumi API is one of the components required for self-hosting Pulumi in your organization's environment. It provides the necessary APIs for both the CLI and the [Console]({{< relref "console" >}}).

--- a/themes/default/content/docs/guides/self-hosted/console.md
+++ b/themes/default/content/docs/guides/self-hosted/console.md
@@ -9,9 +9,9 @@ meta_desc: Pulumi Console is one of the components required for self-hosting Pul
 ---
 
 {{% notes type="info" %}}
-This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
-For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
+To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 The Pulumi Console allows users to view the stacks they have created, see any past activities recorded for those stacks. It also allows you to manage RBAC for your users.

--- a/themes/default/content/docs/guides/self-hosted/console.md
+++ b/themes/default/content/docs/guides/self-hosted/console.md
@@ -9,7 +9,9 @@ meta_desc: Pulumi Console is one of the components required for self-hosting Pul
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+This page is for Self-Hosting of the **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+
+For the **open source self-managed backends** see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}
 
 The Pulumi Console allows users to view the stacks they have created, see any past activities recorded for those stacks. It also allows you to manage RBAC for your users.


### PR DESCRIPTION
Attempt to help with confusion between Self-Hosted and Self-Managed backends.