### PR TITLE
Adding github owner to the github provider setup details

### DIFF
--- a/themes/default/content/docs/intro/cloud-providers/github/setup.md
+++ b/themes/default/content/docs/intro/cloud-providers/github/setup.md
@@ -15,21 +15,30 @@ before it can be used to create resources.
 
 Once obtained, there are two ways to communicate your authorization tokens to Pulumi:
 
-1. Set the environment variable `GITHUB_TOKEN`:
+1. Set the environment variable `GITHUB_TOKEN`.
 
     ```bash
-    $ export GITHUB_TOKEN=XXXXXXXXXXXXXX
     $ export GITHUB_OWNER=YYYYYYYYYYYYYY
     ```
 
-2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
+2. Set the token value using `pulumi config`. This stores your token alongside your Pulumi stack for easy multi-user access.
 
     ```bash
     $ pulumi config set github:token XXXXXXXXXXXXXX --secret
+    ```
+
+    {{% notes type="info" %}}
+Remember to pass `--secret` when setting `github:token` so that it is properly encrypted.
+    {{% /notes %}}
+
+3. (Optional) To target a specific GitHub organization or an individual user account, set the GitHub owner configuration value. If this is not provided, the owner of the GitHub Access Token will be the target of the provider.
+
+    ```bash
+    $ export GITHUB_OWNER=YYYYYYYYYYYYYY
+    ```
+
+    ```bash
     $ pulumi config set github:owner YYYYYYYYYYYYYY
     ```
 
-If you need to target a specific GitHub organization of individual user account then you will need to set the owner configuration
-value. If this is not provided, then the owner of the GitHub Access Token will be the target of the provider. Remember
-to pass `--secret` when setting `github:token` so that it is properly encrypted. A full set of configuration parameters
-can be found listed on the [Project README](https://github.com/pulumi/pulumi-github/blob/master/README.md).
+A full set of configuration parameters can be found listed on the [Project README](https://github.com/pulumi/pulumi-github/blob/master/README.md).

--- a/themes/default/content/docs/intro/cloud-providers/github/setup.md
+++ b/themes/default/content/docs/intro/cloud-providers/github/setup.md
@@ -19,13 +19,17 @@ Once obtained, there are two ways to communicate your authorization tokens to Pu
 
     ```bash
     $ export GITHUB_TOKEN=XXXXXXXXXXXXXX
+    $ export GITHUB_OWNER=YYYYYYYYYYYYYY
     ```
 
 2. Set them using configuration, if you prefer that they be stored alongside your Pulumi stack for easy multi-user access:
 
     ```bash
     $ pulumi config set github:token XXXXXXXXXXXXXX --secret
+    $ pulumi config set github:owner YYYYYYYYYYYYYY
     ```
 
-Remember to pass `--secret` when setting `github:token` so that it is properly encrypted. A full set of configuration parameters
+If you need to target a specific GitHub organization of individual user account then you will need to set the owner configuration
+value. If this is not provided, then the owner of the GitHub Access Token will be the target of the provider. Remember
+to pass `--secret` when setting `github:token` so that it is properly encrypted. A full set of configuration parameters
 can be found listed on the [Project README](https://github.com/pulumi/pulumi-github/blob/master/README.md).


### PR DESCRIPTION
Fixes: https://github.com/pulumi/docs/issues/5359

Please note, the difference from that original issue is that
GITHUB_ORGANIZATION has been deprecated in favour of GITHUB_OWNER as
per https://github.com/pulumi/pulumi-github/#configuration