### PR TITLE
Update solutions page common architecture types header

### DIFF
--- a/themes/default/assets/sass/styles.scss
+++ b/themes/default/assets/sass/styles.scss
@@ -291,4 +291,13 @@ main {
     text-shadow: none;
 }
 
+#architectures {
+    @apply text-center;
+
+    h2 {
+        @apply pl-2 pr-2 inline;
+        background-color: rgba(255, 255, 255, 0.7);
+    }
+}
+
 @tailwind utilities;


### PR DESCRIPTION
This change addresses https://github.com/pulumi/pulumi-hugo/issues/136, to make the background of the "Common Architecture Types" header on the Solutions page slightly opaque.

Before this change:
<img width="1136" alt="Screen Shot 2021-04-29 at 10 40 17 AM" src="https://user-images.githubusercontent.com/25756367/116595455-2dd0e800-a8d8-11eb-9d65-9af3a3b6d63b.png">


With this change:
<img width="1080" alt="Screen Shot 2021-04-29 at 10 40 07 AM" src="https://user-images.githubusercontent.com/25756367/116595473-345f5f80-a8d8-11eb-9831-c4cd1862549a.png">
