### PR TITLE
Fix MockCallArgs property in Golang example

### DIFF
--- a/themes/default/content/docs/guides/testing/unit.md
+++ b/themes/default/content/docs/guides/testing/unit.md
@@ -288,7 +288,7 @@ func (mocks) NewResource(args MockResourceArgs) (string, resource.PropertyMap, e
 }
 
 func (mocks) Call(args MockCallArgs) (resource.PropertyMap, error) {
-	return args.Inputs, nil
+	return args.Args, nil
 }
 ```
 


### PR DESCRIPTION
The `MockCallArgs` does not have `Inputs` as a property. This should be `Args`.

Source code: https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi/mocks.go#L34

Doc page: https://www.pulumi.com/docs/guides/testing/unit/#add-mocks _select golang examples_