### PR TITLE
fix numbering

### DIFF
--- a/themes/default/content/docs/get-started/crossguard/enforcing-a-policy-pack.md
+++ b/themes/default/content/docs/get-started/crossguard/enforcing-a-policy-pack.md
@@ -33,7 +33,7 @@ Once you’ve validated the behavior of your policies, an organization administr
 
     The Policy Pack version is specified in the `package.json` file for TypeScript/JavaScript (Node.js) packs and in the `PulumiPolicy.yaml` file for Python packs. A version can only be used one time and once published the version can never be used by that Policy Pack again.
 
-<!-- markdownlint-disable ul -->
+    <!-- markdownlint-disable ul -->
 1. You can enable this Policy Pack to your organization’s default Policy Group by running:
 
     ```sh


### PR DESCRIPTION
noticed this numbering issue when reviewing the policy docs
/docs/get-started/crossguard/enforcing-a-policy-pack/
fixes part of #198 

## before
![before](https://user-images.githubusercontent.com/5489125/117309193-0e394280-ae37-11eb-9c3c-d3283b55713a.png)

## after
![after](https://user-images.githubusercontent.com/5489125/117309176-0b3e5200-ae37-11eb-9bd0-5db1911269ce.png)
