### PR TITLE
Minor adjustments to video display

### DIFF
--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -42,7 +42,7 @@ Select one of the following options to deploy a simple application in your cloud
 
 Or, watch how to do it in this video walkthrough:
 
-<div class="rounded-xl shadow-2xl w-3/4 mx-auto" style="position: relative; padding-bottom: 40.25%; height: 0; overflow: hidden;">
+<div class="rounded-md shadow border border-gray-300 w-3/4" style="position: relative; padding-bottom: 40.25%; height: 0; overflow: hidden;">
     <iframe
         src="//www.youtube.com/embed/6f8KF6UGN7g?rel=0"
         style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;"


### PR DESCRIPTION
The video on the get-started page looks out of place as it is now, centered and with shadowing that doesn't align with the other elements on the page. This just left-justifies the video and gives it a border and shadow treatment that looks consistent with the tiles above it.