### PR TITLE
Fix a syntax error

### DIFF
--- a/themes/default/content/docs/get-started/gcp/modify-program.md
+++ b/themes/default/content/docs/get-started/gcp/modify-program.md
@@ -111,7 +111,7 @@ In `main.go`, create the `BucketObject` right after creating the bucket itself.
 ```go
 bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
     Bucket: bucket.Name,
-    Source: pulumi.NewFileAsset("index.html")
+    Source: pulumi.NewFileAsset("index.html"),
 })
 if err != nil {
     return err


### PR DESCRIPTION
Lists of member definitions need a comma after each member.

It's the smallest PR ever, but I'd be happy to contribute.