### PR TITLE
Relax the Hugo version restriction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ clean:
 	./scripts/clean.sh
 
 .PHONY: ensure
-ensure: clean
+ensure:
 	./scripts/ensure.sh
 
 .PHONY: lint

--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -16,7 +16,7 @@ if [[ -z "$(which go)" || -z "$(go version | grep ${REQUIRED_GO})"  ]]; then
     exit 1
 fi
 
-if [[ -z "$(which hugo)" || -z "$(hugo version | grep ${REQUIRED_HUGO})"  ]]; then
+if [[ -z "$(which hugo)" ]]; then
     echo "This project uses Hugo version ${REQUIRED_HUGO}."
     echo "See the README for the complete list of prerequisities and "
     echo "https://gohugo.io/getting-started/quick-start for help installing Hugo."


### PR DESCRIPTION
We currently impose a restriction on Hugo version, pinning to the same version as what's used in CI. But this is technically unnecessary (Hugo's built-in `minVersion` warns when the CLI is too far behind what's required by the modules in use in a given site), and given how often Hugo updates, and how hard it is to install a specific version on certain platforms, it makes life more difficult for contributors. So this change just relaxes that restriction and leaves it up to `minVersion` to alert when necessary.  