### PR TITLE
Fix Stencil async warnings

### DIFF
--- a/themes/default/components/src/components.d.ts
+++ b/themes/default/components/src/components.d.ts
@@ -21,9 +21,6 @@ import {
 import {
   SourceKind,
 } from './components/convert/convert';
-import {
-  SwiperOptions,
-} from 'swiper';
 
 export namespace Components {
   interface PulumiAudio {
@@ -82,16 +79,16 @@ export namespace Components {
   interface PulumiSwipeable {}
   interface PulumiSwiper {
     'autoplay': boolean;
-    'autoplayDelay': string;
+    'autoplayDelay': number;
     'centeredSlides': boolean;
-    'direction': SwiperOptions["direction"];
+    'direction': "vertical" | "horizontal";
     'enableMouseEvents': boolean;
-    'initialSlide': string;
+    'initialSlide': number;
     'loop': boolean;
     'navControls': boolean;
-    'slides': string;
-    'spaceBetween': string;
-    'speed': string;
+    'slides': number;
+    'spaceBetween': number;
+    'speed': number;
     'startSwiper': () => Promise<void>;
     'stopSwiper': () => Promise<void>;
   }
@@ -298,16 +295,16 @@ declare namespace LocalJSX {
   interface PulumiSwipeable {}
   interface PulumiSwiper {
     'autoplay'?: boolean;
-    'autoplayDelay'?: string;
+    'autoplayDelay'?: number;
     'centeredSlides'?: boolean;
-    'direction'?: SwiperOptions["direction"];
+    'direction'?: "vertical" | "horizontal";
     'enableMouseEvents'?: boolean;
-    'initialSlide'?: string;
+    'initialSlide'?: number;
     'loop'?: boolean;
     'navControls'?: boolean;
-    'slides'?: string;
-    'spaceBetween'?: string;
-    'speed'?: string;
+    'slides'?: number;
+    'spaceBetween'?: number;
+    'speed'?: number;
   }
   interface PulumiTooltip {}
   interface PulumiTopButton {}

--- a/themes/default/components/src/components/convert/convert.e2e.ts
+++ b/themes/default/components/src/components/convert/convert.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('pulumi-convert', () => {
-  it('renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pulumi-convert></pulumi-convert>');
+describe("pulumi-convert", () => {
+    it("renders", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<pulumi-convert from="tf" endpoint="https://someserver/somepath"></pulumi-convert>`);
 
-    const element = await page.find('pulumi-convert');
-    expect(element).toHaveClass('hydrated');
-  });
+        const element = await page.find("pulumi-convert");
+        expect(element).toHaveClass("hydrated");
+    });
 });

--- a/themes/default/components/src/components/slot-machine/slot-machine.tsx
+++ b/themes/default/components/src/components/slot-machine/slot-machine.tsx
@@ -83,14 +83,14 @@ export class SlotMachine {
                     <pulumi-swiper
                         ref={(el) => this.leftSwiper = el}
                         direction="vertical"
-                        slides="3"
-                        centered-slides="true"
+                        slides={3}
+                        centered-slides={true}
                         loop={true}
                         autoplay={true}
-                        autoplayDelay="300"
-                        speed="1000"
+                        autoplayDelay={300}
+                        speed={1000}
                         enable-mouse-events={false}
-                        space-between="120"
+                        space-between={120}
                     >
                         {this.renderImageList(this.leftImages.split(","))}
                     </pulumi-swiper>
@@ -100,14 +100,14 @@ export class SlotMachine {
                     <pulumi-swiper
                         ref={(el) => this.centerSwiper = el}
                         direction="vertical"
-                        slides="3"
-                        centered-slides="true"
+                        slides={3}
+                        centered-slides={true}
                         loop={true}
                         autoplay={true}
-                        autoplayDelay="300"
-                        speed="1000"
+                        autoplayDelay={300}
+                        speed={1000}
                         enable-mouse-events={false}
-                        space-between="120"
+                        space-between={120}
                     >
                         {this.renderImageList(this.centerImages.split(","))}
                     </pulumi-swiper>
@@ -117,14 +117,14 @@ export class SlotMachine {
                     <pulumi-swiper
                         ref={(el) => this.rightSwiper = el}
                         direction="vertical"
-                        slides="3"
-                        centered-slides="true"
+                        slides={3}
+                        centered-slides={true}
                         loop={true}
                         autoplay={true}
-                        autoplayDelay="300"
-                        speed="1000"
+                        autoplayDelay={300}
+                        speed={1000}
                         enable-mouse-events={false}
-                        space-between="120"
+                        space-between={120}
                     >
                         {this.renderImageList(this.rightImages.split(","))}
                     </pulumi-swiper>

--- a/themes/default/components/src/components/swiper/swiper.e2e.ts
+++ b/themes/default/components/src/components/swiper/swiper.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('pulumi-swiper', () => {
-  it('renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pulumi-swiper></pulumi-swiper>');
+describe("pulumi-swiper", () => {
+    it("renders", async () => {
+        const page = await newE2EPage();
+        await page.setContent(`<pulumi-swiper autoplay="false"></pulumi-swiper>`);
 
-    const element = await page.find('pulumi-swiper');
-    expect(element).toHaveClass('hydrated');
-  });
+        const element = await page.find("pulumi-swiper");
+        expect(element).toHaveClass("hydrated");
+    });
 });

--- a/themes/default/components/src/components/swiper/swiper.tsx
+++ b/themes/default/components/src/components/swiper/swiper.tsx
@@ -1,5 +1,7 @@
 import { Component, Element, h, Prop, State, Method } from "@stencil/core";
-import SwiperJS, { Autoplay, Navigation, SwiperOptions } from "swiper";
+import SwiperJS, { Autoplay, Navigation } from "swiper";
+import { AutoplayOptions } from "swiper/components/autoplay";
+import { NavigationOptions } from "swiper/components/navigation";
 
 @Component({
     tag: "pulumi-swiper",
@@ -10,7 +12,7 @@ export class Swiper {
     el: Element;
 
     @Prop()
-    speed = "300";
+    speed = 300;
 
     @Prop()
     loop = false;
@@ -19,31 +21,31 @@ export class Swiper {
     autoplay = false;
 
     @Prop()
-    autoplayDelay = "3000";
+    autoplayDelay = 3000;
 
     @Prop()
     navControls = false;
 
     @Prop()
-    slides = "1";
+    slides = 1;
 
     @Prop()
     centeredSlides = false;
 
     @Prop()
-    initialSlide = "1";
+    initialSlide = 1;
 
     @Prop()
-    direction: SwiperOptions["direction"] = "horizontal";
+    direction: "vertical" | "horizontal" = "horizontal";
 
     @Prop()
     enableMouseEvents = true;
 
     @Prop()
-    spaceBetween = "0";
+    spaceBetween = 0;
 
     @State()
-    swiperHash = Math.random().toString(5).substring(2, 15) + Math.random().toString(5).substring(2, 15);
+    swiperID = Math.random().toString(5).substring(2, 15) + Math.random().toString(5).substring(2, 15);
 
     @State()
     containerClass: string;
@@ -58,6 +60,7 @@ export class Swiper {
 
     componentWillLoad() {
         const modules = [];
+
         if (this.autoplay) {
             modules.push(Autoplay);
         }
@@ -68,45 +71,39 @@ export class Swiper {
 
         SwiperJS.use(modules);
 
-        this.containerClass = `swiper-container-${this.swiperHash}`;
-        this.nextBtnClass = `swiper-button-next-${this.swiperHash}`;
-        this.previousBtnClass = `swiper-button-prev-${this.swiperHash}`;
+        this.containerClass = `swiper-container-${this.swiperID}`;
+        this.nextBtnClass = `swiper-button-next-${this.swiperID}`;
+        this.previousBtnClass = `swiper-button-prev-${this.swiperID}`;
     }
 
     componentDidLoad() {
-        let autoplay: any = false;
-        if (this.autoplay) {
-            autoplay = {
-                delay: parseInt(this.autoplayDelay),
-                disableOnInteraction: true,
-            };
-        }
 
-        let navigation: any = false;
-        if (this.navControls) {
-            navigation = {
-                nextEl: `.swiper-button-next.${this.nextBtnClass}`,
-                prevEl: `.swiper-button-prev.${this.previousBtnClass}`,
-            };
-        }
+        const autoplayOptions: AutoplayOptions = {
+            delay: this.autoplayDelay,
+            disableOnInteraction: true,
+        };
+
+        let navigationOptions: NavigationOptions = {
+            nextEl: `.swiper-button-next.${this.nextBtnClass}`,
+            prevEl: `.swiper-button-prev.${this.previousBtnClass}`,
+        };
 
         const swipeContainer = this.el.querySelector(`.swiper-container.${this.containerClass}`) as HTMLElement;
         this.swiper = new SwiperJS(swipeContainer, {
-            speed: parseInt(this.speed),
+            speed: this.speed,
             direction: this.direction,
             loop: this.loop,
             centeredSlides: this.centeredSlides,
-            initialSlide: parseInt(this.initialSlide),
-            autoplay,
-            navigation,
-            slidesPerView: parseInt(this.slides),
-            spaceBetween: parseInt(this.spaceBetween),
+            initialSlide: this.initialSlide,
+            autoplay: this.autoplay ? autoplayOptions : false,
+            navigation: this.navControls ? navigationOptions : false,
+            slidesPerView: this.slides,
+            spaceBetween: this.spaceBetween,
         });
 
-        this.stopSwiper();
-
         if (this.autoplay) {
-            this.swiper.autoplay.start();
+            this.startSwiper();
+
             if (this.enableMouseEvents) {
                 swipeContainer.addEventListener("mouseenter", this.stopSwiper.bind(this));
                 swipeContainer.addEventListener("mouseleave", this.startSwiper.bind(this));
@@ -115,13 +112,17 @@ export class Swiper {
     }
 
     @Method()
-    public stopSwiper() {
-        this.swiper.autoplay.stop();
+    public async stopSwiper() {
+        if (this.autoplay) {
+            this.swiper.autoplay.stop();
+        }
     }
 
     @Method()
-    public startSwiper() {
-        this.swiper.autoplay.start();
+    public async startSwiper() {
+        if (this.autoplay) {
+            this.swiper.autoplay.start();
+        }
     }
 
     render() {


### PR DESCRIPTION
Stencil's `@Method` decorator [expects methods to be defined `async`](https://stenciljs.com/docs/methods), so this change just declares them async to suppress the warnings we see in the console in development.

Update: Turned out we had a bit of logic to clean up as well (e.g., only use the `autoplay` module when autoplay is enabled), so did that, and tightened up some typings as well.