### PR TITLE
Size code elements relatively in headings

### DIFF
--- a/themes/default/assets/sass/_code.scss
+++ b/themes/default/assets/sass/_code.scss
@@ -4,6 +4,12 @@ code {
     @apply bg-gray-100 rounded py-1 px-2 text-sm break-words;
 }
 
+h1, h2, h3, h4, h5, h6 {
+    code {
+        font-size: 0.9em;
+    }
+}
+
 pre, .code-max-h {
     @apply rounded my-4;
 }


### PR DESCRIPTION
Little thing I've been meaning to fix forever.

![image](https://user-images.githubusercontent.com/274700/117495886-12468c80-af2b-11eb-9447-0db3296bac00.png)

  👇👇 

![image](https://user-images.githubusercontent.com/274700/117495859-08bd2480-af2b-11eb-9c04-5b85a1eb007a.png)
