### PR TITLE
remove apis text from apis and webhooks

### DIFF
--- a/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -46,7 +46,7 @@ td {
 | **TEAM STARTER**                  | **TEAM PRO**  	                | **ENTERPRISE** |
 | --- | --- | --- |
 | For teams just getting started with cloud applications and infrastructure. | For medium to large teams using Pulumi for multiple projects or clouds. | For large organizations operating at scale or with advanced custom needs.
-| Includes<ul><li>Any Cloud<li>Includes 3 users<li>Up to 20 stacks<li>Basic secrets management<li>CI/CD Integrations</ul> | Everything in Team Starter plus...<ul><li>Up to 25 users<li>Unlimited projects and stacks<li>APIs and webhooks<li>Advanced secrets management<li>12x5 support available</ul> | Everything in Team Pro plus...<ul><li>Teams, roles, and policies<li>SAML/SSO<li>On-premeses/self-host available<li>24x7 support available</ul> |
+| Includes<ul><li>Any Cloud<li>Includes 3 users<li>Up to 20 stacks<li>Basic secrets management<li>CI/CD Integrations</ul> | Everything in Team Starter plus...<ul><li>Up to 25 users<li>Unlimited projects and stacks<li>Webhooks<li>Advanced secrets management<li>12x5 support available</ul> | Everything in Team Pro plus...<ul><li>Teams, roles, and policies<li>SAML/SSO<li>On-premeses/self-host available<li>24x7 support available</ul> |
 
 All editions offer a 30-day free trial, no credit card
 required. If you need a longer trial period, want to discuss potential proof of

--- a/themes/default/content/pricing/open-source-free-tier.md
+++ b/themes/default/content/pricing/open-source-free-tier.md
@@ -19,7 +19,7 @@ features:
     description: |
         The Pulumi Open Source Free Tier provides the Pro Tier of the Pulumi Service at no cost
         to qualifying projects that want a Pulumi managed service with features such as dashboards,
-        CI/CD integrations, role based access controls, and APIs and Webhooks. Projects get
+        CI/CD integrations, role based access controls, and Webhooks. Projects get
         25 team members and unlimited project stacks.
 
 requirements:

--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -145,7 +145,7 @@
                                 <li>
                                     <span>
                                         <i class="fa fa-check pricing-checkmark mr-2"></i>
-                                        <span>APIs and webhooks</span>
+                                        <span>Webhooks</span>
                                     </span>
                                 </li>
                                 <li>
@@ -520,7 +520,7 @@
 
             <div class="compare-plans-table-row-container">
                 <div class="compare-plans-table-row-item">
-                    <span><a class="link" href="{{ relref . "/docs/intro/console/webhooks" }}">APIs and Webhooks</a></span>
+                    <span><a class="link" href="{{ relref . "/docs/intro/console/webhooks" }}">Webhooks</a></span>
                 </div>
                 <div class="compare-plans-table-row-item">
                     <span></span>


### PR DESCRIPTION
a bit ago in community slack a user was confused on what apis meant here alongside webhooks, they thought it meant they couldn't interact with any apis unless they were on enterprise.

i believe this language is confusing so I've changed it to only say webhooks, pls let me know if you have any concerns or think I'm overlooking something with this change.