### PR TITLE
add tutorial to cloud buttons

### DIFF
--- a/themes/default/content/docs/_index.md
+++ b/themes/default/content/docs/_index.md
@@ -22,15 +22,19 @@ Pulumi is an <a href="https://github.com/pulumi/pulumi" target="_blank">open sou
     <div class="md:flex justify-between items-center">
         <a class="block rounded hover:bg-gray-200 transition-all my-2 py-4 text-center px-6" href="{{< relref "/docs/get-started/aws" >}}">
             <img class="inline-block h-8 w-auto -mb-2" src="/logos/tech/aws.svg">
+            <p class="mb-0  mt-2.5">Tutorial</p>
         </a>
         <a class="block rounded hover:bg-gray-200 transition-all my-2 text-center md:mx-2 py-4 px-6" href="{{< relref "/docs/get-started/azure" >}}">
             <img class="inline-block h-8 w-auto" src="/logos/tech/azure.svg">
+            <p class="mb-0  mt-2">Tutorial</p>
         </a>
         <a class="block rounded hover:bg-gray-200 transition-all my-2 text-center md:mx-2 py-4 px-6" href="{{< relref "/docs/get-started/gcp" >}}">
             <img class="inline-block h-8 w-auto" src="/logos/tech/gcp.svg">
+            <p class="mb-0  mt-2">Tutorial</p>
         </a>
         <a class="block rounded hover:bg-gray-200 transition-all my-2 py-4 text-center px-6" href="{{< relref "/docs/get-started/kubernetes" >}}">
             <img class="inline-block h-8 w-auto" src="/logos/tech/k8s.svg">
+            <p class="mb-0 mt-2">Tutorial</p>
         </a>
     </div>
 </div>

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -21,21 +21,25 @@ Select one of the following options to deploy a simple application in your cloud
     <div class="pb-4 md:pr-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/aws" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/kubernetes" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
         </a>
     </div>
     <div class="pb-4 md:pr-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/azure" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/gcp" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
         </a>
     </div>
 </div>

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -27,19 +27,19 @@ Select one of the following options to deploy a simple application in your cloud
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/kubernetes" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
+            <p class="mb-0  mt-2 text-center">Tutorial</p>
         </a>
     </div>
     <div class="pb-4 md:pr-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/azure" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
+            <p class="mb-0  mt-2 text-center">Tutorial</p>
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8" href="{{< relref "/docs/get-started/gcp" >}}">
             <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-            <p class="mb-0  mt-2.5 text-center">Tutorial</p>
+            <p class="mb-0  mt-2 text-center">Tutorial</p>
         </a>
     </div>
 </div>


### PR DESCRIPTION
## overview

recently some folks shared that they had no idea where the cloud buttons would take them, was it to sign in, to the cloud websites, something else?

this adds the word tutorial to those buttons to make it more clear where it will send folks (though it would probably be better to be like aws + pulumi tutorial...)

let me know what yall think or if you have another idea

note: the aws logo is a special beast, ill fiddle with it later.

## before
![before-docs-landing](https://user-images.githubusercontent.com/5489125/117038587-a9f27380-acbc-11eb-834d-0e1de5ba8b3f.png)

![before-get-started](https://user-images.githubusercontent.com/5489125/117038594-ac54cd80-acbc-11eb-944e-2dc54ec9f5bb.png)

## after
![after-docs-landing](https://user-images.githubusercontent.com/5489125/117038609-b1b21800-acbc-11eb-8242-5b3cd943f82c.png)

![after-get-started](https://user-images.githubusercontent.com/5489125/117038616-b4ad0880-acbc-11eb-935f-17464137cbde.png)
