### PR TITLE
Add Enterprise note to organizational enforcement of policy docs

### DIFF
--- a/themes/default/content/blog/pulumi-2020-update/index.md
+++ b/themes/default/content/blog/pulumi-2020-update/index.md
@@ -57,7 +57,7 @@ In addition to the major areas above, we've continued to ship many other improve
 
 * [Many quality-of-life improvements in the Pulumi SaaS Console]({{< relref "/blog/pulumi-service-improvements_02-2020" >}}), including stack tagging, grouping, and sorting; deep linking into CI/CD systems; infrastructure configuration pretty-printing; reverse stack membership lookups; performance improvements; and more.
 
-* [Full audit logs for Pulumi Enterprise Edition]({{< relref "/blog/auditing-your-organizations-infrastructure-as-code-activity" >}}) enable you to go back in time and figure out who, when, and why something about your organization, project, or stack changed.
+* [Full audit logs for Pulumi Enterprise]({{< relref "/blog/auditing-your-organizations-infrastructure-as-code-activity" >}}) enable you to go back in time and figure out who, when, and why something about your organization, project, or stack changed.
 
 * [Pulumi runtime mocking for infrastructure testing](https://github.com/pulumi/pulumi/pull/3738), developed in partnership with several of our customers leading the charge on "test-driven infrastructure." Look for more end-to-end docs and guidance soon!
 

--- a/themes/default/content/blog/pulumiup-bring-your-whole-team-to-pulumi/index.md
+++ b/themes/default/content/blog/pulumiup-bring-your-whole-team-to-pulumi/index.md
@@ -18,7 +18,7 @@ Pulumi's Cloud Engineering Platform helps teams of all sizes deliver and manage 
 Most teams larger than a few people define their team members, and the groups they’re a part of, using an Identity Provider (IdP) like [Okta](https://www.okta.com/products/single-sign-on/), Microsoft’s [Azure Active Directory](https://azure.microsoft.com/en-us/services/active-directory/), or [Google Cloud Identity & Access Management](https://cloud.google.com/iam/). Defining groups allows you to set policies based on logical groupings of teammates, such as giving different capabilities to individual developers versus infrastructure administrators. Pulumi works seamlessly with these IdPs (and many more) by providing [Single Sign-On with SAML]({{< ref "/docs/guides/saml" >}}) and [user and group synchronization via SCIM 2.0]({{< ref "/docs/guides/scim" >}}). When you use both SAML SSO and SCIM, you can manage the users who should have access to Pulumi and the [Pulumi teams]({{< ref "/docs/intro/console/teams" >}}) they belong to entirely from your IdP. Managing users and teams this way helps keep your organization more secure by ensuring a single point of control over the users who have access to manage and update your infrastructure. It also saves you time by centralizing all of your identity and access management workflows in your identity provider.
 
 {{% notes type="info" %}}
-SAML SSO and SCIM support are available in the Pulumi Enterprise offering. See [pricing]({{<relref "/pricing">}}) for more details.
+SAML SSO and SCIM support are only available in **Pulumi Enterprise**. See [pricing]({{<relref "/pricing">}}) for more details.
 {{% /notes %}}
 
 ## SAML SSO

--- a/themes/default/content/docs/get-started/crossguard/enforcing-a-policy-pack.md
+++ b/themes/default/content/docs/get-started/crossguard/enforcing-a-policy-pack.md
@@ -9,6 +9,10 @@ menu:
 aliases: ["/docs/get-started/policy-as-code/enforcing-a-policy-pack/"]
 ---
 
+{{% notes type="info" %}}
+Server-side enforcement of policy packs across an organization is only available in **Pulumi Enterprise**. See [pricing]({{<relref "/pricing">}}) for more details.
+{{% /notes %}}
+
 Once you’ve validated the behavior of your policies, an organization administrator can publish them to the Pulumi Console to be enforced across your organization. Any Pulumi client (a developer’s workstation, CI/CD tool, etc) that interacts with a stack via the Pulumi Console will have policy enforcement during the execution of `preview` and `update`. Policy Packs are versioned by the Pulumi Console so that updated policies can be published and applied as ready and also reverted to previous versions as needed.
 
 1. From within the Policy Pack directory, run the following command to publish your pack:

--- a/themes/default/content/docs/guides/saml/_index.md
+++ b/themes/default/content/docs/guides/saml/_index.md
@@ -13,7 +13,7 @@ aliases:
   - /docs/console/accounts/saml/
 ---
 
-The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, refer to the [pricing page]({{< relref "/pricing" >}}).
+The [Pulumi Console](https://app.pulumi.com) can be configured to work with any SAML 2.0 identity provider. SAML support requires Pulumi Enterprise. To learn more about the capabilities of Pulumi Enterprise, refer to the [pricing page]({{< relref "/pricing" >}}).
 
 > Looking for information on how to enable SAML SSO for self-hosted Pulumi? Learn more [here]({{< relref "docs/guides/self-hosted/saml-sso" >}}).
 

--- a/themes/default/content/docs/guides/scim/_index.md
+++ b/themes/default/content/docs/guides/scim/_index.md
@@ -9,7 +9,7 @@ menu:
 
 ---
 
-The [Pulumi Console](https://app.pulumi.com) supports System for Cross-domain Identity Management (SCIM) 2.0 integration with different identity providers. SCIM enables you to manage your users and groups centrally in your Identity Provider (IdP) and then synchronize those users and groups to the Pulumi Console. This support requires Pulumi Enterprise Edition. To learn more about the capabilities of the Enterprise Edition, see the [pricing page]({{< relref "/pricing" >}}).
+The [Pulumi Console](https://app.pulumi.com) supports System for Cross-domain Identity Management (SCIM) 2.0 integration with different identity providers. SCIM enables you to manage your users and groups centrally in your Identity Provider (IdP) and then synchronize those users and groups to the Pulumi Console. This support requires Pulumi Enterprise. To learn more about the capabilities of Pulumi Enterprise, see the [pricing page]({{< relref "/pricing" >}}).
 
 To set up synchronization between Pulumi and your SAML 2.0 identity provider, refer to one of our example guides:
 

--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -4,11 +4,11 @@ menu:
     userguides:
         identifier: self_hosted
         weight: 9
-meta_desc: Pulumi Enterprise Edition gives you the option to self-host Pulumi within your organization's infrastructure.
+meta_desc: Pulumi Enterprise gives you the option to self-host Pulumi within your organization's infrastructure.
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}

--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -8,7 +8,7 @@ meta_desc: Pulumi Enterprise gives you the option to self-host Pulumi within you
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Enterprise**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate Self-Hosted Pulumi Enterprise.
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}

--- a/themes/default/content/docs/guides/self-hosted/api.md
+++ b/themes/default/content/docs/guides/self-hosted/api.md
@@ -9,7 +9,7 @@ meta_desc: Pulumi API is one of the components required for self-hosting Pulumi.
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate Self-Hosted Pulumi Enterprise.
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}

--- a/themes/default/content/docs/guides/self-hosted/console.md
+++ b/themes/default/content/docs/guides/self-hosted/console.md
@@ -9,7 +9,7 @@ meta_desc: Pulumi Console is one of the components required for self-hosting Pul
 ---
 
 {{% notes type="info" %}}
-Self-hosting is only available with **Pulumi Enterprise Edition**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+Self-hosting is only available with **Pulumi Enterprise**. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate Self-Hosted Pulumi Enterprise.
 
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends]({{< relref "/docs/intro/concepts/state" >}}).
 {{% /notes %}}

--- a/themes/default/content/docs/intro/console/auditing.md
+++ b/themes/default/content/docs/intro/console/auditing.md
@@ -11,7 +11,7 @@ aliases:
 
 <div class="note note-info" role="alert">
     <p>
-        Audit Logs are only available with the <strong>Pulumi Enterprise Edition</strong>.
+        Audit Logs are only available in <strong>Pulumi Enterprise</strong>.
     </p>
 </div>
 

--- a/themes/default/content/docs/intro/console/collaboration/auditing.md
+++ b/themes/default/content/docs/intro/console/collaboration/auditing.md
@@ -4,7 +4,7 @@ meta_desc: "This is a guide on how to audit your organization's infrastructure a
 ---
 
 {{< notes type="info" >}}
-Audit Logs are only available with Pulumi Enterprise Edition.
+Audit Logs are only available in Pulumi Enterprise.
 {{< /notes >}}
 
 ## Overview

--- a/themes/default/content/docs/intro/console/organizations.md
+++ b/themes/default/content/docs/intro/console/organizations.md
@@ -110,9 +110,8 @@ to learn more.
 
 ## SAML Single Sign-on (SSO)
 
-The Pulumi Enterprise edition provides more options for identity and access, including
-support for
-any SAML 2.0-based identity provider.
+Pulumi Enterprise provides more options for identity and access, including
+support for any SAML 2.0-based identity provider.
 
 [Learn more]({{< relref "/docs/guides/saml" >}}) about configuring a SAML-based
 organization on Pulumi. Or refer to one

--- a/themes/default/data/glossary.toml
+++ b/themes/default/data/glossary.toml
@@ -125,7 +125,7 @@ link = "/docs/intro/concepts/function-serialization"
 
 [[entries]]
 term = "SAML"
-description = "Security Assertion Markup Language. You may use a SAML 2.0-compatible identity provider in order to sign in to the Pulumi Console via single sign-on. The SAML SSO feature is only available on the Pulumi Enterprise Edition."
+description = "Security Assertion Markup Language. You may use a SAML 2.0-compatible identity provider in order to sign in to the Pulumi Console via single sign-on. The SAML SSO feature is only available in Pulumi Enterprise."
 link = "https://en.wikipedia.org/wiki/SAML_2.0"
 
 [[entries]]


### PR DESCRIPTION
Also consistently use "Pulumi Enterprise" to refer to the SKU, instead of "Pulumi Enterprise Edition".

Fixes #198.