### PR TITLE
Change from `bucket-path` to `bucket-name`

### DIFF
--- a/themes/default/content/docs/intro/concepts/state.md
+++ b/themes/default/content/docs/intro/concepts/state.md
@@ -150,10 +150,10 @@ Notice that `pulumi login --local` is simply syntactic sugar for `pulumi login f
 
 ##### Logging Into the AWS S3 Backend
 
-To use the [AWS S3](https://aws.amazon.com/s3/) backend, pass the `s3://<bucket-path>` as your `<backend-url>`:
+To use the [AWS S3](https://aws.amazon.com/s3/) backend, pass the `s3://<bucket-name>` as your `<backend-url>`:
 
 ```sh
-$ pulumi login s3://<bucket-path>
+$ pulumi login s3://<bucket-name>
 ```
 
 To configure credentials and authorize access, please see the [AWS Session documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/). For additional configuration options, see [AWS Setup]({{< relref "/docs/intro/cloud-providers/aws/setup" >}}). If you're new to AWS S3, see [the AWS documentation](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html).
@@ -161,7 +161,7 @@ To configure credentials and authorize access, please see the [AWS Session docum
 This backend also supports [alternative object storage servers with AWS S3 compatible REST APIs](https://en.wikipedia.org/wiki/Amazon_S3#S3_API_and_competing_services), including [Minio](https://www.minio.io/), [Ceph](https://ceph.io/), or [SeaweedFS](https://github.com/chrislusf/seaweedfs). To use such a server, you may pass `endpoint`, `disableSSL`, and `s3ForcePathStyle` querystring parameters to your `<backend-url>`, as follows:
 
 ```sh
-$ pulumi login s3://<bucket-path>?endpoint=my.minio.local:8080&disableSSL=true&s3ForcePathStyle=true
+$ pulumi login s3://<bucket-name>?endpoint=my.minio.local:8080&disableSSL=true&s3ForcePathStyle=true
 ```
 
 ##### Logging Into the Azure Blob Storage Backend


### PR DESCRIPTION
Change the variable name to better match AWS documentation. We want a user to enter `s3://my-bucket` rather than `s3://my-bucket.s3-us-east-1.amazonaws.com`