### PR TITLE
Don't super-size button labels

### DIFF
--- a/themes/default/assets/sass/_hero.scss
+++ b/themes/default/assets/sass/_hero.scss
@@ -98,11 +98,6 @@
                 line-height: 5.5rem !important;
                 font-size: 5.25rem !important;
             }
-
-            @media (min-width: 2000px) {
-                line-height: 6.5rem !important;
-                font-size: 6.25rem !important;
-            }
         }
 
         .home-hero-btn-primary {

--- a/themes/default/assets/sass/_mixins.scss
+++ b/themes/default/assets/sass/_mixins.scss
@@ -69,8 +69,4 @@
     &:focus {
         @apply bg-blue-600 border-blue-600;
     }
-
-    @media (min-width: 2000px) {
-        @apply text-2xl;
-    }
 }


### PR DESCRIPTION
There's not really a need to make buttons huge on wide screens, especially when everything else stays the same size. 

Fixes #170.