### PR TITLE
Updated structure of Pulumi v. Terraform doc

### DIFF
--- a/themes/default/content/docs/guides/adopting/from_terraform.md
+++ b/themes/default/content/docs/guides/adopting/from_terraform.md
@@ -426,31 +426,56 @@ To use this tool, [first install it](https://github.com/pulumi/tf2pulumi#buildin
 
 Next, `cd` into a Terraform project you'd like to convert. Create a new Pulumi project:
 
+{{< chooser language "typescript,python,go,csharp" >}}
+{{% choosable language typescript %}}
+
 ```bash
 $ pulumi new typescript -f
 ```
 
-> At the moment, TypeScript and Python are the only language targets. Let us know if your desired language isn't available.
-
 Next, run `tf2pulumi`. It will convert the entire project whose directory you are in and put the resulting code in the local directory.
 
-{{< chooser language "typescript,python" >}}
-
-{{% choosable language typescript %}}
-
 ```bash
-$ tf2pulumi
+$ tf2pulumi --target-language typescript
 ```
-
 {{% /choosable %}}
 {{% choosable language python %}}
 
 ```bash
-$ tf2pulumi --target-language python
+$ pulumi new python -f
 ```
 
+Next, run `tf2pulumi`. It will convert the entire project whose directory you are in and put the resulting code in the local directory.
+
+```bash
+$ tf2pulumi --target-language python
+```
 {{% /choosable %}}
-{{% /chooser %}}
+{{% choosable language go %}}
+
+```bash
+$ pulumi new go -f
+```
+
+Next, run `tf2pulumi`. It will convert the entire project whose directory you are in and put the resulting code in the local directory.
+
+```bash
+$ tf2pulumi --target-language go
+```
+{{% /choosable %}}
+{{% choosable language csharp %}}
+
+```bash
+$ pulumi new csharp -f
+```
+
+Next, run `tf2pulumi`. It will convert the entire project whose directory you are in and put the resulting code in the local directory.
+
+```bash
+$ tf2pulumi --target-language csharp
+```
+{{% /choosable %}}
+{{< /chooser >}}
 
 This will generate a Pulumi TypeScript program in index.ts that when run with pulumi update will deploy the infrastructure originally described by the Terraform project. Note that if your infrastructure references files or directories with paths relative to the location of the Terraform project, you will most likely need to update these paths such that they are relative to the generated index.ts file.
 
@@ -462,7 +487,7 @@ If you'd like to record the original HCL source code positions in the resulting 
 
 That command converted the static HCL source code to Pulumi code. What if you want to import existing resource states from a `.tfstate` file, however, to avoid unnecessarily recreating your infrastructure?
 
-To do so, [copy the `import.ts` file from this repo](https://github.com/pulumi/tf2pulumi/blob/master/misc/import/import.ts) into your new stack's directory, and add the following near the top of your generated `index.ts` file just before any resource creations:
+If you are using TypeScript, [copy the `import.ts` file from this repo](https://github.com/pulumi/tf2pulumi/blob/master/misc/import/import.ts) into your new stack's directory and add the following near the top of your generated `index.ts` file just before any resource creations:
 
 ```typescript
 ...

--- a/themes/default/content/docs/guides/adopting/from_terraform.md
+++ b/themes/default/content/docs/guides/adopting/from_terraform.md
@@ -438,6 +438,7 @@ Next, run `tf2pulumi`. It will convert the entire project whose directory you ar
 ```bash
 $ tf2pulumi --target-language typescript
 ```
+
 {{% /choosable %}}
 {{% choosable language python %}}
 
@@ -450,6 +451,7 @@ Next, run `tf2pulumi`. It will convert the entire project whose directory you ar
 ```bash
 $ tf2pulumi --target-language python
 ```
+
 {{% /choosable %}}
 {{% choosable language go %}}
 
@@ -462,6 +464,7 @@ Next, run `tf2pulumi`. It will convert the entire project whose directory you ar
 ```bash
 $ tf2pulumi --target-language go
 ```
+
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
@@ -474,6 +477,7 @@ Next, run `tf2pulumi`. It will convert the entire project whose directory you ar
 ```bash
 $ tf2pulumi --target-language csharp
 ```
+
 {{% /choosable %}}
 {{< /chooser >}}
 

--- a/themes/default/content/docs/intro/vs/terraform.md
+++ b/themes/default/content/docs/intro/vs/terraform.md
@@ -14,40 +14,52 @@ Terraform and Pulumi hold a lot of similarities, but they differ in a few key wa
 Terraform requires the use of a custom programming language, Pulumi allows you to use familiar general purpose languages and tools to accomplish the same goals. Like Terraform, Pulumi is
 [open source on GitHub](https://github.com/pulumi/pulumi) and is [free to use]({{< relref "/docs/get-started" >}}).
 
-## Summary
-
-In Terraform, you write programs in a custom domain-specific-language (DSL) called HashiCorp Configuration Language
-(HCL), and the Terraform engine takes care of provisioning and updating resources. With Pulumi, you use general
-purpose languages to express desired state, and Pulumi's engine similarly gives you diffs and a way to robustly update
-your infrastructure. Both Terraform and Pulumi support many cloud providers, including AWS, Azure, and Google Cloud,
+Both Terraform and Pulumi support many cloud providers, including AWS, Azure, and Google Cloud,
 plus other services like CloudFlare, Digital Ocean, and more. Thanks to integration with Terraform providers, Pulumi
 is able to support a superset of the providers that Terraform currently offers.
 
-## Major Differences Between Terraform and Pulumi
+Here is a summary of the key differences between Pulumi and Terraform:
 
-The major differences between Terraform and Pulumi are as follows:
+| **Component** | **Pulumi** | **Terraform** |
+| :--- | :--- | :--- |
+| [Language Support]({{< relref "#languagesupport" >}}) | Python, TypeScript, JavaScript, Go, .NET core languages | Hashicorp Configuration Language (HCL) |
+| [State Management]({{< relref "#statemanagement" >}}) | Managed through Pulumi Service by default, self-managed options available | Self-managed by default, managed SaaS offering available |
+| [Provider Support]({{< relref "#providersupport" >}}) | Native cloud providers with 100% same-day resource coverage plus Terraform-based providers for additional coverage | Support across multiple IaaS, SaaS, and PaaS providers |
+| [OSS License]({{< relref "#license" >}}) | Apache License 2.0 | Mozilla Public License 2.0 |
 
-1. Terraform requires that you and your team learn a new custom language, the HCL DSL. In contrast, Pulumi lets you use
-   languages you already know and love, like Python, Go, JavaScript, TypeScript, and C#.
+If you have Terraform HCL that you would like to convert to Pulumi, see [Converting Terraform HCL to Pulumi]({{< relref "/docs/guides/adopting/from_terraform#converting-terraform-hcl-to-pulumi" >}}) in our Adopting Pulumi user guide.
 
-2. Because of the use of familiar languages, you get familiar constructs like for loops, functions, and classes. This
-   significantly improves the ability to cut down on boilerplate and enforce best practices. Instead of creating
-   a new ecosystem of modules and sharing, Pulumi lets you leverage existing package management tools and techniques.
+The following sections go into further detail on the differences between Pulumi and Terraform.
 
-3. Terraform, by default, requires that you manage concurrency and state manually, by way of its "state files." Pulumi,
-   in contrast, uses the free app.pulumi.com service to eliminate these concerns. This makes getting started with
-   Pulumi, and operationalizing it in a team setting, much easier. For advanced use cases, [it is possible to use
-   Pulumi without the service]({{< relref "/docs/troubleshooting/faq#can-i-use-pulumi-without-depending-on-pulumicom" >}}),
-   which works a lot more like Terraform, but it is harder to do and opt-in. Pulumi errs on the side of ease-of-use.
+## Language Support {#languagesupport}
 
-4. Pulumi has deep support for cloud native technologies, like Kubernetes, and supports advanced deployment
-   scenarios that cannot be expressed with Terraform. This includes Prometheus-based canaries, automatic Envoy
-   sidecar injection, and more. Pulumi is a proud member of the Cloud Native Computing Foundation (CNCF).
+Terraform requires that you and your team you write programs in a custom domain-specific-language (DSL) called HashiCorp Configuration Language
+(HCL). In contrast, Pulumi lets you use programming languages like Python, Go, JavaScript, TypeScript, and C#. Because of the use of familiar languages, you get familiar constructs like for loops, functions, and classes. This significantly improves the ability to cut down on boilerplate and enforce best practices. Instead of creating
+a new ecosystem of modules and sharing, Pulumi lets you leverage existing package management tools and techniques.
 
-For some concrete examples of these differences, see our article, [From Terraform to Infrastructure as Software](
-{{< relref "from-terraform-to-infrastructure-as-software" >}}).
+For more information on the languages that Pulumi supports, see [Languages]({{< relref "/docs/intro/languages" >}}).
 
-## Using Terraform Providers
+## State Management {#statemanagement}
+
+The Terraform engine takes care of provisioning and updating resources. With Pulumi, you use general
+purpose languages to express desired state, and Pulumi's engine similarly gives you diffs and a way to robustly update
+your infrastructure.
+
+By default, Terraform requires that you manage concurrency and state manually, by way of its "state files." Pulumi,
+in contrast, uses the free [Pulumi Service](https://app.pulumi.com) to eliminate these concerns. This makes getting started with
+Pulumi, and operationalizing it in a team setting, much easier. For advanced use cases, it is possible to use
+[Pulumi without the service]({{< relref "/docs/troubleshooting/faq#can-i-use-pulumi-without-depending-on-pulumicom" >}}),
+which works a lot more like Terraform, but it requires you to manage state and concurrency issues. Pulumi errs on the side of ease-of-use.
+
+For more information on how Pulumi manages state or how to use different backends, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
+
+## Provider Support {#providersupport}
+
+Pulumi has deep support for cloud native technologies, like Kubernetes, and supports advanced deployment
+scenarios that cannot be expressed with Terraform. This includes Prometheus-based canaries, automatic Envoy
+sidecar injection, and more. Pulumi is a proud member of the Cloud Native Computing Foundation (CNCF).
+
+### Using Terraform Providers
 
 Pulumi is able to adapt [any Terraform Provider](https://github.com/terraform-providers) for use with Pulumi, enabling
 management of any infrastructure supported by the Terraform Providers ecosystem using Pulumi programs.
@@ -63,26 +75,29 @@ In the event you'd like to add new providers, or understand how this integration
 [Pulumi Terraform bridge repo](https://github.com/pulumi/pulumi-terraform-bridge).  This bridge is fully open source and
 makes it easy to create new Pulumi providers out of existing Terraform Providers.
 
-## Converting From Terraform
+### Converting From Terraform
 
-Pulumi offers a tool, [`tf2pulumi`](https://github.com/pulumi/tf2pulumi), that converts Terraform HashiCorp Configuration Language to Pulumi. It is
+Pulumi offers a tool, [tf2pulumi](https://github.com/pulumi/tf2pulumi), that converts Terraform HashiCorp Configuration Language to Pulumi. It is
 open source on GitHub, and works for most projects we have come across; if you run into a snag, Issues and Pull
-Requests are welcome! [Download and use it now.](https://github.com/pulumi/tf2pulumi)
+Requests are welcome!
 
-To learn more, [see Referencing Terraform State in our Adopting Pulumi user guide]({{< relref "/docs/guides/adopting/from_terraform#referencing-terraform-state" >}}).
+To learn more, see [Converting Terraform HCL to Pulumi]({{< relref "/docs/guides/adopting/from_terraform#converting-terraform-hcl-to-pulumi" >}}) in our Adopting Pulumi user guide.
 
-## Using Pulumi and Terraform Side-by-Side
+For an example on how to do this conversion, see our article, [From Terraform to Infrastructure as Software](
+{{< relref "from-terraform-to-infrastructure-as-software" >}}).
 
-Pulumi supports
-[consuming local or remote Terraform state](
-{{< relref "using-terraform-remote-state-with-pulumi" >}})
-from your Pulumi programs. This helps with
-incremental adoption, whereby you continue managing a subset of your infrastructure with Terraform, while you
-incrementally move to Pulumi.
+### Using Pulumi and Terraform Side-by-Side
 
-For instance, say you would like to keep your VPC and low level network definitions written in Terraform so as to
+Pulumi supports [consuming local or remote Terraform state]({{< relref "using-terraform-remote-state-with-pulumi" >}}) from your Pulumi programs. This helps with
+incremental adoption, whereby you continue managing a subset of your infrastructure with Terraform, while you incrementally move to Pulumi.
+
+For example, maybe you would like to keep your VPC and low-level network definitions written in Terraform so as to
 avoid any disruption, or maybe because some of the team would like to stay on Terraform for now and make a shift in the future. Using the
-state reference support described above, you can author higher level infrastructure in Pulumi that consumes the
-Terraform-provisioned VPC information (like the VPC ID, Subnet IDs, etc), making the co-existence of Pulumi and Terraform easy to automate.
+state reference support described previously, you can author higher-level infrastructure in Pulumi that consumes the
+Terraform-provisioned VPC information (such as the VPC ID, Subnet IDs, etc.), making the co-existence of Pulumi and Terraform easy to automate.
 
-To learn more, [see Converting Terraform HCL to Pulumi in our Adopting Pulumi user guide]({{< relref "/docs/guides/adopting/from_terraform#converting-terraform-hcl-to-pulumi" >}}).
+To learn more, see [Referencing Terraform State]({{< relref "/docs/guides/adopting/from_terraform#referencing-terraform-state" >}}) in our Adopting Pulumi user guide.
+
+## OSS License {#license}
+
+Terraform uses the weak copyleft [Mozilla Public License 2.0](https://github.com/hashicorp/terraform/blob/main/LICENSE). Conversely, Pulumi open-source projects use the permissive and business-friendly [Apache License 2.0](https://github.com/pulumi/pulumi/blob/master/LICENSE). This includes the core [Pulumi repo](https://github.com/pulumi/pulumi), all of the open-source Pulumi resource providers (such as the [Azure Native provider](https://github.com/pulumi/pulumi-azure-native)), conversion utilities like [tf2pulumi](https://github.com/pulumi/tf2pulumi), and other useful projects.

--- a/themes/default/content/docs/intro/vs/terraform.md
+++ b/themes/default/content/docs/intro/vs/terraform.md
@@ -22,7 +22,7 @@ Here is a summary of the key differences between Pulumi and Terraform:
 
 | **Component** | **Pulumi** | **Terraform** |
 | :--- | :--- | :--- |
-| [Language Support]({{< relref "#languagesupport" >}}) | Python, TypeScript, JavaScript, Go, .NET core languages | Hashicorp Configuration Language (HCL) |
+| [Language Support]({{< relref "#languagesupport" >}}) | Python, TypeScript, JavaScript, Go, C#, F# | Hashicorp Configuration Language (HCL) |
 | [State Management]({{< relref "#statemanagement" >}}) | Managed through Pulumi Service by default, self-managed options available | Self-managed by default, managed SaaS offering available |
 | [Provider Support]({{< relref "#providersupport" >}}) | Native cloud providers with 100% same-day resource coverage plus Terraform-based providers for additional coverage | Support across multiple IaaS, SaaS, and PaaS providers |
 | [OSS License]({{< relref "#license" >}}) | Apache License 2.0 | Mozilla Public License 2.0 |
@@ -33,7 +33,7 @@ The following sections go into further detail on the differences between Pulumi 
 
 ## Language Support {#languagesupport}
 
-Terraform requires that you and your team you write programs in a custom domain-specific-language (DSL) called HashiCorp Configuration Language
+Terraform requires that you and your team write programs in a custom domain-specific-language (DSL) called HashiCorp Configuration Language
 (HCL). In contrast, Pulumi lets you use programming languages like Python, Go, JavaScript, TypeScript, and C#. Because of the use of familiar languages, you get familiar constructs like for loops, functions, and classes. This significantly improves the ability to cut down on boilerplate and enforce best practices. Instead of creating
 a new ecosystem of modules and sharing, Pulumi lets you leverage existing package management tools and techniques.
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/docs/issues/4589 including customer feedback asking about OSS license comparison.

Also, updated some text on using tf2pulumi for Go and C#.