### PR TITLE
Fix digitalocean example

### DIFF
--- a/themes/default/content/docs/intro/cloud-providers/digitalocean/_index.md
+++ b/themes/default/content/docs/intro/cloud-providers/digitalocean/_index.md
@@ -40,9 +40,9 @@ const domain = new do.Domain("test", {
 {{% choosable language typescript %}}
 
 ```typescript
-import * as do from "@pulumi/digitalocean";
+import * as digitalocean from "@pulumi/digitalocean";
 
-const instance = new do.Domain("test", {
+const instance = new digitalocean.Domain("test", {
   name: "mydomain.com",
   ipAddress: "192.168.10.10",
 });


### PR DESCRIPTION
TypeScript reported that `do` is a reserved keyword and the homepage example didn't work out of the box as a result of that. The full API reference examples use `digitalocean` already.