### PR TITLE
Clean up tags

### DIFF
--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -46,7 +46,7 @@ including all the required frontmatter parameters.
    ---
    ```
 
-   Feel free to adjust the title, authors (more on this below) and tags as appropriate. To change the post's URL, simply rename the folder containing `_index.md`; changing the folder name to `my-awesome-post`, for example, would result in a post ultimately published at https://www.pulumi.com/blog/my-awesome-post.
+   Adjust the title and authors (more on this below), then add tags as appropriate. **Be judicious** when adding tags: prefer existing tags and only add new tags if there's a high likelihood of having multiple posts with that tag in the near future. To change the post's URL, simply rename the folder containing `_index.md`; changing the folder name to `my-awesome-post`, for example, would result in a post ultimately published at https://www.pulumi.com/blog/my-awesome-post.
 
    **Important**
 

--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -46,7 +46,7 @@ including all the required frontmatter parameters.
    ---
    ```
 
-   Adjust the title and authors (more on this below), then add tags as appropriate. **Be judicious** when adding tags: prefer existing tags and only add new tags if there's a high likelihood of having multiple posts with that tag in the near future. To change the post's URL, simply rename the folder containing `_index.md`; changing the folder name to `my-awesome-post`, for example, would result in a post ultimately published at https://www.pulumi.com/blog/my-awesome-post.
+   Adjust the title and authors and add tags as appropriate (see the two headings below for more details). To change the post's URL, simply rename the folder containing `_index.md`; changing the folder name to `my-awesome-post`, for example, would result in a post ultimately published at https://www.pulumi.com/blog/my-awesome-post.
 
    **Important**
 
@@ -62,6 +62,16 @@ including all the required frontmatter parameters.
    ```
 
    **Keep in mind that only posts dated prior to "now" (meaning the moment the build process begins) and _not_ marked as `draft`s will published to production.** The development server renders both future and draft content (so you can work on scheduled posts in advance), but the build process does not; see below for details on scheduling posts for future publishing.
+
+   **Tags**
+
+   Every tag added makes the overall tagging system harder to quickly grok and use. So, we strongly prefer using existing tags wherever possible. The tag system is as follows:
+
+   - **Pulumi tags:** `pulumi-news` for company news (funding, certifications, etc.), `pulumi-events` for events we participate in or host, `pulumi-interns` for intern posts, `pulumi-enterprise` for enterprise-focused blog posts
+   - **Cloud provider tags:** Only add a cloud provider tag if we expect to have multiple posts about the provider. Today, that means `aws`, `azure`, `google-cloud`, `digitalocean`
+   - **Feature tags:** Only add a feature tag if we expect to have multiple posts about the feature. Today, that means `features` (for feature announcements), `aliases`, `continuous-delivery`, `logging`, `migration`, `native-providers`, `packages`, `policy-as-code`, `secrets`, `testing`.
+   - **Technology/scenario tags:** Similar to feature tags, but focused on user scenarios. Today, that means `cloud-engineering`, `cloud-native`, `containers`, `data-and-analytics`, `development-environment`, `github-actions`, `kubernetes`, `serverless`.
+   - **Language tags:** Any post that is language/ecosystem specific should have one or more of `.net`, `go`, `javascript`, `python`, `typescript`.
 
 2. If you don't already have a [TOML](https://github.com/toml-lang/toml) file [in the `team` directory](https://github.com/pulumi/docs/tree/master/data/team/team) of the repo, create one now. For Pulumi employees, that file should look something like this:
 

--- a/themes/default/content/blog/2018-year-at-a-glance/index.md
+++ b/themes/default/content/blog/2018-year-at-a-glance/index.md
@@ -1,7 +1,7 @@
 ---
 title: "2018 Year at a Glance"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "As we close out 2018, here are some of the exciting things at Pulumi. We've launched our open source community, with support for many major clouds."
 date: "2018-12-31"
 ---

--- a/themes/default/content/blog/2019-year-at-a-glance/index.md
+++ b/themes/default/content/blog/2019-year-at-a-glance/index.md
@@ -1,7 +1,7 @@
 ---
 title: "2019 Year at a Glance"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "As 2019 winds down, let's review Pulumi's most exciting recent milestones. This includes 1.0, our 2.0 roadmap, and dozens of other major features."
 meta_image: "pulumi-new-year.png"
 date: "2019-12-31"

--- a/themes/default/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
+++ b/themes/default/content/blog/adopting-existing-cloud-resources-into-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-08-15"
 meta_desc: "Migrating from Terraform or another IaC tool? Learn how to adopt existing cloud infrastructure from Terraform, CloudFormation, ARM, YAML, and more into Pulumi."
 meta_image: "meta.png"
 authors: ["luke-hoban"]
-tags: ["Infrastructure"]
+tags: ["migration"]
 ---
 
 {{% notes %}}

--- a/themes/default/content/blog/amazon-ecr-public/index.md
+++ b/themes/default/content/blog/amazon-ecr-public/index.md
@@ -4,7 +4,7 @@ date: "2020-12-01"
 meta_desc: "Pulumi container images now available on Amazon ECR Public"
 meta_image: "pulumi-images-ecr.png"
 authors: ["paul-stack"]
-tags: ["aws", "containers", "ecr"]
+tags: ["aws", "docker-containers"]
 ---
 
 At re:Invent, the AWS team unveiled the new Amazon Elastic Container Registry Public (Amazon ECR Public), creating a new

--- a/themes/default/content/blog/amazon-ecr-public/index.md
+++ b/themes/default/content/blog/amazon-ecr-public/index.md
@@ -4,7 +4,7 @@ date: "2020-12-01"
 meta_desc: "Pulumi container images now available on Amazon ECR Public"
 meta_image: "pulumi-images-ecr.png"
 authors: ["paul-stack"]
-tags: ["aws", "docker-containers"]
+tags: ["aws", "containers"]
 ---
 
 At re:Invent, the AWS team unveiled the new Amazon Elastic Container Registry Public (Amazon ECR Public), creating a new

--- a/themes/default/content/blog/amazon-eks-distro/index.md
+++ b/themes/default/content/blog/amazon-eks-distro/index.md
@@ -9,7 +9,7 @@ authors:
     - lee-briggs
 tags:
     - kubernetes
-    - eks
+    - aws
 ---
 
 As Kubernetes grows in popularity, the number of options for Kubernetes users continues to increase. Providers of managed Kubernetes offerings will often learn lessons about operating large numbers of clusters at scale; it's increasingly common that they will contribute this knowledge back to the ecosystem, allowing those organizations who need more control and flexibility to reap the benefits.

--- a/themes/default/content/blog/announcing-crossguard-preview/index.md
+++ b/themes/default/content/blog/announcing-crossguard-preview/index.md
@@ -4,7 +4,7 @@ date: 2019-12-02
 meta_desc: "Today we are announcing Pulumi CrossGuard, a Policy as Code solution that enforces custom infrastructure policies, is available for all users to preview."
 meta_image: crossguard.svg
 authors: ["erin-krengel"]
-tags: ["policy-as-code", "new-features"]
+tags: ["policy-as-code", "features"]
 ---
 
 Over the past few months, we have been hard at work on Pulumi CrossGuard, a Policy as Code solution. Using CrossGuard, you can express flexible business and security rules using code. CrossGuard enables organization administrators to enforce these policies across their organization or just on specific stacks. CrossGuard allows you to verify or enforce custom policies on changes before they are applied to your resources. CrossGuard is 100% open source and available to all users of Pulumi, including the Community Edition. Advanced organization-wide policy management features are available to Team Pro and Enterprise customers.

--- a/themes/default/content/blog/announcing-crossguard-preview/index.md
+++ b/themes/default/content/blog/announcing-crossguard-preview/index.md
@@ -4,7 +4,7 @@ date: 2019-12-02
 meta_desc: "Today we are announcing Pulumi CrossGuard, a Policy as Code solution that enforces custom infrastructure policies, is available for all users to preview."
 meta_image: crossguard.svg
 authors: ["erin-krengel"]
-tags: ["crossguard", "policy-as-code", "New-Features", "Pulumi-News", "Features"]
+tags: ["policy-as-code", "policy-as-code", "New-Features", "Pulumi-News", "Features"]
 ---
 
 Over the past few months, we have been hard at work on Pulumi CrossGuard, a Policy as Code solution. Using CrossGuard, you can express flexible business and security rules using code. CrossGuard enables organization administrators to enforce these policies across their organization or just on specific stacks. CrossGuard allows you to verify or enforce custom policies on changes before they are applied to your resources. CrossGuard is 100% open source and available to all users of Pulumi, including the Community Edition. Advanced organization-wide policy management features are available to Team Pro and Enterprise customers.

--- a/themes/default/content/blog/announcing-crossguard-preview/index.md
+++ b/themes/default/content/blog/announcing-crossguard-preview/index.md
@@ -4,7 +4,7 @@ date: 2019-12-02
 meta_desc: "Today we are announcing Pulumi CrossGuard, a Policy as Code solution that enforces custom infrastructure policies, is available for all users to preview."
 meta_image: crossguard.svg
 authors: ["erin-krengel"]
-tags: ["policy-as-code", "policy-as-code", "New-Features", "Pulumi-News", "Features"]
+tags: ["policy-as-code", "new-features"]
 ---
 
 Over the past few months, we have been hard at work on Pulumi CrossGuard, a Policy as Code solution. Using CrossGuard, you can express flexible business and security rules using code. CrossGuard enables organization administrators to enforce these policies across their organization or just on specific stacks. CrossGuard allows you to verify or enforce custom policies on changes before they are applied to your resources. CrossGuard is 100% open source and available to all users of Pulumi, including the Community Edition. Advanced organization-wide policy management features are available to Team Pro and Enterprise customers.

--- a/themes/default/content/blog/announcing-enum-support/index.md
+++ b/themes/default/content/blog/announcing-enum-support/index.md
@@ -6,7 +6,7 @@ meta_image: meta.png
 authors:
 - komal-ali
 tags:
-- new-features
+- features
 ---
 
 Here at Pulumi, we believe in leveraging the best features of programming languages to create a delightful development experience for our users. Today, we continue our contributions in this area by announcing cross-language support for `enum` types in our provider SDKs, available in all Pulumi languages - Python, TypeScript, .NET and Go.

--- a/themes/default/content/blog/announcing-enum-support/index.md
+++ b/themes/default/content/blog/announcing-enum-support/index.md
@@ -6,7 +6,7 @@ meta_image: meta.png
 authors:
 - komal-ali
 tags:
-- enhancement
+- new-features
 ---
 
 Here at Pulumi, we believe in leveraging the best features of programming languages to create a delightful development experience for our users. Today, we continue our contributions in this area by announcing cross-language support for `enum` types in our provider SDKs, available in all Pulumi languages - Python, TypeScript, .NET and Go.

--- a/themes/default/content/blog/announcing-enum-support/index.md
+++ b/themes/default/content/blog/announcing-enum-support/index.md
@@ -6,11 +6,7 @@ meta_image: meta.png
 authors:
 - komal-ali
 tags:
-- enums
-- python
-- go
-- c#
-- typescript
+- enhancement
 ---
 
 Here at Pulumi, we believe in leveraging the best features of programming languages to create a delightful development experience for our users. Today, we continue our contributions in this area by announcing cross-language support for `enum` types in our provider SDKs, available in all Pulumi languages - Python, TypeScript, .NET and Go.

--- a/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -3,7 +3,8 @@ title: "Announcing Per User Pricing and Unlimited Stacks for Teams"
 date: "2019-04-19"
 meta_desc: "Today we are announcing Pulumi's new pricing tier, with three paid editions: Team Starter Edition, Team Pro Edition, and Enterprise Edition."
 authors: ["joe-duffy"]
-tags: ["Customer"]
+tags: 
+  - new-features
 ---
 
 Since launching last year, thousands of users and hundreds of

--- a/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -4,7 +4,7 @@ date: "2019-04-19"
 meta_desc: "Today we are announcing Pulumi's new pricing tier, with three paid editions: Team Starter Edition, Team Pro Edition, and Enterprise Edition."
 authors: ["joe-duffy"]
 tags: 
-  - new-features
+  - features
 ---
 
 Since launching last year, thousands of users and hundreds of

--- a/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -3,7 +3,7 @@ title: "Announcing Pulumi 0.15"
 date: "2018-08-15"
 meta_desc: "Pulumi can now deploy and manage Kubernetes resources using the same familiar programming model supported for AWS, Azure, and Google Cloud Platform."
 authors: ["luke-hoban"]
-tags: ["Pulumi", "New-Features", "continuous-delivery"]
+tags: ["New-Features", "continuous-delivery"]
 ---
 
 

--- a/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -3,7 +3,7 @@ title: "Announcing Pulumi 0.15"
 date: "2018-08-15"
 meta_desc: "Pulumi can now deploy and manage Kubernetes resources using the same familiar programming model supported for AWS, Azure, and Google Cloud Platform."
 authors: ["luke-hoban"]
-tags: ["New-Features", "continuous-delivery"]
+tags: ["features", "continuous-delivery"]
 ---
 
 

--- a/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
+++ b/themes/default/content/blog/announcing-pulumi-0.15-kubernetes-cicd-openstack-and-more/index.md
@@ -3,7 +3,7 @@ title: "Announcing Pulumi 0.15"
 date: "2018-08-15"
 meta_desc: "Pulumi can now deploy and manage Kubernetes resources using the same familiar programming model supported for AWS, Azure, and Google Cloud Platform."
 authors: ["luke-hoban"]
-tags: ["Pulumi", "New-Features", "CI/CD"]
+tags: ["Pulumi", "New-Features", "continuous-delivery"]
 ---
 
 

--- a/themes/default/content/blog/announcing-support-for-email-based-identities/index.md
+++ b/themes/default/content/blog/announcing-support-for-email-based-identities/index.md
@@ -4,7 +4,7 @@ date: "2019-03-21"
 meta_desc: "Pulumi now supports email-based identities, in addition to GitHub, Atlassian, and GitLab."
 meta_image: "email-signup.png"
 authors: ["praneet-loke"]
-tags: ["pulumi-news","new-features"]
+tags: ["pulumi-news","features"]
 ---
 
 We have been hard at work the past few months providing our users with

--- a/themes/default/content/blog/announcing-support-for-email-based-identities/index.md
+++ b/themes/default/content/blog/announcing-support-for-email-based-identities/index.md
@@ -4,7 +4,7 @@ date: "2019-03-21"
 meta_desc: "Pulumi now supports email-based identities, in addition to GitHub, Atlassian, and GitLab."
 meta_image: "email-signup.png"
 authors: ["praneet-loke"]
-tags: ["Pulumi-News","Features"]
+tags: ["pulumi-news","new-features"]
 ---
 
 We have been hard at work the past few months providing our users with

--- a/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
+++ b/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
@@ -5,7 +5,7 @@ date: "2019-10-17"
 meta_desc: "How to architect your AWS infrastructure to optimize team collaboration with Pulumi Stack References"
 meta_image: "application-architecture.png"
 authors: ["paul-stack"]
-tags: ["AWS","stack-reference", "architecture"]
+tags: ["AWS","stack-reference"]
 ---
 
 In this post, we will talk about the best way to architect your Pulumi applications. We are going to build out the following

--- a/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
+++ b/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
@@ -5,7 +5,7 @@ date: "2019-10-17"
 meta_desc: "How to architect your AWS infrastructure to optimize team collaboration with Pulumi Stack References"
 meta_image: "application-architecture.png"
 authors: ["paul-stack"]
-tags: ["AWS","stack-reference"]
+tags: ["AWS"]
 ---
 
 In this post, we will talk about the best way to architect your Pulumi applications. We are going to build out the following

--- a/themes/default/content/blog/architecture-as-code-intro/index.md
+++ b/themes/default/content/blog/architecture-as-code-intro/index.md
@@ -6,10 +6,9 @@ meta_image: architecture.png
 authors:
     - sophia-parafina
 tags:
-    - virtual machines
     - Kubernetes
     - serverless
-    - microservices
+    - architecture-as-code
 ---
 
 Abstraction is key to building resilient systems because it encapsulates behavior and decouples code, letting each component perform its function independently. The same principles apply to infrastructure, where we want to declare behavior or state and not implementation details. As an industry, we've moved away from monolithic applications to distributed systems such as serverless, microservices, Kubernetes, and virtual machine deployments. In this article, we'll take a closer look at the characteristics of these architectures and how Pulumi can abstract the components that comprise these systems.

--- a/themes/default/content/blog/architecture-as-code-microservices/index.md
+++ b/themes/default/content/blog/architecture-as-code-microservices/index.md
@@ -6,7 +6,7 @@ meta_image: microservices.png
 authors:
     - sophia-parafina
 tags:
-    - microservices
+    - architecture-as-code
 ---
 
 This article is the third in a series about Architecture as Code. The [first article]({{< relref "/blog/architecture-as-code-intro">}}) provided an overview of virtual machines, microservices, serverless, and Kubernetes. The [second]({{< relref "/blog/architecture-as-code-vm" >}}) one went in-depth on deploying virtual machines as reusable components. In this third installment, we'll look at microservices and how to implement them as reusable components with Pulumi.

--- a/themes/default/content/blog/architecture-as-code-vm/index.md
+++ b/themes/default/content/blog/architecture-as-code-vm/index.md
@@ -6,8 +6,7 @@ meta_image: vm.png
 authors:
     - sophia-parafina
 tags:
-    - virtual machines
-    - provisioning
+    - architecture-as-code
 ---
 
 In a [previous article]({{< relref "/blog/architecture-as-code-intro" >}}), we presented an overview of four infrastructure patterns for deploying modern applications. The article reviewed virtual machines, serverless, Kubernetes, and microservices. In this post, we'll examine virtual machines in-depth.

--- a/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
+++ b/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
@@ -4,7 +4,7 @@ date: "2020-02-20"
 meta_desc: "Pulumi now supports Audit Logs. Learn how to audit your organization's infrastructure as code activity"
 meta_image: "auditlogs.png"
 authors: ["sean-holung"]
-tags: ["New-Features", "AuditLogs", "Enterprise"]
+tags: ["New-Features", "pulumi-enterprise"]
 ---
 
 We are excited to announce the release of Audit Logs on

--- a/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
+++ b/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
@@ -4,7 +4,7 @@ date: "2020-02-20"
 meta_desc: "Pulumi now supports Audit Logs. Learn how to audit your organization's infrastructure as code activity"
 meta_image: "auditlogs.png"
 authors: ["sean-holung"]
-tags: ["New-Features", "pulumi-enterprise"]
+tags: ["features", "pulumi-enterprise"]
 ---
 
 We are excited to announce the release of Audit Logs on

--- a/themes/default/content/blog/automation-api-as-platform/index.md
+++ b/themes/default/content/blog/automation-api-as-platform/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - Automation API
-    - CRUD
 ---
 
 If you could create infrastructure without using a cloud provider's console, a CLI, or a templating engine, what would you build? Pulumi's Automation API lets you create declarative infrastructure defined by your best practices and expose it behind a REST, gRPC, or custom API.

--- a/themes/default/content/blog/automation-api-dotnet/index.md
+++ b/themes/default/content/blog/automation-api-dotnet/index.md
@@ -8,8 +8,8 @@ authors:
 - sophia-parafina
 tags:
 - Automation API
-- C#
 - .NET
+- guest-post
 ---
 
 {{% notes type="info" %}}

--- a/themes/default/content/blog/automation-api-dotnet/index.md
+++ b/themes/default/content/blog/automation-api-dotnet/index.md
@@ -9,8 +9,6 @@ authors:
 tags:
 - Automation API
 - C#
-- csharp
-- dotnet
 - .NET
 ---
 

--- a/themes/default/content/blog/automation-api-supercharged-cloud-tooling/index.md
+++ b/themes/default/content/blog/automation-api-supercharged-cloud-tooling/index.md
@@ -6,8 +6,7 @@ meta_image: automation_api_v2.png
 authors:
     - sophia-parafina
 tags:
-    - Automation API
-    - cloud tools
+    - automation-api
 ---
 
 "Why use a programming language to build and maintain infrastructure?" is a question we hear frequently. There are apparent advantages such as using a mature and well-known language across a team, enabling cloud engineers to use software development best practices, and an ecosystem of tools for building robust systems.

--- a/themes/default/content/blog/automation-api-workflow/index.md
+++ b/themes/default/content/blog/automation-api-workflow/index.md
@@ -7,8 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - Automation API
-    - Aurora ADS
-    - workflow orchestration
 ---
 
 There are many moving parts when deploying infrastructure and applications. Playbooks are step-by-step maps that standardize how infrastructure and applications are deployed across your organization. Typically playbooks describe every action to build and deploy, requiring an operator to complete each step before moving on to the next. It's a process that can be tedious and prone to human error.

--- a/themes/default/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/themes/default/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -2,7 +2,7 @@
 title: "AWS EKS - How to Scale Your Cluster"
 h1: "How to Scale Your Amazon EKS Cluster: EC2, Managed Node Groups, and Fargate"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News", "AWS", "Kubernetes", "EKS"]
+tags: ["AWS", "Kubernetes"]
 meta_desc: "Pulumi supports simplify the scaling your Elastic Kubernetes Service (EKS) clusters with Managed Node Groups and Fargate."
 date: "2019-12-05"
 meta_image: "pulumi-eks-fargate.png"

--- a/themes/default/content/blog/aws-iam-access-analyzer-and-crossguard/index.md
+++ b/themes/default/content/blog/aws-iam-access-analyzer-and-crossguard/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Running AWS IAM Access Analyzer at Deployment Time"
 authors: ["joe-duffy"]
-tags: ["AWS", "Security", "crossguard", "policy-as-code"]
+tags: ["AWS", "Security", "policy-as-code"]
 meta_desc: "In this post, we will look at running AWS IAM Access Analyzer at deployment time."
 date: "2019-12-03"
 

--- a/themes/default/content/blog/aws-lambda-container-support/index.md
+++ b/themes/default/content/blog/aws-lambda-container-support/index.md
@@ -8,7 +8,7 @@ authors:
     - mikhail-shilkov
 tags:
     - aws
-    - docker-containers
+    - containers
     - serverless
 
 ---

--- a/themes/default/content/blog/aws-lambda-container-support/index.md
+++ b/themes/default/content/blog/aws-lambda-container-support/index.md
@@ -8,7 +8,7 @@ authors:
     - mikhail-shilkov
 tags:
     - aws
-    - containers
+    - docker-containers
     - serverless
 
 ---

--- a/themes/default/content/blog/aws-lambda-efs/index.md
+++ b/themes/default/content/blog/aws-lambda-efs/index.md
@@ -7,6 +7,7 @@ authors:
     - luke-hoban
 tags:
     - AWS
+    - serverless
 ---
 
 Ever since AWS Lambda was released in 2015, users have wanted persistent file storage beyond the small 512MB `/tmp` disk allocated to each Lambda function.  The following year, Amazon launched EFS,  offering a simple managed file system service for AWS, but initially only available to mount onto Amazon EC2 instances. Over the last few months, AWS has been extending access to EFS to all of the modern compute offerings.  First [EKS](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-announces-beta-release-of-amazon-efs-csi-driver/) for Kubernetes, then [ECS and Fargate](https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ecs-aws-fargate-support-amazon-efs-filesystems-generally-available/) for containers.  Today, AWS announced that [EFS is now also supported in Lambda](https://aws.amazon.com/blogs/aws/new-a-shared-file-system-for-your-lambda-functions/), providing easy access to network file systems from your serverless functions.

--- a/themes/default/content/blog/aws-lambda-efs/index.md
+++ b/themes/default/content/blog/aws-lambda-efs/index.md
@@ -7,8 +7,6 @@ authors:
     - luke-hoban
 tags:
     - AWS
-    - Lambda
-    - EFS
 ---
 
 Ever since AWS Lambda was released in 2015, users have wanted persistent file storage beyond the small 512MB `/tmp` disk allocated to each Lambda function.  The following year, Amazon launched EFS,  offering a simple managed file system service for AWS, but initially only available to mount onto Amazon EC2 instances. Over the last few months, AWS has been extending access to EFS to all of the modern compute offerings.  First [EKS](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-announces-beta-release-of-amazon-efs-csi-driver/) for Kubernetes, then [ECS and Fargate](https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ecs-aws-fargate-support-amazon-efs-filesystems-generally-available/) for containers.  Today, AWS announced that [EFS is now also supported in Lambda](https://aws.amazon.com/blogs/aws/new-a-shared-file-system-for-your-lambda-functions/), providing easy access to network file systems from your serverless functions.

--- a/themes/default/content/blog/aws-serverless-analytics/index.md
+++ b/themes/default/content/blog/aws-serverless-analytics/index.md
@@ -1,7 +1,7 @@
 ---
 title: "AWS Serverless Analytics"
 authors: ["evan-boyle"]
-tags: ["AWS", "Data-Warehouse"]
+tags: ["AWS", "data-and-analytics"]
 date: "2020-01-30"
 meta_desc: "Building a serverless data warehouse on AWS using architecture as code."
 meta_image: "ServerlessArchitecture.png"

--- a/themes/default/content/blog/aws-serverless-analytics/index.md
+++ b/themes/default/content/blog/aws-serverless-analytics/index.md
@@ -1,7 +1,7 @@
 ---
 title: "AWS Serverless Analytics"
 authors: ["evan-boyle"]
-tags: ["AWS-Serverless", "Analytics", "Architecture-as-Code", "Data-Warehouse"]
+tags: ["AWS", "Data-Warehouse"]
 date: "2020-01-30"
 meta_desc: "Building a serverless data warehouse on AWS using architecture as code."
 meta_image: "ServerlessArchitecture.png"

--- a/themes/default/content/blog/bigdata-boutique-guest-post/index.md
+++ b/themes/default/content/blog/bigdata-boutique-guest-post/index.md
@@ -6,8 +6,7 @@ meta_image: meta.png
 authors:
     - itamar-syn-hershko
 tags:
-    - BigData Boutique
-    - Elasticsearch
+    - guest-post
     - testing
 
 ---

--- a/themes/default/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
+++ b/themes/default/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
@@ -5,7 +5,7 @@ date: "2018-06-21"
 meta_desc: "Extracting a thumbnail from a video using a combination of Lambdas, containers, and connected data services and infrastructure."
 meta_image: "video-thumbnail-diagram.png"
 authors: ["donna-malayeri"]
-tags: ["JavaScript","Serverless","AWS","docker-containers"]
+tags: ["JavaScript","Serverless","AWS","containers"]
 ---
 
 Pulumi makes it easy to build cloud applications that use a combination

--- a/themes/default/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
+++ b/themes/default/content/blog/build-a-video-thumbnailer-with-pulumi-using-lambdas-containers-and-infrastructure-on-aws/index.md
@@ -5,7 +5,7 @@ date: "2018-06-21"
 meta_desc: "Extracting a thumbnail from a video using a combination of Lambdas, containers, and connected data services and infrastructure."
 meta_image: "video-thumbnail-diagram.png"
 authors: ["donna-malayeri"]
-tags: ["JavaScript","Serverless","AWS","Containers","Infrastructure"]
+tags: ["JavaScript","Serverless","AWS","docker-containers"]
 ---
 
 Pulumi makes it easy to build cloud applications that use a combination

--- a/themes/default/content/blog/build-publish-containers-iac/index.md
+++ b/themes/default/content/blog/build-publish-containers-iac/index.md
@@ -2,7 +2,7 @@
 title: "Build and publish container images to any cloud with Infrastructure as Code"
 allow_long_title: True
 authors: ["joe-duffy"]
-tags: ["docker-containers", "Kubernetes"]
+tags: ["containers", "Kubernetes"]
 meta_desc: "Go from Dockerfile to a fully running containerized service on your cloud of choice using infrastructure as code."
 date: "2020-12-08"
 meta_image: "containers.png"

--- a/themes/default/content/blog/build-publish-containers-iac/index.md
+++ b/themes/default/content/blog/build-publish-containers-iac/index.md
@@ -2,7 +2,7 @@
 title: "Build and publish container images to any cloud with Infrastructure as Code"
 allow_long_title: True
 authors: ["joe-duffy"]
-tags: ["Docker", "Kubernetes"]
+tags: ["docker-containers", "Kubernetes"]
 meta_desc: "Go from Dockerfile to a fully running containerized service on your cloud of choice using infrastructure as code."
 date: "2020-12-08"
 meta_image: "containers.png"

--- a/themes/default/content/blog/building-a-future-of-cloud-engineering/index.md
+++ b/themes/default/content/blog/building-a-future-of-cloud-engineering/index.md
@@ -3,7 +3,7 @@ title: "Building a future of cloud engineering"
 date: "2018-10-22"
 meta_desc: "Using your favorite general purpose programming language to define your cloud infrastructure and applications. Program the cloud with Pulumi."
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 ---
 
 

--- a/themes/default/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/themes/default/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -4,7 +4,7 @@ date: "2018-10-01"
 meta_desc: "This blog shows how to build Pulumi projects and stacks from templates."
 meta_image: "new-project-ui-1.gif"
 authors: ["marc-holmes"]
-tags: ["Features"]
+tags: ["new-features"]
 ---
 
 When you're able to build an app for any cloud using familiar languages,

--- a/themes/default/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
+++ b/themes/default/content/blog/building-new-pulumi-projects-and-stacks-from-templates/index.md
@@ -4,7 +4,7 @@ date: "2018-10-01"
 meta_desc: "This blog shows how to build Pulumi projects and stacks from templates."
 meta_image: "new-project-ui-1.gif"
 authors: ["marc-holmes"]
-tags: ["new-features"]
+tags: ["features"]
 ---
 
 When you're able to build an app for any cloud using familiar languages,

--- a/themes/default/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
+++ b/themes/default/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
@@ -4,7 +4,7 @@ date: "2019-05-06"
 meta_desc: "Pulumi open-source task extensions for Azure Pipelines will manage the installation of the Pulumi CLI, and run the Pulumi commands against your stack."
 meta_image: "add-pulumi.png"
 authors: ["praneet-loke"]
-tags: ["Azure", "CI/CD", "New-Features"]
+tags: ["Azure", "continuous-delivery", "New-Features"]
 ---
 
 Azure DevOps is very popular among teams that want a single place to

--- a/themes/default/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
+++ b/themes/default/content/blog/cd-made-easy-with-pulumi-and-azure-pipelines/index.md
@@ -4,7 +4,7 @@ date: "2019-05-06"
 meta_desc: "Pulumi open-source task extensions for Azure Pipelines will manage the installation of the Pulumi CLI, and run the Pulumi commands against your stack."
 meta_image: "add-pulumi.png"
 authors: ["praneet-loke"]
-tags: ["Azure", "continuous-delivery", "New-Features"]
+tags: ["Azure", "continuous-delivery", "features"]
 ---
 
 Azure DevOps is very popular among teams that want a single place to

--- a/themes/default/content/blog/ces-reloaded/index.md
+++ b/themes/default/content/blog/ces-reloaded/index.md
@@ -6,7 +6,7 @@ meta_image: cloud_engineering.png
 authors:
     - sophia-parafina
 tags:
-    - cloud engineering summit=
+    - cloud-engineering
 ---
 
 Putting on a new event is always risky, especially when the calendar is saturated with virtual conferences. Our goal for the Cloud Engineering Summit was to bring the level of conversation above specific technologies and take a holistic look into the future of the cloud and you knocked it out of the park! Here are the stats:

--- a/themes/default/content/blog/cicd-pipelines-with-codefresh-and-pulumi/index.md
+++ b/themes/default/content/blog/cicd-pipelines-with-codefresh-and-pulumi/index.md
@@ -7,8 +7,7 @@ authors:
     - sophia-parafina
     - kostis-kapelonis
 tags:
-    - CI/CD
-    - Codefresh
+    - continuous-delivery
     - Kubernetes
 
 ---

--- a/themes/default/content/blog/connecting-multiple-identities-to-pulumi/index.md
+++ b/themes/default/content/blog/connecting-multiple-identities-to-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Connecting multiple identities to Pulumi"
 authors: ["praneet-loke"]
-tags: ["CI/CD"]
+tags: ["continuous-delivery"]
 meta_desc: "Pulumi now supports multiple identities for a single Pulumi account in the Pulumi Console."
 date: "2018-12-14"
 

--- a/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
+++ b/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery to Any Cloud using GitHub Actions
 h1: "Continuous Delivery to Any Cloud using GitHub Actions and Pulumi"
 authors: ["joe-duffy"]
-tags: ["pulumi-news", "New-Features", "continuous-delivery"]
+tags: ["pulumi-news", "features", "continuous-delivery"]
 meta_desc: "Pulumi GitHub Actions delivers the easiest, most capable, and friction-free way to achieve continuous delivery of cloud applications and infrastructure."
 date: "2018-10-17"
 

--- a/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
+++ b/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery to Any Cloud using GitHub Actions
 h1: "Continuous Delivery to Any Cloud using GitHub Actions and Pulumi"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News", "New-Features", "CI/CD"]
+tags: ["Pulumi-News", "New-Features", "continuous-delivery"]
 meta_desc: "Pulumi GitHub Actions delivers the easiest, most capable, and friction-free way to achieve continuous delivery of cloud applications and infrastructure."
 date: "2018-10-17"
 

--- a/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
+++ b/themes/default/content/blog/continuous-delivery-to-any-cloud-using-github-actions-and-pulumi/index.md
@@ -2,7 +2,7 @@
 title: Continuous Delivery to Any Cloud using GitHub Actions
 h1: "Continuous Delivery to Any Cloud using GitHub Actions and Pulumi"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News", "New-Features", "continuous-delivery"]
+tags: ["pulumi-news", "New-Features", "continuous-delivery"]
 meta_desc: "Pulumi GitHub Actions delivers the easiest, most capable, and friction-free way to achieve continuous delivery of cloud applications and infrastructure."
 date: "2018-10-17"
 

--- a/themes/default/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/themes/default/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous Delivery with GitLab and Pulumi on Amazon EKS"
 authors: ["nishi-davidson"]
-tags: ["AWS","Kubernetes","CI/CD"]
+tags: ["AWS","Kubernetes","continuous-delivery"]
 meta_desc: "In this blog, we'll walk through how to use Pulumi to enable GitLab-based continuous delivery with your Kubernetes workloads on Amazon EKS."
 date: "2019-05-22"
 

--- a/themes/default/content/blog/controlling-aws-costs-with-lambda-and-pulumi/index.md
+++ b/themes/default/content/blog/controlling-aws-costs-with-lambda-and-pulumi/index.md
@@ -2,7 +2,7 @@
 date: "2020-04-09"
 title: "Controlling AWS Costs with Pulumi and AWS Lambda"
 authors: ["paul-stack"]
-tags: ["AWS", "serverless", "lambda"]
+tags: ["AWS", "serverless"]
 meta_desc: "Learn how to use Pulumi and AWS Lambda to create and deploy an application that can control cloud costs."
 meta_image: "cost.png"
 ---

--- a/themes/default/content/blog/coronavirus-plan/index.md
+++ b/themes/default/content/blog/coronavirus-plan/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi’s Coronavirus Plan"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 date: "2020-03-18"
 meta_desc: "Together, we’re facing an unprecedented situation with the COVID-19 pandemic. Learn about the steps we've taken."
 ---

--- a/themes/default/content/blog/create-eks-clusters-in-your-favorite-language/index.md
+++ b/themes/default/content/blog/create-eks-clusters-in-your-favorite-language/index.md
@@ -8,7 +8,6 @@ authors:
     - levi-blackstone
 tags:
     - aws
-    - eks
     - .net
     - python
     - go

--- a/themes/default/content/blog/create-secure-jupyter-notebooks-on-kubernetes-using-pulumi/index.md
+++ b/themes/default/content/blog/create-secure-jupyter-notebooks-on-kubernetes-using-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Secure Jupyter Notebooks on Kubernetes using Pulumi"
 authors: ["nishi-davidson"]
-tags: ["Kubernetes","Applications","GKE","Jupyter"]
+tags: ["Kubernetes","google-cloud","data-and-analytics"]
 meta_desc: "In this blog, we'll walk through how to use Pulumi to create Jupyter Notebooks on Kubernetes. "
 date: "2019-05-30"
 

--- a/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
+++ b/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
@@ -4,7 +4,7 @@ date: 2020-08-13T15:06:26-07:00
 meta_desc: A tutorial on how to create a Python AWS application using Flask, Redis, and Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "docker-containers"]
+tags: ["aws", "python", "containers"]
 ---
 
 *Meet Vova Ivanov---one of the Pulumi summer interns. He'll be writing about his experiences learning Pulumi while modernizing a web app and its underlying infrastructure.*

--- a/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
+++ b/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
@@ -4,7 +4,7 @@ date: 2020-08-13T15:06:26-07:00
 meta_desc: A tutorial on how to create a Python AWS application using Flask, Redis, and Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "ecs", "docker"]
+tags: ["aws", "python", "docker-containers"]
 ---
 
 *Meet Vova Ivanov---one of the Pulumi summer interns. He'll be writing about his experiences learning Pulumi while modernizing a web app and its underlying infrastructure.*

--- a/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
+++ b/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating and Reusing Cloud Components using Package Managers"
 authors: ["chris-smith"]
-tags: ["Infrastructure", "continuous-delivery"]
+tags: [packages]
 meta_desc: "Pulumi's code-centric approach to infrastructure can make you more productive programming the cloud. Package up, share, and reuse our code."
 date: "2018-08-09"
 

--- a/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
+++ b/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating and Reusing Cloud Components using Package Managers"
 authors: ["chris-smith"]
-tags: ["Infrastructure", "CI/CD"]
+tags: ["Infrastructure", "continuous-delivery"]
 meta_desc: "Pulumi's code-centric approach to infrastructure can make you more productive programming the cloud. Package up, share, and reuse our code."
 date: "2018-08-09"
 

--- a/themes/default/content/blog/crossguard-2-0/index.md
+++ b/themes/default/content/blog/crossguard-2-0/index.md
@@ -7,7 +7,6 @@ authors:
    - erin-krengel
 tags:
    - "Policy as Code"
-   - "CrossGuard"
 ---
 
 In a [previous blog post]({{< relref "/blog/announcing-crossguard-preview" >}}), I introduced CrossGuard, Pulumi's Policy as Code solution. As part of our [2.0 release]({{< relref "/blog/pulumi-2-0" >}}), CrossGuard is now generally available and has some awesome new features to improve the user experience around managing Policy Packs.

--- a/themes/default/content/blog/crosswalk-kubernetes/index.md
+++ b/themes/default/content/blog/crosswalk-kubernetes/index.md
@@ -2,7 +2,7 @@
 title: A Year of Helping Build Production-Ready Kubernetes
 h1: A Year of Helping Customers Build Production-Ready Kubernetes Infrastructure
 authors: ["joe-duffy"]
-tags: ["Pulumi-News", "Kubernetes"]
+tags: ["pulumi-news", "Kubernetes"]
 meta_desc: "Pulumi Crosswalk for Kubernetes, a collection of open source technologies to help developers and operators bring Kubernetes into their organizations."
 date: "2019-11-14"
 meta_image: "pulumi-crosswalk-k8s.png"

--- a/themes/default/content/blog/cumundi-guest-post/index.md
+++ b/themes/default/content/blog/cumundi-guest-post/index.md
@@ -6,7 +6,7 @@ meta_image: cumundi-pulumi.png
 authors:
     - ringo-de-smet
 tags:
-    - testing
+    - aliases
 ---
 
 **Guest Article:** [Ringo De Smet](https://www.linkedin.com/in/ringodesmet/), Founder of Cumundi, standardizes on Pulumi for writing infrastructure as reusable code libraries for his customers. Pulumi enables him to rapidly iterate through the build-test-release cycle of these building blocks.

--- a/themes/default/content/blog/cumundi-guest-post/index.md
+++ b/themes/default/content/blog/cumundi-guest-post/index.md
@@ -6,7 +6,7 @@ meta_image: cumundi-pulumi.png
 authors:
     - ringo-de-smet
 tags:
-    - Test Driven Development
+    - testing
 ---
 
 **Guest Article:** [Ringo De Smet](https://www.linkedin.com/in/ringodesmet/), Founder of Cumundi, standardizes on Pulumi for writing infrastructure as reusable code libraries for his customers. Pulumi enables him to rapidly iterate through the build-test-release cycle of these building blocks.

--- a/themes/default/content/blog/data-science-in-the-cloud/index.md
+++ b/themes/default/content/blog/data-science-in-the-cloud/index.md
@@ -6,8 +6,7 @@ meta_image: data_science.png
 authors:
     - sophia-parafina
 tags:
-    - Jupyter
-    - Data Science
+    - data-and-analytics
     - Automation API
     - Python
 ---

--- a/themes/default/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
+++ b/themes/default/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
@@ -5,7 +5,7 @@ date: "2018-11-02"
 meta_desc: "Find out how Wallaroo powered their cluster provisioning with Pulumi, for data science on demand."
 meta_image: "tty-fast.gif"
 authors: ["marc-holmes", "simon-zelazny"]
-tags: ["Infrastructure","Customer"]
+tags: ["guest-post"]
 ---
 
 *This guest post is from Simon Zelazny of

--- a/themes/default/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
+++ b/themes/default/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
@@ -2,7 +2,7 @@
 title: "Day 2 Kubernetes: Migrate EKS Node Groups with Zero Downtime"
 h1: "Day 2 Kubernetes: Migrating EKS Node Groups with Zero Downtime"
 authors: ["mike-metral"]
-tags: ["Kubernetes","EKS"]
+tags: ["Kubernetes"]
 meta_desc: "Use Pulumi's for Day 2 Kubernetes. Spin up a new EKS cluster, add one more node groups, and migrate the workloads with zero downtime using code and kubectl."
 date: "2019-07-23"
 

--- a/themes/default/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
+++ b/themes/default/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
@@ -5,7 +5,7 @@ date: "2018-12-05"
 meta_desc: "In our latest white paper, Delivering Cloud Native Infrastructure as Code, we make the case for a consistent programming model for the cloud."
 meta_image: "graph.png"
 authors: ["marc-holmes"]
-tags: ["Cloud-Native"]
+tags: ["pulumi-news"]
 ---
 
 **Enterprise software has undergone a slow shift from containerless

--- a/themes/default/content/blog/deploy-kubernetes-and-apps-with-go/index.md
+++ b/themes/default/content/blog/deploy-kubernetes-and-apps-with-go/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - Kubernetes
     - Go
-    - docker-containers
+    - containers
 ---
 
 We're excited that Go is now a first-class language in Pulumi and that you can build your infrastructure with Go on AWS, Azure, GCP, and many other clouds. Users often ask, "Can I use Pulumi to manage Kubernetes infrastructure in Go today?" With the release of Pulumi 2.0., the answer is "Yes!"

--- a/themes/default/content/blog/deploy-kubernetes-and-apps-with-go/index.md
+++ b/themes/default/content/blog/deploy-kubernetes-and-apps-with-go/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - Kubernetes
     - Go
-    - containers
+    - docker-containers
 ---
 
 We're excited that Go is now a first-class language in Pulumi and that you can build your infrastructure with Go on AWS, Azure, GCP, and many other clouds. Users often ask, "Can I use Pulumi to manage Kubernetes infrastructure in Go today?" With the release of Pulumi 2.0., the answer is "Yes!"

--- a/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-08-28
 meta_desc: Using Pulumi to create and deploy a simple Django MySQL application to AWS
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "mysql", "docker"]
+tags: ["aws", "python", "docker-containers"]
 ---
 
 In this blog post, we will finish swapping out the frontend and backend of our [Python AWS application]({{< relref "/blog/creating-a-python-aws-application-using-flask-and-redis" >}}). Although Flask and Redis are different from Django and MySQL in many ways, the underlying infrastructure behind their deployment is nonetheless very similar, and can be effortlessly updated as we transition from one to the other.

--- a/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-08-28
 meta_desc: Using Pulumi to create and deploy a simple Django MySQL application to AWS
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "docker-containers"]
+tags: ["aws", "python", "containers"]
 ---
 
 In this blog post, we will finish swapping out the frontend and backend of our [Python AWS application]({{< relref "/blog/creating-a-python-aws-application-using-flask-and-redis" >}}). Although Flask and Redis are different from Django and MySQL in many ways, the underlying infrastructure behind their deployment is nonetheless very similar, and can be effortlessly updated as we transition from one to the other.

--- a/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-09-04
 meta_desc: Creating and quickly deploying a PERN stack application to the cloud Using Pulumi
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker"]
+tags: ["aws", "typescript", "docker-containers"]
 ---
 
 In this blog post, we will explore PERN stack applications and deploy one to AWS. *PERN* is an acronym for PostgreSQL, Express, React, and Node. A PERN stack application is a project that uses PostgreSQL, Express as an application framework, React as a user interface framework, and runs on Node. We will also use [Pulumi Crosswalk]({{< relref "/docs/guides/crosswalk/aws" >}}) to reduce the amount of code and provide a quick and straightforward path for deploying the application.

--- a/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-09-04
 meta_desc: Creating and quickly deploying a PERN stack application to the cloud Using Pulumi
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker-containers"]
+tags: ["aws", "typescript", "containers"]
 ---
 
 In this blog post, we will explore PERN stack applications and deploy one to AWS. *PERN* is an acronym for PostgreSQL, Express, React, and Node. A PERN stack application is a project that uses PostgreSQL, Express as an application framework, React as a user interface framework, and runs on Node. We will also use [Pulumi Crosswalk]({{< relref "/docs/guides/crosswalk/aws" >}}) to reduce the amount of code and provide a quick and straightforward path for deploying the application.

--- a/themes/default/content/blog/deploying-minecraft-on-azure/index.md
+++ b/themes/default/content/blog/deploying-minecraft-on-azure/index.md
@@ -7,8 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - Azure
-    - virtual machine
-    - Minecraft
 ---
 
 This article demonstrates how to deploy and provision a virtual machine in Azure using the Pulumi [Azure-Native provider]({{< relref "/blog/full-coverage-of-azure-resources-with-azure-native" >}}). While there are numerous examples of using the Azure console, the Azure CLI, or ARM templates to deploy and provision virtual machines, we'll use Python to implement a repeatable deployment.

--- a/themes/default/content/blog/deploying-mysql-schemas-using-dynamic-providers/index.md
+++ b/themes/default/content/blog/deploying-mysql-schemas-using-dynamic-providers/index.md
@@ -4,7 +4,7 @@ date: 2020-08-18
 meta_desc: Leveraging Pulumi Dynamic Providers to expand opportunities in cloud architecture design
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "mysql"]
+tags: ["aws", "python"]
 ---
 
 In our [previous post]({{< relref "/blog/creating-a-python-aws-application-using-flask-and-redis" >}}), we created a Python voting application using Flask and Redis. This blog post will explore creating a MySQL database and initializing it with a schema and data. What seems to be a simple step is much more interesting than it appears, because Pulumi's MySQL provider does not support creating and populating tables. To do it, we will extend it with a Dynamic Provider.

--- a/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
+++ b/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
@@ -5,7 +5,7 @@ draft: false
 meta_desc: "Implementing Netlify CMS without Netlify, deploying the Netlify CMS on AWS."
 meta_image: cms.png
 authors: ["zephyr-zhou"]
-tags: ["aws", "netlify-cms","s3","cloudfront","route53", "github-actions"]
+tags: ["aws", "github-actions"]
 ---
 
 [Netlify CMS](https://www.netlifycms.org/docs/intro/) is an open-source content management system that provides UI for editing content and adopting Git workflow. Initially, we want to take advantage of it to increase efficiency to edit Pulumi's website. However, during development, we found few examples are deploying the CMS application on AWS instead of Netlify, its home platform. Therefore, in this blog post, we would like to share how to organize Netlify's file structure and use Pulumi to store the content on S3 buckets, connect to CloudFront, and configure certificate in Certificate Manager.

--- a/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
+++ b/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
@@ -5,7 +5,7 @@ draft: false
 meta_desc: "Implementing Netlify CMS without Netlify, deploying the Netlify CMS on AWS."
 meta_image: cms.png
 authors: ["zephyr-zhou"]
-tags: ["aws", "netlify-cms","s3","cloudfront","certificate-manager","route53", "github-actions"]
+tags: ["aws", "netlify-cms","s3","cloudfront","route53", "github-actions"]
 ---
 
 [Netlify CMS](https://www.netlifycms.org/docs/intro/) is an open-source content management system that provides UI for editing content and adopting Git workflow. Initially, we want to take advantage of it to increase efficiency to edit Pulumi's website. However, during development, we found few examples are deploying the CMS application on AWS instead of Netlify, its home platform. Therefore, in this blog post, we would like to share how to organize Netlify's file structure and use Pulumi to store the content on S3 buckets, connect to CloudFront, and configure certificate in Certificate Manager.

--- a/themes/default/content/blog/deploying-production-ready-containers-with-pulumi/index.md
+++ b/themes/default/content/blog/deploying-production-ready-containers-with-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2018-06-20"
 meta_desc: "This blog covers creating a container registry instance in ECR, creating task definitions in ECS, and configuring a load balancer."
 meta_image: "hello-world-page.png"
 authors: ["donna-malayeri"]
-tags: ["JavaScript","AWS","docker-containers"]
+tags: ["JavaScript","AWS","containers"]
 ---
 
 Containers are a great way to deploy applications to the cloud,

--- a/themes/default/content/blog/deploying-production-ready-containers-with-pulumi/index.md
+++ b/themes/default/content/blog/deploying-production-ready-containers-with-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2018-06-20"
 meta_desc: "This blog covers creating a container registry instance in ECR, creating task definitions in ECS, and configuring a load balancer."
 meta_image: "hello-world-page.png"
 authors: ["donna-malayeri"]
-tags: ["JavaScript","AWS","Containers"]
+tags: ["JavaScript","AWS","docker-containers"]
 ---
 
 Containers are a great way to deploy applications to the cloud,

--- a/themes/default/content/blog/deploying-the-infrastructure-of-oauth-server-for-cms-app/index.md
+++ b/themes/default/content/blog/deploying-the-infrastructure-of-oauth-server-for-cms-app/index.md
@@ -5,7 +5,7 @@ draft: false
 meta_desc: "Implementing and deploying an OAuth server for Netlify CMS on Fargate."
 meta_image: cms-oauth.png
 authors: ["zephyr-zhou"]
-tags: ["aws","netlify-cms","github-oauth","ecs-fargate", "github-actions"]
+tags: ["aws","github-actions"]
 ---
 
 In our [previous post]({{< relref "/blog/deploying-netlify-cms-on-aws" >}}), we deployed our CMS app on AWS instead of Netlify. We couldn't use [Netlify's Identity Service](https://docs.netlify.com/visitor-access/identity/#enable-identity-in-the-ui), which manages GitHub access to Netlify CMS, because we deployed on AWS. As a result, we needed to implement an external [OAuth Server](https://www.netlifycms.org/docs/external-oauth-clients/#header).

--- a/themes/default/content/blog/deploying-with-octopus-and-pulumi/index.md
+++ b/themes/default/content/blog/deploying-with-octopus-and-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous Delivery on Octopus Deploy using Pulumi"
 authors: ["sophia-parafina"]
-tags: ["CD","Octopus"]
+tags: ["continuous-delivery"]
 meta_image: "octopus-pulumi.png"
 meta_desc: "Continuous delivery of Pulumi apps with Octopus Deploy "
 date: "2019-10-22"

--- a/themes/default/content/blog/dotnet-preview/index.md
+++ b/themes/default/content/blog/dotnet-preview/index.md
@@ -8,9 +8,6 @@ authors:
     - sophia-parafina
 tags:
     - ".NET"
-    - "C#"
-    - "F#"
-    - "Visual Basic"
 ---
 With the release of [Pulumi for .NET preview]({{< relref "/blog/pulumi-dotnet-core" >}}), we've open the doors to infrastructure as code to even more developers and operators. Millions of .NET developers can now use their favorite languages and open source ecosystems to build modern, cloud native applications. We've added support for C#, F#, and Visual Basic. Because .NET Core is available on Windows, Linux, and macOS, you have a choice of platforms to use.
 

--- a/themes/default/content/blog/dynamic-providers/index.md
+++ b/themes/default/content/blog/dynamic-providers/index.md
@@ -6,7 +6,7 @@ meta_image: meta.png
 authors:
     - praneet-loke
 tags:
-    - new-features
+    - features
 ---
 
 Pulumi has many resource providers that allow you to interact with your favorite cloud or resource. There are times when a provider may not deliver on the specific task that you want to accomplish. Dynamic Providers can be a powerful tool to help accomplish your infrastructure tasks.

--- a/themes/default/content/blog/dynamic-providers/index.md
+++ b/themes/default/content/blog/dynamic-providers/index.md
@@ -6,8 +6,7 @@ meta_image: meta.png
 authors:
     - praneet-loke
 tags:
-    - providers
-    - resources
+    - new-features
 ---
 
 Pulumi has many resource providers that allow you to interact with your favorite cloud or resource. There are times when a provider may not deliver on the specific task that you want to accomplish. Dynamic Providers can be a powerful tool to help accomplish your infrastructure tasks.

--- a/themes/default/content/blog/easily-bring-your-team-to-pulumi/index.md
+++ b/themes/default/content/blog/easily-bring-your-team-to-pulumi/index.md
@@ -6,8 +6,7 @@ meta_image: sso.png
 authors:
     - alex-mullans
 tags:
-    - auth
-    - enterprise
+    - pulumi-enterprise
     - security
 ---
 

--- a/themes/default/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/themes/default/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -9,7 +9,6 @@ authors:
   - levi-blackstone
 tags:
   - aws
-  - eks
   - kubernetes
 ---
 

--- a/themes/default/content/blog/eks-oidc/index.md
+++ b/themes/default/content/blog/eks-oidc/index.md
@@ -2,7 +2,7 @@
 date: "2020-06-02"
 title: "Access Control for Pods on Amazon EKS"
 authors: ["mike-metral"]
-tags: ["EKS", "RBAC", "Kubernetes"]
+tags: ["aws", "Kubernetes"]
 meta_desc: "Amazon EKS clusters can use IAM roles and policies for Pods to assign fine-grained access control of AWS services."
 meta_image: cluster.png
 ---

--- a/themes/default/content/blog/enforcing-different-kinds-of-policies-for-cloud-resources/index.md
+++ b/themes/default/content/blog/enforcing-different-kinds-of-policies-for-cloud-resources/index.md
@@ -6,7 +6,7 @@ meta_image: crossguard.png
 authors:
     - justin-vanpatten
 tags:
-    - crossguard
+    - policy-as-code
     - policy-as-code
 ---
 

--- a/themes/default/content/blog/enforcing-different-kinds-of-policies-for-cloud-resources/index.md
+++ b/themes/default/content/blog/enforcing-different-kinds-of-policies-for-cloud-resources/index.md
@@ -7,7 +7,6 @@ authors:
     - justin-vanpatten
 tags:
     - policy-as-code
-    - policy-as-code
 ---
 
 We recently announced [a new policy as code solution, CrossGuard]({{< relref "/blog/announcing-crossguard-preview" >}}) that validates policies at deployment time. Policies are expressed as code and are used to prevent the creation of out-of-compliance resources. This allows an organization to prevent entire classes of security and reliability defects to ensure infrastructure is following best practices. Because policies are written using full-blown programming languages, it's possible to do interesting things such as [combining IAM Access Analyzer and Pulumi CrossGuard]({{< relref "/blog/aws-iam-access-analyzer-and-crossguard" >}}). In this post, we'll take a closer look at the different types of policies that can be written.

--- a/themes/default/content/blog/from-terraform-to-infrastructure-as-software/index.md
+++ b/themes/default/content/blog/from-terraform-to-infrastructure-as-software/index.md
@@ -4,7 +4,7 @@ date: "2018-11-02"
 meta_desc: "Convert existing Terrraform configuration to Pulumi TypeScript to help you create simpler, more flexible infrastructure as code, with less repetition."
 meta_image: "tf-to-pulumi.png"
 authors: ["pat-gavlin"]
-tags: ["JavaScript","Infrastructure","TypeScript"]
+tags: ["JavaScript","TypeScript"]
 ---
 
 Here at Pulumi, we love programming the cloud using infrastructure as

--- a/themes/default/content/blog/gartner-cool-vendor-award/index.md
+++ b/themes/default/content/blog/gartner-cool-vendor-award/index.md
@@ -6,8 +6,7 @@ meta_image: gartner.png
 authors:
     - sophia-parafina
 tags:
-    - Gartner
-    - DevOps
+    - pulumi-news
 ---
 
 Pulumi is honored to be named as one of only three vendors in the [2020 Gartner Cool Vendor for Agile and DevOps report, published on May 28th, 2020](https://info.pulumi.com/press-release/gartner-cool-vendor-5_28_2020). Being recognized in this way is a strong validation of Pulumi's impact thanks to our more modern approach to Infrastructure as Code and approaches to building cloud software. Vendors can only be selected once and in only one category making this an exclusive award.

--- a/themes/default/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
+++ b/themes/default/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-04-30"
 meta_desc: "Using Pulumi to build a custom Docker image, publish it to a AWS container registry, and spin up an AWS Fargate load balanced service running that container."
 meta_image: "docker-fargate-history.png"
 authors: ["joe-duffy"]
-tags: ["JavaScript","AWS","docker-containers","TypeScript"]
+tags: ["JavaScript","AWS","containers","TypeScript"]
 ---
 
 > Update: Check out the [Learning Machine Case Study]({{< relref "/case-studies/learning-machine" >}}) where provisioning went from 3 weeks to 1 hour with Pulumi and AWS.

--- a/themes/default/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
+++ b/themes/default/content/blog/get-started-with-docker-on-aws-fargate-using-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-04-30"
 meta_desc: "Using Pulumi to build a custom Docker image, publish it to a AWS container registry, and spin up an AWS Fargate load balanced service running that container."
 meta_image: "docker-fargate-history.png"
 authors: ["joe-duffy"]
-tags: ["JavaScript","AWS","Containers","Infrastructure","TypeScript"]
+tags: ["JavaScript","AWS","docker-containers","TypeScript"]
 ---
 
 > Update: Check out the [Learning Machine Case Study]({{< relref "/case-studies/learning-machine" >}}) where provisioning went from 3 weeks to 1 hour with Pulumi and AWS.

--- a/themes/default/content/blog/getting-started-with-k8s-part4/index.md
+++ b/themes/default/content/blog/getting-started-with-k8s-part4/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-    - StatefulSets
 ---
 
 This article is the fourth in a series using infrastructure as code to deploy applications with Kubernetes. This series walks you through:

--- a/themes/default/content/blog/getting-started-with-k8s-part5/index.md
+++ b/themes/default/content/blog/getting-started-with-k8s-part5/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-    - networking
 ---
 
 In previous installments, we examined how to deploy applications. However, we only touched on how applications talk to each other inside and outside the cluster. Whether you are building a modern application or modernizing a legacy application, understanding how resources and components talk to each other is essential. In this installment, we’ll examine networking in Kubernetes.

--- a/themes/default/content/blog/getting-started-with-k8s-part6/index.md
+++ b/themes/default/content/blog/getting-started-with-k8s-part6/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - kubernetes
-    - day 2
 ---
 
 Your application made it out of the dev stage, passed the testing stage, and arrived in production. As a developer, you might think that it's an ops problem now. However, DevOps is a collaborative effort between developers and operators to build and maintain applications using shared techniques and processes, often called "Day 2" activities.

--- a/themes/default/content/blog/getting-started-with-pac/index.md
+++ b/themes/default/content/blog/getting-started-with-pac/index.md
@@ -7,8 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - policy-as-code
-    - S3
-    - Elasticsearch
 ---
 
 Modern applications have brought many benefits and improvements, including the ability to scale and rapid iterations to update software. However, this has come at the cost of complexity. Modern infrastructure is composed of many resources that require detailed configuration to work correctly and securely. Even managed solutions from cloud service providers need additional configuration to ensure that services are secure and free of defects. Cloud providers, such as AWS, do allow you to create policies to ensure that applications are secure, but they are specific to resources that are already deployed. A significant benefit of Policy as Code is the ability to verify and spot problems before deploying your infrastructure.

--- a/themes/default/content/blog/getting-started-with-pac/index.md
+++ b/themes/default/content/blog/getting-started-with-pac/index.md
@@ -6,10 +6,9 @@ meta_image: crossguard.png
 authors:
     - sophia-parafina
 tags:
-    - "Policy as Code"
+    - policy-as-code
     - S3
     - Elasticsearch
-    - "data breach"
 ---
 
 Modern applications have brought many benefits and improvements, including the ability to scale and rapid iterations to update software. However, this has come at the cost of complexity. Modern infrastructure is composed of many resources that require detailed configuration to work correctly and securely. Even managed solutions from cloud service providers need additional configuration to ensure that services are secure and free of defects. Cloud providers, such as AWS, do allow you to create policies to ensure that applications are secure, but they are specific to resources that are already deployed. A significant benefit of Policy as Code is the ability to verify and spot problems before deploying your infrastructure.

--- a/themes/default/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/themes/default/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -4,7 +4,7 @@ date: "2019-01-23"
 meta_desc: "Get started with Pulumi Webhooks to enable notifications of infrastructure changes and respond to those changes as part of a ChatOps workflow."
 meta_image: "pulumi-webhooks.png"
 authors: ["chris-smith"]
-tags: ["CI/CD", "New-Features"]
+tags: ["continuous-delivery", "New-Features"]
 ---
 
 Today we are delighted to announce the availability of Webhooks on

--- a/themes/default/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
+++ b/themes/default/content/blog/getting-to-chatops-with-pulumi-webhooks/index.md
@@ -4,7 +4,7 @@ date: "2019-01-23"
 meta_desc: "Get started with Pulumi Webhooks to enable notifications of infrastructure changes and respond to those changes as part of a ChatOps workflow."
 meta_image: "pulumi-webhooks.png"
 authors: ["chris-smith"]
-tags: ["continuous-delivery", "New-Features"]
+tags: ["continuous-delivery", "features"]
 ---
 
 Today we are delighted to announce the availability of Webhooks on

--- a/themes/default/content/blog/github-token-scanning-service/index.md
+++ b/themes/default/content/blog/github-token-scanning-service/index.md
@@ -2,7 +2,7 @@
 title: GitHub & Pulumi Join Forces To Ensure Pulumi Tokens Are Safe
 h1: "GitHub And Pulumi Join Forces To Ensure Your Pulumi Tokens Are Safe"
 authors: ["praneet-loke"]
-tags: ["Security", "GitHub", "Token Scanning", "Exposed Token", "Leaked Token", "Pulumi Token Scanning"]
+tags: ["Security", "GitHub"]
 date: "2019-08-19"
 
 meta_desc: "Protect your Pulumi Access Tokens with GitHub Token Scanning."

--- a/themes/default/content/blog/github-token-scanning-service/index.md
+++ b/themes/default/content/blog/github-token-scanning-service/index.md
@@ -2,7 +2,7 @@
 title: GitHub & Pulumi Join Forces To Ensure Pulumi Tokens Are Safe
 h1: "GitHub And Pulumi Join Forces To Ensure Your Pulumi Tokens Are Safe"
 authors: ["praneet-loke"]
-tags: ["Security", "GitHub"]
+tags: ["Security"]
 date: "2019-08-19"
 
 meta_desc: "Protect your Pulumi Access Tokens with GitHub Token Scanning."

--- a/themes/default/content/blog/gitlab-project-integration/index.md
+++ b/themes/default/content/blog/gitlab-project-integration/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Amp-up GitLab Merge Requests With Pulumi"
 authors: ["praneet-loke"]
-tags: ["GitLab CI/CD","Pulumi"]
+tags: [continuous-delivery]
 date: "2020-08-26"
 meta_desc: "We are excited to announce the launch of first-class support for integrating GitLab Merge Requests with Pulumi."
 meta_image: pulumi_gitlab.png

--- a/themes/default/content/blog/go-sdk-road-to-2/index.md
+++ b/themes/default/content/blog/go-sdk-road-to-2/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Modern Cloud Infrastructure in Go - The Road to 2.0"
 authors: ["evan-boyle"]
-tags: ["go", "aws", "gcp", "azure"]
+tags: ["go", "aws", google-cloud, "azure"]
 date: "2020-02-27"
 meta_desc: "Pulumi + Go is a powerful combo for your cloud-native infrastructure."
 meta_image: "pulumigo.png"

--- a/themes/default/content/blog/google-cloud-run-serverless-containers/index.md
+++ b/themes/default/content/blog/google-cloud-run-serverless-containers/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - google-cloud
     - "Serverless"
-    - "docker-containers"
+    - "containers"
 ---
 
 Google [Cloud Run](https://cloud.google.com/run/) is the latest addition to the serverless compute family. While it may look similar to existing services of public cloud, the feature set makes Cloud Run unique:

--- a/themes/default/content/blog/google-cloud-run-serverless-containers/index.md
+++ b/themes/default/content/blog/google-cloud-run-serverless-containers/index.md
@@ -6,9 +6,9 @@ meta_image: "meta.png"
 authors:
     - mikhail-shilkov
 tags:
-    - "GCP"
+    - google-cloud
     - "Serverless"
-    - "Containers"
+    - "docker-containers"
 ---
 
 Google [Cloud Run](https://cloud.google.com/run/) is the latest addition to the serverless compute family. While it may look similar to existing services of public cloud, the feature set makes Cloud Run unique:

--- a/themes/default/content/blog/happy-birthday-to-pulumi-open-source/index.md
+++ b/themes/default/content/blog/happy-birthday-to-pulumi-open-source/index.md
@@ -4,7 +4,7 @@ date: "2019-06-18"
 meta_desc: "It's been a year since we open sourced Pulumi, multi-cloud infrastructure as code using your favorite languages. Read more about what we've achieved."
 meta_image: "pulumi-birthday.png"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 ---
 
 One year ago today -- on June 18, 2018 --

--- a/themes/default/content/blog/how-to-registries/index.md
+++ b/themes/default/content/blog/how-to-registries/index.md
@@ -6,7 +6,7 @@ meta_image: registry.png
 authors:
     - sophia-parafina
 tags:
-    - docker-containers
+    - containers
 ---
 
 Whether you are working with Kubernetes or serverless, your application uses containers. If you use the Docker desktop client, images are pushed to Docker Hub by default. Pulling images from Docker Hub is convenient, but there are many reasons to store images in your own registry. For example, Docker Hub doesn’t guarantee to produce the same image on repeated pulls, i.e., your base image might have changed. It’s also possible to inadvertently expose secrets in an intermediate image used to build the image stored on Docker Hub. There is also the possibility of vulnerabilities in even official images. This article shows how to create a repository and how to build and push images to that repository

--- a/themes/default/content/blog/how-to-registries/index.md
+++ b/themes/default/content/blog/how-to-registries/index.md
@@ -6,9 +6,7 @@ meta_image: registry.png
 authors:
     - sophia-parafina
 tags:
-    - containers
-    - registry
-    - Docker
+    - docker-containers
 ---
 
 Whether you are working with Kubernetes or serverless, your application uses containers. If you use the Docker desktop client, images are pushed to Docker Hub by default. Pulling images from Docker Hub is convenient, but there are many reasons to store images in your own registry. For example, Docker Hub doesn’t guarantee to produce the same image on repeated pulls, i.e., your base image might have changed. It’s also possible to inadvertently expose secrets in an intermediate image used to build the image stored on Docker Hub. There is also the possibility of vulnerabilities in even official images. This article shows how to create a repository and how to build and push images to that repository

--- a/themes/default/content/blog/how-we-use-pulumi-to-build-pulumi/index.md
+++ b/themes/default/content/blog/how-we-use-pulumi-to-build-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2018-06-26"
 meta_desc: "In this post, we discuss how we use Pulumi ourselves to build, deploy and manage the Pulumi platform."
 meta_image: "image-4.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","Containers","Infrastructure"]
+tags: ["Serverless","AWS","docker-containers"]
 ---
 
 

--- a/themes/default/content/blog/how-we-use-pulumi-to-build-pulumi/index.md
+++ b/themes/default/content/blog/how-we-use-pulumi-to-build-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2018-06-26"
 meta_desc: "In this post, we discuss how we use Pulumi ourselves to build, deploy and manage the Pulumi platform."
 meta_image: "image-4.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","docker-containers"]
+tags: ["Serverless","AWS","containers"]
 ---
 
 

--- a/themes/default/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
+++ b/themes/default/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-02-13"
 meta_desc: "Like ksonnet, Pulumi provides complete access to the raw Kubernetes API, and supports additional features like modules/imports, components, functions, and more."
 meta_image: "kube-update.gif"
 authors: ["mike-metral"]
-tags: ["Kubernetes","Cloud-Native"]
+tags: ["Kubernetes"]
 ---
 
 The Kubernetes landscape is constantly evolving as end users and

--- a/themes/default/content/blog/improved-preview-experience/index.md
+++ b/themes/default/content/blog/improved-preview-experience/index.md
@@ -7,7 +7,7 @@ meta_image: preview_update.png
 authors:
     - paul-stack
 tags:
-    - enhancement
+    - new-features
 ---
 
 Today we are announcing a minor but significant improvement to the Pulumi [preview]({{< relref "/docs/reference/cli/pulumi_preview" >}})

--- a/themes/default/content/blog/improved-preview-experience/index.md
+++ b/themes/default/content/blog/improved-preview-experience/index.md
@@ -8,7 +8,6 @@ authors:
     - paul-stack
 tags:
     - enhancement
-    - pulumi
 ---
 
 Today we are announcing a minor but significant improvement to the Pulumi [preview]({{< relref "/docs/reference/cli/pulumi_preview" >}})

--- a/themes/default/content/blog/improved-preview-experience/index.md
+++ b/themes/default/content/blog/improved-preview-experience/index.md
@@ -7,7 +7,7 @@ meta_image: preview_update.png
 authors:
     - paul-stack
 tags:
-    - new-features
+    - features
 ---
 
 Today we are announcing a minor but significant improvement to the Pulumi [preview]({{< relref "/docs/reference/cli/pulumi_preview" >}})

--- a/themes/default/content/blog/infrastructure-as-code-resource-naming/index.md
+++ b/themes/default/content/blog/infrastructure-as-code-resource-naming/index.md
@@ -6,7 +6,7 @@ meta_image: meta.png
 authors:
     - eric-rudder
 tags:
-    - new-features
+    - features
 ---
 
 "What's in a name? That which we call a rose by any other name would smell as sweet."  William Shakespeare's oft repeated quote was used to help Juliet explain that a "Montague" is worthy of love.  Juliet may have underestimated the importance of a name, however, since things didn't work out so well for everyone in Verona!  Many customers have questions about "names" in Pulumi -- and in an effort to make sure that things work out better for them than they did for Romeo, here's a quick note on naming!

--- a/themes/default/content/blog/infrastructure-as-code-resource-naming/index.md
+++ b/themes/default/content/blog/infrastructure-as-code-resource-naming/index.md
@@ -6,8 +6,7 @@ meta_image: meta.png
 authors:
     - eric-rudder
 tags:
-    - pulumi
-    - infrastructure
+    - new-features
 ---
 
 "What's in a name? That which we call a rose by any other name would smell as sweet."  William Shakespeare's oft repeated quote was used to help Juliet explain that a "Montague" is worthy of love.  Juliet may have underestimated the importance of a name, however, since things didn't work out so well for everyone in Verona!  Many customers have questions about "names" in Pulumi -- and in an effort to make sure that things work out better for them than they did for Romeo, here's a quick note on naming!

--- a/themes/default/content/blog/infrastructure-testing-got-better/index.md
+++ b/themes/default/content/blog/infrastructure-testing-got-better/index.md
@@ -6,8 +6,7 @@ meta_image: dustin-farris.png
 authors:
     - dustin-farris
 tags:
-    - test driven development
-    - unit testing
+    - testing
 ---
 
 **Guest Article:** Dustin Farris is an experienced cloud engineering consultant.  He’s currently building a new data lake for a large public university using Pulumi. The project handles sensitive student and research data and as a result, his team must meet stringent QA and security requirements.  Dustin shows how resource mocking in Pulumi makes testing and verification faster than ever before.

--- a/themes/default/content/blog/inside-crosswalk-for-kubernetes/index.md
+++ b/themes/default/content/blog/inside-crosswalk-for-kubernetes/index.md
@@ -10,7 +10,7 @@ tags:
  - kubernetes
  - azure
  - aws
- - gcp
+ - google-cloud
 ---
 
 Running Kubernetes in production can be challenging. This past year, Pulumi has collected common patterns of usage informed by best practices for provisioning Kubernetes infrastructure and running containerized applications. We call this Pulumi Crosswalk for Kubernetes: a collection of playbooks and libraries to help you to successfully configure, deploy, and manage Kubernetes in a way that works for teams in production.

--- a/themes/default/content/blog/intro-to-step-functions/index.md
+++ b/themes/default/content/blog/intro-to-step-functions/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - serverless
-    - "step functions"
 ---
 
 [AWS Step Functions](https://aws.amazon.com/step-functions/) lets you build applications by connecting AWS services. Daisy-chaining steps into a workflow simplifies application development by creating a state machine diagram which shows how services are connected to each other in your application. We'll go into the details of creating a lambda function, IAM roles and policies, and creating a workflow. Once we have the example deployed, we'll walk through the process of adding another function and step to the workflow. Included in the walkthrough is a discussion of one of the aspects of the Pulumi programming model. The goal of this article is to provide a foundation for building your application using serverless workflows.

--- a/themes/default/content/blog/introducing-new-docker-images/index.md
+++ b/themes/default/content/blog/introducing-new-docker-images/index.md
@@ -7,7 +7,7 @@ meta_desc: "Introducing new language specific Docker images which are smaller an
 authors:
     - lee-briggs
 tags:
-    - new-features
+    - features
 
 ---
 

--- a/themes/default/content/blog/introducing-new-docker-images/index.md
+++ b/themes/default/content/blog/introducing-new-docker-images/index.md
@@ -7,7 +7,7 @@ meta_desc: "Introducing new language specific Docker images which are smaller an
 authors:
     - lee-briggs
 tags:
-    - docker
+    - new-features
 
 ---
 

--- a/themes/default/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
+++ b/themes/default/content/blog/introducing-pulumi-a-cloud-development-platform/index.md
@@ -3,7 +3,7 @@ title: "Introducing Pulumi, a Cloud Development Platform"
 date: "2018-06-18"
 meta_desc: "Announcing the launch of Pulumi, an open source cloud development platform, and the cloud's first true programming model using familiar programming languages."
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 ---
 
 Ahoy!

--- a/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
+++ b/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
@@ -4,7 +4,7 @@ date: "2019-06-10"
 meta_desc: "Pulumi Crosswalk for AWS is an open source library of infrastructure-as-code components that make it easier to get from zero to production on AWS."
 meta_image: "crosswalk-for-aws.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","docker-containers","pulumi-news","Kubernetes","docker-containers"]
+tags: ["Serverless","AWS","containers","pulumi-news","Kubernetes","containers"]
 ---
 
 Amazon Web Services provides an incredible platform for developers to

--- a/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
+++ b/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
@@ -4,7 +4,7 @@ date: "2019-06-10"
 meta_desc: "Pulumi Crosswalk for AWS is an open source library of infrastructure-as-code components that make it easier to get from zero to production on AWS."
 meta_image: "crosswalk-for-aws.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","Containers","Pulumi-News","Kubernetes","EKS","Lambda","APIGateway","Docker"]
+tags: ["Serverless","AWS","Containers","Pulumi-News","Kubernetes","EKS","Lambda","aws-APIGateway","Docker"]
 ---
 
 Amazon Web Services provides an incredible platform for developers to

--- a/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
+++ b/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
@@ -4,7 +4,7 @@ date: "2019-06-10"
 meta_desc: "Pulumi Crosswalk for AWS is an open source library of infrastructure-as-code components that make it easier to get from zero to production on AWS."
 meta_image: "crosswalk-for-aws.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","Containers","Pulumi-News","Kubernetes","EKS","Lambda","aws-APIGateway","Docker"]
+tags: ["Serverless","AWS","docker-containers","pulumi-news","Kubernetes","docker-containers"]
 ---
 
 Amazon Web Services provides an incredible platform for developers to

--- a/themes/default/content/blog/jamstack-with-pulumi/index.md
+++ b/themes/default/content/blog/jamstack-with-pulumi/index.md
@@ -6,7 +6,6 @@ meta_image: jamstack.png
 authors:
     - sophia-parafina
 tags:
-    - jamstack
     - aws
 ---
 

--- a/themes/default/content/blog/keep-your-secrets-secure-by-default/index.md
+++ b/themes/default/content/blog/keep-your-secrets-secure-by-default/index.md
@@ -8,6 +8,7 @@ authors:
     - alex-mullans
 tags:
     - security
+    - secrets
 ---
 
 An unauthorized user gaining access to your infrastructure can be catastrophic: data can be stolen or leaked, security holes can be exploited, and more. That risk makes it critical to keep the infrastructure secrets—the passwords, access tokens, keys, and so on—well-protected. This is particularly true in automated systems, like continuous integration and delivery and infrastructure-as-code systems.

--- a/themes/default/content/blog/keep-your-secrets-secure-by-default/index.md
+++ b/themes/default/content/blog/keep-your-secrets-secure-by-default/index.md
@@ -7,7 +7,6 @@ meta_image: secure_by_default.png
 authors:
     - alex-mullans
 tags:
-    - secrets
     - security
 ---
 

--- a/themes/default/content/blog/keeping-your-secrets-secret/index.md
+++ b/themes/default/content/blog/keeping-your-secrets-secret/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - security
+    - secrets
 
 ---
 

--- a/themes/default/content/blog/keeping-your-secrets-secret/index.md
+++ b/themes/default/content/blog/keeping-your-secrets-secret/index.md
@@ -6,7 +6,7 @@ meta_image: secrets.png
 authors:
     - sophia-parafina
 tags:
-    - secrets
+    - security
 
 ---
 

--- a/themes/default/content/blog/kenshoo-migrates-to-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/kenshoo-migrates-to-aws-with-pulumi/index.md
@@ -7,7 +7,7 @@ authors:
     - danny-zalkind
 tags:
     - AWS
-    - migration
+    - guest-post
 ---
 
 > Danny Zalkind is the DevOps group manager for Kenshoo, an award-winning intelligent marketing platform. He brings his 15 years of exprience of managing tech teams to his current role where he's dedicated to allow Kenshoo R&D to efficiently produce and serve software. You can find him on [Linkedin](https://www.linkedin.com/in/danny-zalkind-01602b56/).

--- a/themes/default/content/blog/kubecon-review/index.md
+++ b/themes/default/content/blog/kubecon-review/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - Kubernetes
     - "Query for Kubernetes"
-    - "KubeCon 2019"
+    - events
 ---
 
 ![Pulumi Booth KubeCon2019](booth.jpg)

--- a/themes/default/content/blog/kubecon-review/index.md
+++ b/themes/default/content/blog/kubecon-review/index.md
@@ -6,7 +6,7 @@ meta_image: meta.jpg
 authors:
     - sophia-parafina
 tags:
-    - "Crosswalk for Kubernetes"
+    - Kubernetes
     - "Query for Kubernetes"
     - "KubeCon 2019"
 ---

--- a/themes/default/content/blog/kubecon-review/index.md
+++ b/themes/default/content/blog/kubecon-review/index.md
@@ -7,8 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Kubernetes
-    - "Query for Kubernetes"
-    - events
+    - pulumi-events
 ---
 
 ![Pulumi Booth KubeCon2019](booth.jpg)

--- a/themes/default/content/blog/kubernetes-anti-patterns/index.md
+++ b/themes/default/content/blog/kubernetes-anti-patterns/index.md
@@ -7,7 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - kubernetes
-    - anti-patterns
 ---
 
 In software development, an anti-pattern is defined as an apparent solution that has unintended or negative consequences. The other side of anti-patterns is that they also offer solutions. Let's look at [container](https://codefresh.io/containers/docker-anti-patterns/) and [Kubernetes](https://medium.com/better-programming/10-antipatterns-for-kubernetes-deployments-e97ce1199f2d) anti-patterns and how to avoid them with infrastructure as code.

--- a/themes/default/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
+++ b/themes/default/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
@@ -5,7 +5,7 @@ date: "2019-07-09"
 meta_desc: "In this post, we work through a simple example of running ALB based Kubernetes Ingresses with Pulumi EKS, AWS, and AWSX packages."
 meta_image: "featured-img-albingresscontroller.png"
 authors: ["nishi-davidson"]
-tags: ["Kubernetes", "EKS"]
+tags: ["Kubernetes"]
 ---
 
 [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)

--- a/themes/default/content/blog/kubernetes-yaml-generation/index.md
+++ b/themes/default/content/blog/kubernetes-yaml-generation/index.md
@@ -8,8 +8,6 @@ authors:
     - levi-blackstone
 tags:
     - kubernetes
-    - yaml
-    - kubernetesx
     
 ---
 

--- a/themes/default/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
+++ b/themes/default/content/blog/level-up-your-azure-platform-as-a-service-applications-with-pulumi/index.md
@@ -5,7 +5,7 @@ date: "2019-05-06"
 meta_desc: "This post walks through the process of developing Pulumi programs to leverage Azure Platform services."
 meta_image: "app-insights.png"
 authors: ["mikhail-shilkov"]
-tags: ["Infrastructure","Azure"]
+tags: ["Azure"]
 ---
 
 *Today's guest post is from [Mikhail Shilkov](https://mikhail.io/), a

--- a/themes/default/content/blog/life-of-a-pulumi-intern/index.md
+++ b/themes/default/content/blog/life-of-a-pulumi-intern/index.md
@@ -3,7 +3,7 @@ title: "Life of a Pulumi Intern"
 meta_image: meta.png
 authors: ["tasia-halim"]
 meta_desc: "Peek into the kind of things I've experienced and accomplished as Pulumi's first."
-tags: ["pulumi", "intern"]
+tags: ["pulumi-interns"]
 date: "2020-04-02"
 ---
 

--- a/themes/default/content/blog/manage-infrastructure-with-pac/index.md
+++ b/themes/default/content/blog/manage-infrastructure-with-pac/index.md
@@ -9,7 +9,7 @@ tags:
    - "Policy as Code"
    - "AWS"
    - "Azure"
-   - "GCP"
+   - google-cloud
    - "Kubernetes"
 ---
 

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
@@ -7,7 +7,7 @@ authors:
     - chris-smith
     - sophia-parafina
 tags:
-    - CI/CD
+    - continuous-delivery
 ---
 
 Continuous delivery requires providing highly sensitive credentials to your

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -9,6 +9,7 @@ authors:
 tags:
     - continuous-delivery
     - security
+    - secrets
 ---
 
 This article is the second part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we go in-depth on providing AWS credentials securely to a 3rd party and introduce a Pulumi program to automate rotating access keys.

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -8,7 +8,7 @@ authors:
     - sophia-parafina
 tags:
     - continuous-delivery
-    - secrets
+    - security
 ---
 
 This article is the second part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we go in-depth on providing AWS credentials securely to a 3rd party and introduce a Pulumi program to automate rotating access keys.

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-2/index.md
@@ -7,7 +7,7 @@ authors:
     - chris-smith
     - sophia-parafina
 tags:
-    - CI/CD
+    - continuous-delivery
     - secrets
 ---
 

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -8,7 +8,7 @@ authors:
     - sophia-parafina
 tags:
     - continuous-delivery
-    - secrets
+    - security
 ---
 
 This article is the third part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we cover the

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -7,7 +7,7 @@ authors:
     - chris-smith
     - sophia-parafina
 tags:
-    - CI/CD
+    - continuous-delivery
     - secrets
 ---
 

--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-3/index.md
@@ -9,6 +9,7 @@ authors:
 tags:
     - continuous-delivery
     - security
+    - secrets
 ---
 
 This article is the third part of a series on best practices for securely managing AWS credentials on CI/CD. In this article, we cover the

--- a/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
@@ -6,11 +6,8 @@ meta_image: meta.png
 authors:
     - sophia-parafina
 tags:
-    - EKS
-    - ECS
-    - Lambda
     - AWS
-    - containers
+    - docker-containers
 ---
 
 The Amazon Web Services (AWS) Cloud ecosystem is large and vibrant, so vast and vibrant that at times, it can be challenging to know where best to start! In the case of [containers](https://www.pulumi.com/containers/), [Abby Fuller](https://twitter.com/abbyfuller) tweeted a descriptive summary about using AWS container services.

--- a/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - AWS
-    - docker-containers
+    - containers
 ---
 
 The Amazon Web Services (AWS) Cloud ecosystem is large and vibrant, so vast and vibrant that at times, it can be challenging to know where best to start! In the case of [containers](https://www.pulumi.com/containers/), [Abby Fuller](https://twitter.com/abbyfuller) tweeted a descriptive summary about using AWS container services.

--- a/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
@@ -3,7 +3,7 @@ title: "Managing F5 BIG-IP Systems with Pulumi"
 date: "2019-02-07"
 meta_desc: "In this post, we look at what's possible the F5 BIG-IP provider for Pulumi, as well as the power and the flexibility that Pulumi brings."
 authors: ["cameron-stokes"]
-tags: ["new-features"]
+tags: ["features"]
 ---
 
 The [Pulumi](/) ecosystem is continuously growing

--- a/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
@@ -3,7 +3,7 @@ title: "Managing F5 BIG-IP Systems with Pulumi"
 date: "2019-02-07"
 meta_desc: "In this post, we look at what's possible the F5 BIG-IP provider for Pulumi, as well as the power and the flexibility that Pulumi brings."
 authors: ["cameron-stokes"]
-tags: ["Infrastructure","Cloud-Native"]
+tags: ["new-features"]
 ---
 
 The [Pulumi](/) ecosystem is continuously growing

--- a/themes/default/content/blog/managing-github-webhooks-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-github-webhooks-with-pulumi/index.md
@@ -93,7 +93,7 @@ webhook and fill in my information:
   [random.org](https://www.random.org/) to do so, but any random
   string will suffice. We'll use this string to validate that the
   request came from GitHub.
-- Events: I only care about `pull_request` events, so I picked "Let me
+- pulumi-events: I only care about `pull_request` events, so I picked "Let me
   select individual events" and then checked "Pull requests" and
   unchecked the other event types.
 - Active: Since we want GitHub to deliver events, we'll keep this

--- a/themes/default/content/blog/managing-kubernetes-infrastructure-with-dotnet-and-pulumi/index.md
+++ b/themes/default/content/blog/managing-kubernetes-infrastructure-with-dotnet-and-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing Kubernetes Infrastructure with .NET and Pulumi"
 authors: ["luke-hoban"]
-tags: ["dotnet","kubernetes"]
+tags: [".NET","kubernetes"]
 date: "2019-12-10"
 meta_desc: "Manage Kubernetes with .NET using the Pulumi.Kubernetes resource provider for Pulumi."
 meta_image: "k8s-dotnet.png"

--- a/themes/default/content/blog/managing-secrets-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-secrets-with-pulumi/index.md
@@ -3,7 +3,7 @@ title: "Managing Secrets with Pulumi"
 date: "2019-05-17"
 meta_desc: "Pulumi supports automatic tracking of secret values, and client-side encryption, giving you full control over secrets encryption and decryption."
 authors: ["matt-ellis"]
-tags: ["new-features","Security"]
+tags: ["features","Security"]
 ---
 
 We've had a 1st class concept of encrypted secrets configuration ever

--- a/themes/default/content/blog/managing-secrets-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-secrets-with-pulumi/index.md
@@ -3,7 +3,7 @@ title: "Managing Secrets with Pulumi"
 date: "2019-05-17"
 meta_desc: "Pulumi supports automatic tracking of secret values, and client-side encryption, giving you full control over secrets encryption and decryption."
 authors: ["matt-ellis"]
-tags: ["Features","Security"]
+tags: ["new-features","Security"]
 ---
 
 We've had a 1st class concept of encrypted secrets configuration ever

--- a/themes/default/content/blog/managing-your-mysql-databases-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-your-mysql-databases-with-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-05-28"
 meta_desc: "In this post, we'll walk through a quick tutorial of how to use the Pulumi MySQL provider to manage new and existing MySQL databases."
 meta_image: "hero.png"
 authors: ["linio-engineering"]
-tags: ["Applications","MySQL"]
+tags: [guest-post]
 ---
 
 One of the most critical components of an application’s infrastructure is its

--- a/themes/default/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
+++ b/themes/default/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
@@ -4,7 +4,7 @@ date: "2019-06-12"
 meta_desc: "In this blog, we'll show snippets of the JavaScript code that embraces the power of Pulumi to program AWS service APIs to create the Mapbox solution."
 meta_image: "aws-architecture-iot.jpg"
 authors: ["chris-toomey"]
-tags: ["JavaScript","Serverless","AWS","Infrastructure","Customer"]
+tags: ["JavaScript","Serverless","AWS","guest-post"]
 ---
 
 ## **Guest Author: Chris Toomey, Solution Architect Lead @ Mapbox**

--- a/themes/default/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
+++ b/themes/default/content/blog/meet-the-pulumi-team-at-aws-reinvent/index.md
@@ -3,7 +3,7 @@ title: "Meet the Pulumi team at AWS re:Invent"
 date: "2018-11-15"
 meta_desc: "Catch up with Pulumi on serverless functions, containers, and Kubernetes at AWS re:invent."
 authors: ["marc-holmes"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 ---
 
 Heading to AWS re:Invent? Concerned about how you'll manage to get

--- a/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
+++ b/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
@@ -4,7 +4,7 @@ date: 2020-09-14
 meta_desc: Using Pulumi to integrate applications with Kubernetes for on-demand scalability and freedom of design.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker", "kubernetes"]
+tags: ["aws", "typescript", "docker-containers", "kubernetes"]
 ---
 
 In this blog post, we will explore and demonstrate the advantages of Kubernetes by converting and deploying our [PERN application]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) to Amazon EKS. With the help of Pulumi, the process becomes greatly simplified and allows us to focus more on the big picture of designing our cloud architecture.

--- a/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
+++ b/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
@@ -4,7 +4,7 @@ date: 2020-09-14
 meta_desc: Using Pulumi to integrate applications with Kubernetes for on-demand scalability and freedom of design.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker-containers", "kubernetes"]
+tags: ["aws", "typescript", "containers", "kubernetes"]
 ---
 
 In this blog post, we will explore and demonstrate the advantages of Kubernetes by converting and deploying our [PERN application]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) to Amazon EKS. With the help of Pulumi, the process becomes greatly simplified and allows us to focus more on the big picture of designing our cloud architecture.

--- a/themes/default/content/blog/multicloud-app/index.md
+++ b/themes/default/content/blog/multicloud-app/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Multicloud Kubernetes: Running Apps Across EKS, AKS, and GKE"
 authors: ["mike-metral"]
-tags: ["Kubernetes","amazon-EKS", "azure-AKS", "google-GKE"]
+tags: ["Kubernetes","aws", "azure", "google-cloud"]
 meta_desc: "Run Kubernetes apps using a multicloud strategy. We'll walk through how to leverage multiple Kubernetes providers for deployments across AWS, Azure, and GCP."
 date: "2019-08-14"
 

--- a/themes/default/content/blog/multicloud-app/index.md
+++ b/themes/default/content/blog/multicloud-app/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Multicloud Kubernetes: Running Apps Across EKS, AKS, and GKE"
 authors: ["mike-metral"]
-tags: ["Kubernetes","EKS", "AKS", "GKE"]
+tags: ["Kubernetes","amazon-EKS", "azure-AKS", "google-GKE"]
 meta_desc: "Run Kubernetes apps using a multicloud strategy. We'll walk through how to leverage multiple Kubernetes providers for deployments across AWS, Azure, and GCP."
 date: "2019-08-14"
 

--- a/themes/default/content/blog/observability-with-infrastructure-as-code/index.md
+++ b/themes/default/content/blog/observability-with-infrastructure-as-code/index.md
@@ -7,8 +7,7 @@ meta_desc: "Andy Davies from Reaktor introduces observability into infrastructur
 authors:
 - andy-davies
 tags:
-- observability
-- honeycomb
+- guest-post
 - automation-api
 
 meta_image: "reaktor.png"

--- a/themes/default/content/blog/opa-support-for-crossguard/index.md
+++ b/themes/default/content/blog/opa-support-for-crossguard/index.md
@@ -7,8 +7,6 @@ authors:
     - luke-hoban
 tags:
     - policy-as-code
-    - policy-as-code
-    - opa
 ---
 
 We're excited to announce the addition of Open Policy Agent (OPA) Rego language support to Pulumi's CrossGuard policy-as-code framework. This enables Pulumi CrossGuard policy to be authored in either JavaScript/TypeScript/Python or in the popular Rego language using OPA.

--- a/themes/default/content/blog/opa-support-for-crossguard/index.md
+++ b/themes/default/content/blog/opa-support-for-crossguard/index.md
@@ -7,7 +7,7 @@ authors:
     - luke-hoban
 tags:
     - policy-as-code
-    - crossguard
+    - policy-as-code
     - opa
 ---
 

--- a/themes/default/content/blog/peace-of-mind-with-cloud-secret-providers/index.md
+++ b/themes/default/content/blog/peace-of-mind-with-cloud-secret-providers/index.md
@@ -8,7 +8,7 @@ meta_image: secrets.png
 authors:
     - lee-briggs
 tags:
-    - features
+    - new-features
     - security
 ---
 

--- a/themes/default/content/blog/peace-of-mind-with-cloud-secret-providers/index.md
+++ b/themes/default/content/blog/peace-of-mind-with-cloud-secret-providers/index.md
@@ -8,7 +8,7 @@ meta_image: secrets.png
 authors:
     - lee-briggs
 tags:
-    - new-features
+    - features
     - security
 ---
 

--- a/themes/default/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
+++ b/themes/default/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
@@ -3,7 +3,7 @@ title: "Persisting Kubernetes workloads with Amazon EFS CSI volumes"
 title_tag: "Persisting Kubernetes workloads with Amazon EFS CSI volumes"
 date: "2019-07-15"
 authors: ["nishi-davidson"]
-tags: ["AWS", "EKS", "Kubernetes"]
+tags: ["AWS", "Kubernetes"]
 meta_desc: "In this blog, we will show how to use AWS EFS CSI storage components with Kubernetes workloads running on Amazon EKS worker nodes (EKS, AWS, and AWSX)."
 meta_image: "featured-img-efs-csi-driver.png"
 ---

--- a/themes/default/content/blog/pinpoint/index.md
+++ b/themes/default/content/blog/pinpoint/index.md
@@ -7,7 +7,7 @@ authors:
     - andrew-kunzel
     - michael-goode
 tags:
-    - Pinpoint
+    - guest-post
     - Kubernetes
 ---
 

--- a/themes/default/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
+++ b/themes/default/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
@@ -3,7 +3,7 @@ title: "Program the Cloud with 12 Pulumi Pearls"
 date: "2018-07-25"
 meta_desc: "In this post, we'll look at some fun ways you can program the cloud using Pulumi, including infrastructure, serverless, containers, and general tips and tricks."
 authors: ["joe-duffy"]
-tags: ["Serverless","AWS","docker-containers","TypeScript"]
+tags: ["Serverless","AWS","containers","TypeScript"]
 ---
 
 In this post, we'll look at 12 "pearls" -- bite-sized code snippets --

--- a/themes/default/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
+++ b/themes/default/content/blog/program-the-cloud-with-12-pulumi-pearls/index.md
@@ -3,7 +3,7 @@ title: "Program the Cloud with 12 Pulumi Pearls"
 date: "2018-07-25"
 meta_desc: "In this post, we'll look at some fun ways you can program the cloud using Pulumi, including infrastructure, serverless, containers, and general tips and tricks."
 authors: ["joe-duffy"]
-tags: ["Serverless","AWS","Containers","Infrastructure","TypeScript"]
+tags: ["Serverless","AWS","docker-containers","TypeScript"]
 ---
 
 In this post, we'll look at 12 "pearls" -- bite-sized code snippets --

--- a/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
+++ b/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-04-24"
 meta_desc: "With Pulumi's new AWSX package, you can quickly define a Lambda and an AWS Lambda authorizer to protect it in three easy steps."
 meta_image: "lambda-authorizer.jpg"
 authors: ["erin-krengel"]
-tags: ["Serverless","AWS","Lambda","Auth","aws-APIGateway"]
+tags: ["Serverless","AWS"]
 ---
 
 Creating serverless applications just got even easier! You can now

--- a/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
+++ b/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-04-24"
 meta_desc: "With Pulumi's new AWSX package, you can quickly define a Lambda and an AWS Lambda authorizer to protect it in three easy steps."
 meta_image: "lambda-authorizer.jpg"
 authors: ["erin-krengel"]
-tags: ["Serverless","AWS","Lambda","Auth","APIGateway"]
+tags: ["Serverless","AWS","Lambda","Auth","aws-APIGateway"]
 ---
 
 Creating serverless applications just got even easier! You can now

--- a/themes/default/content/blog/provisioning-and-managing-cloud-infrastructure-with-pulumi/index.md
+++ b/themes/default/content/blog/provisioning-and-managing-cloud-infrastructure-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Provisioning and Managing Cloud Infrastructure with Pulumi"
 authors: ["donna-malayeri"]
-tags: ["JavaScript","AWS","Infrastructure"]
+tags: ["JavaScript","AWS"]
 date: "2018-07-20"
 meta_desc: "Use Pulumi AWS, Azure, and GCP libraries to provision and manage infrastructure. Configure alerting & monitoring directly in code using Pulumi."
 

--- a/themes/default/content/blog/pulumi-1-0/index.md
+++ b/themes/default/content/blog/pulumi-1-0/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi 1.0"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "We are excited to announce Pulumi 1.0, a modern infrastructure as code platform that works for any cloud, AWS, Azure, GCP, or Kubernetes included."
 date: "2019-09-05"
 

--- a/themes/default/content/blog/pulumi-2-0-roadmap/index.md
+++ b/themes/default/content/blog/pulumi-2-0-roadmap/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi 2.0 Roadmap"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "We've published Pulumi's 2.0 roadmap. This release will support great productivity, deeper support for enterprise workloads, and a whole lot more."
 date: "2019-12-02"
 

--- a/themes/default/content/blog/pulumi-2-0/index.md
+++ b/themes/default/content/blog/pulumi-2-0/index.md
@@ -2,7 +2,7 @@
 date: "2020-04-21"
 title: "Announcing Pulumi 2.0, Now with Superpowers"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "Today we are announcing Pulumi 2.0, a modern infrastructure as code platform with advanced capabilities including new languages, testing, and policy as code."
 meta_image: "pulumi-2-0.png"
 ---

--- a/themes/default/content/blog/pulumi-2020-update/index.md
+++ b/themes/default/content/blog/pulumi-2020-update/index.md
@@ -1,7 +1,7 @@
 ---
 title: "An Update on our Roadmap"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 date: "2020-03-09"
 meta_desc: "Learn about some of Pulumi's progress rounding out our .NET and Go SDKs in addition to infrastructure validation using testing and Policy as Code."
 meta_image: "pulumi-1-0.png"

--- a/themes/default/content/blog/pulumi-3-0/index.md
+++ b/themes/default/content/blog/pulumi-3-0/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - automation-api
     - native-providers
-    - pulumi-packages
+    - packages
 ---
 
 Today we’re excited to announce the availability of Pulumi 3.0, the next major version of the Pulumi open source project, and the foundation for Pulumi’s [Cloud Engineering Platform]({{< relref "/cloud-engineering" >}}).

--- a/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
+++ b/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi and Docker: Development to Production"
 authors: ["sean-gillespie"]
-tags: ["Containers","Kubernetes","Docker"]
+tags: ["docker-containers","Kubernetes","docker-containers"]
 date: "2019-05-15"
 meta_desc: "Use Pulumi's infrastructure as software capability to define your Docker resources without running YAML or Docker Compose."
 

--- a/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
+++ b/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi and Docker: Development to Production"
 authors: ["sean-gillespie"]
-tags: ["docker-containers","Kubernetes","docker-containers"]
+tags: ["containers","Kubernetes","containers"]
 date: "2019-05-15"
 meta_desc: "Use Pulumi's infrastructure as software capability to define your Docker resources without running YAML or Docker Compose."
 

--- a/themes/default/content/blog/pulumi-auth0/index.md
+++ b/themes/default/content/blog/pulumi-auth0/index.md
@@ -8,7 +8,6 @@ authors:
     - fernando-carletti
 tags:
     - auth0
-    - Credijusto
 ---
 
 *Guest author Lead Devops Engineer Fernando Carletti, writes about using the Pulumi Auth0 provider to manage resources at Credijusto.*

--- a/themes/default/content/blog/pulumi-auth0/index.md
+++ b/themes/default/content/blog/pulumi-auth0/index.md
@@ -7,7 +7,7 @@ meta_image: credijusto.png
 authors:
     - fernando-carletti
 tags:
-    - auth0
+    - guest-post
 ---
 
 *Guest author Lead Devops Engineer Fernando Carletti, writes about using the Pulumi Auth0 provider to manage resources at Credijusto.*

--- a/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
+++ b/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
@@ -1,7 +1,6 @@
 ---
 title: "Three Infrastructure as Code Blog Posts You Should Read"
 authors: ["sophia-parafina"]
-tags: ["Pulumi","bloggers",]
 meta_image: "blog.png"
 meta_desc: "Some of our favorite recent community posts about Infrastructure as Code."
 date: "2019-10-24"

--- a/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
+++ b/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
@@ -4,6 +4,8 @@ authors: ["sophia-parafina"]
 meta_image: "blog.png"
 meta_desc: "Some of our favorite recent community posts about Infrastructure as Code."
 date: "2019-10-24"
+tags:
+    - community
 ---
 
 We are always excited when people join the Infrastructure as Code community and write about their experiences. Pulumi can be used for a range of common tasks such as standardizing VPC builds, building VSphere virtual machines, or deploying your infrastructure from a CI/CD pipeline. Whether it's `TypeScript`, `JavaScript`, or `Python` you can build your infrastructure with your language and tools of choice. Here are three new blog posts that show how to use Pulumi with code examples to perform these tasks.

--- a/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
+++ b/themes/default/content/blog/pulumi-bloggers-oct-2019/index.md
@@ -5,7 +5,7 @@ meta_image: "blog.png"
 meta_desc: "Some of our favorite recent community posts about Infrastructure as Code."
 date: "2019-10-24"
 tags:
-    - community
+    - guest-post
 ---
 
 We are always excited when people join the Infrastructure as Code community and write about their experiences. Pulumi can be used for a range of common tasks such as standardizing VPC builds, building VSphere virtual machines, or deploying your infrastructure from a CI/CD pipeline. Whether it's `TypeScript`, `JavaScript`, or `Python` you can build your infrastructure with your language and tools of choice. Here are three new blog posts that show how to use Pulumi with code examples to perform these tasks.

--- a/themes/default/content/blog/pulumi-dotnet-core/index.md
+++ b/themes/default/content/blog/pulumi-dotnet-core/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi 💜 .NET Core"
 authors: ["joe-duffy"]
-tags: ["Pulumi-News", ".NET"]
+tags: ["pulumi-news", ".NET"]
 meta_desc: "Today we are excited to announce preview support for writing Pulumi programs in any .NET Core language, including C#, F#, and VB.NET."
 date: "2019-11-11"
 

--- a/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
+++ b/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started on Google Cloud Platform with Pulumi"
 authors: ["luke-hoban"]
-tags: ["Serverless","Kubernetes","Features","CI/CD","GCP"]
+tags: ["Serverless","Kubernetes","Features","continuous-delivery","GCP"]
 date: "2019-04-09"
 meta_desc: "Pulumi offers tooling that works with GCP and enables collaboration, sharing, and reuse. Pulumi gives you full access to the full Google Cloud Platform."
 meta_image: "pulumi_console.png"

--- a/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
+++ b/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started on Google Cloud Platform with Pulumi"
 authors: ["luke-hoban"]
-tags: ["Serverless","Kubernetes","Features","continuous-delivery","GCP"]
+tags: ["Serverless","Kubernetes","new-features","continuous-delivery",google-cloud]
 date: "2019-04-09"
 meta_desc: "Pulumi offers tooling that works with GCP and enables collaboration, sharing, and reuse. Pulumi gives you full access to the full Google Cloud Platform."
 meta_image: "pulumi_console.png"

--- a/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
+++ b/themes/default/content/blog/pulumi-heart-google-cloud-platform/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting Started on Google Cloud Platform with Pulumi"
 authors: ["luke-hoban"]
-tags: ["Serverless","Kubernetes","new-features","continuous-delivery",google-cloud]
+tags: ["Serverless","Kubernetes","features","continuous-delivery",google-cloud]
 date: "2019-04-09"
 meta_desc: "Pulumi offers tooling that works with GCP and enables collaboration, sharing, and reuse. Pulumi gives you full access to the full Google Cloud Platform."
 meta_image: "pulumi_console.png"

--- a/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
+++ b/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
@@ -4,7 +4,7 @@ date: "2020-11-24"
 meta_desc: "Introducing the new pulumi import command that will automatically scaffold your Pulumi application code when importing existing cloud resources."
 meta_image: cloud_engineering.png
 authors: ["paul-stack"]
-tags: ["import","New-Features", "Pulumi-News", "Features"]
+tags: ["New-Features", "new-features"]
 ---
 
 Most infrastructure projects require working with existing cloud resources, either by building on top of existing resources

--- a/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
+++ b/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
@@ -4,7 +4,7 @@ date: "2020-11-24"
 meta_desc: "Introducing the new pulumi import command that will automatically scaffold your Pulumi application code when importing existing cloud resources."
 meta_image: cloud_engineering.png
 authors: ["paul-stack"]
-tags: ["New-Features", "new-features"]
+tags: ["features", "features"]
 ---
 
 Most infrastructure projects require working with existing cloud resources, either by building on top of existing resources

--- a/themes/default/content/blog/pulumi-interstellar/index.md
+++ b/themes/default/content/blog/pulumi-interstellar/index.md
@@ -6,10 +6,6 @@ meta_image: pulumi_interstellar.png
 authors:
     - zack-chase
     - sophia-parafina
-tags:
-    - rockets
-    - terraforming
-    - domes
 
 ---
 

--- a/themes/default/content/blog/pulumi-interstellar/index.md
+++ b/themes/default/content/blog/pulumi-interstellar/index.md
@@ -7,7 +7,7 @@ authors:
     - zack-chase
     - sophia-parafina
 tags:
-    - rnadom
+    - pulumi-news
 ---
 
 Earth is just the beginning. We are putting down the foundations of space so our children can build their future.  At Pulumi, we are committed to making life multi-planetary. We are excited to announce Pulumi Interstellar, a collection of resource providers that will help us reach the future of a space-faring and multi-planet species.

--- a/themes/default/content/blog/pulumi-interstellar/index.md
+++ b/themes/default/content/blog/pulumi-interstellar/index.md
@@ -6,7 +6,8 @@ meta_image: pulumi_interstellar.png
 authors:
     - zack-chase
     - sophia-parafina
-
+tags:
+    - rnadom
 ---
 
 Earth is just the beginning. We are putting down the foundations of space so our children can build their future.  At Pulumi, we are committed to making life multi-planetary. We are excited to announce Pulumi Interstellar, a collection of resource providers that will help us reach the future of a space-faring and multi-planet species.

--- a/themes/default/content/blog/pulumi-kubernetes-operator/index.md
+++ b/themes/default/content/blog/pulumi-kubernetes-operator/index.md
@@ -2,7 +2,7 @@
 date: "2020-08-12"
 title: "Introducing the Pulumi Kubernetes Operator"
 authors: ["mike-metral"]
-tags: ["Kubernetes", "Operator", "Continuous Delivery"]
+tags: ["Kubernetes", "Continuous-Delivery"]
 meta_desc: "Introducing the Pulumi Kubernetes Operator: Deploy infrastructure in Pulumi Stacks"
 meta_image: operator.png
 ---

--- a/themes/default/content/blog/pulumi-meetup-recap-apis-custom-resources-and-github-webhooks/index.md
+++ b/themes/default/content/blog/pulumi-meetup-recap-apis-custom-resources-and-github-webhooks/index.md
@@ -2,7 +2,7 @@
 title: "Pulumi Meetup: APIs, Custom Resources and GitHub Webhooks"
 h1: "Pulumi Meetup Recap: APIs, Custom Resources and GitHub Webhooks"
 authors: ["aydrian-howard"]
-tags: ["events"]
+tags: ["pulumi-events"]
 date: "2019-07-16"
 meta_desc: "Pulumi's July meetup featured talks about how programming languages help in building the best infrastructure code and a bot that enforced pull request policies."
 meta_image: "meta.jpg"

--- a/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
+++ b/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi now supports Atlassian Identity"
 authors: ["praneet-loke"]
-tags: ["new-features","continuous-delivery"]
+tags: ["features","continuous-delivery"]
 date: "2019-01-30"
 meta_desc: "Connect your Pulumi account with your Atlassian identity, invite members of your Bitbucket team, and start collaborating on Pulumi stacks."
 meta_image: "atlassian-1.png"

--- a/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
+++ b/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi now supports Atlassian Identity"
 authors: ["praneet-loke"]
-tags: ["Features","continuous-delivery"]
+tags: ["new-features","continuous-delivery"]
 date: "2019-01-30"
 meta_desc: "Connect your Pulumi account with your Atlassian identity, invite members of your Bitbucket team, and start collaborating on Pulumi stacks."
 meta_image: "atlassian-1.png"

--- a/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
+++ b/themes/default/content/blog/pulumi-now-supports-atlassian-identity/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi now supports Atlassian Identity"
 authors: ["praneet-loke"]
-tags: ["Features","CI/CD"]
+tags: ["Features","continuous-delivery"]
 date: "2019-01-30"
 meta_desc: "Connect your Pulumi account with your Atlassian identity, invite members of your Bitbucket team, and start collaborating on Pulumi stacks."
 meta_image: "atlassian-1.png"

--- a/themes/default/content/blog/pulumi-service-improvements_02-2020/index.md
+++ b/themes/default/content/blog/pulumi-service-improvements_02-2020/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi Console Improvements, February 2020"
 authors: ["chris-smith"]
-tags: ["new-features"]
+tags: ["features"]
 date: "2020-03-02"
 meta_desc: "Recent improvements to the Pulumi Console: stack tags, audit logs, CI/CD integration, downloadable checkpoint files"
 meta_image: "pretty-print-multiline-json.gif"

--- a/themes/default/content/blog/pulumi-service-improvements_02-2020/index.md
+++ b/themes/default/content/blog/pulumi-service-improvements_02-2020/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi Console Improvements, February 2020"
 authors: ["chris-smith"]
-tags: ["pulumi","new-features"]
+tags: ["new-features"]
 date: "2020-03-02"
 meta_desc: "Recent improvements to the Pulumi Console: stack tags, audit logs, CI/CD integration, downloadable checkpoint files"
 meta_image: "pretty-print-multiline-json.gif"

--- a/themes/default/content/blog/pulumi-watch-mode-fast-inner-loop-development-for-cloud-infrastructure/index.md
+++ b/themes/default/content/blog/pulumi-watch-mode-fast-inner-loop-development-for-cloud-infrastructure/index.md
@@ -2,7 +2,7 @@
 title: "Pulumi Watch: Fast Inner Loop Development for Infrastructure"
 h1: "Pulumi Watch Mode: Fast Inner Loop Development for Cloud Infrastructure"
 authors: ["luke-hoban"]
-tags: ["serverless","kubernetes","logging","new-features","applications"]
+tags: ["serverless","kubernetes","logging","new-features"]
 date: "2019-12-02"
 meta_desc: "Pulumi Watch provides a mode for developing cloud infrastructure that speeds up the rate of iteration and allows cloud developers to focus on their code."
 meta_image: "watch.png"

--- a/themes/default/content/blog/pulumi-watch-mode-fast-inner-loop-development-for-cloud-infrastructure/index.md
+++ b/themes/default/content/blog/pulumi-watch-mode-fast-inner-loop-development-for-cloud-infrastructure/index.md
@@ -2,7 +2,7 @@
 title: "Pulumi Watch: Fast Inner Loop Development for Infrastructure"
 h1: "Pulumi Watch Mode: Fast Inner Loop Development for Cloud Infrastructure"
 authors: ["luke-hoban"]
-tags: ["serverless","kubernetes","logging","new-features"]
+tags: ["serverless","kubernetes","logging","features"]
 date: "2019-12-02"
 meta_desc: "Pulumi Watch provides a mode for developing cloud infrastructure that speeds up the rate of iteration and allows cloud developers to focus on their code."
 meta_image: "watch.png"

--- a/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
+++ b/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
@@ -6,7 +6,6 @@ meta_image: aiven.png
 authors:
     - trevor-kennedy
 tags:
-    - Aiven
     - InfluxDB
 ---
 

--- a/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
+++ b/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
@@ -6,7 +6,8 @@ meta_image: aiven.png
 authors:
     - trevor-kennedy
 tags:
-    - InfluxDB
+    - aws
+    - python
 ---
 
 In this article, I’ll show how Pulumi can be used with Aiven’s services to create infrastructure that can be migrated from cloud to cloud with no downtime.

--- a/themes/default/content/blog/pulumis-soc-2-milestone/index.md
+++ b/themes/default/content/blog/pulumis-soc-2-milestone/index.md
@@ -6,7 +6,7 @@ meta_image: soc2.png
 authors:
    - eric-rudder
 tags:
-   - SOC 2
+   - pulumi-enterprise
 ---
 
 ## Pulumi’s Commitment

--- a/themes/default/content/blog/pulumiup-bring-your-whole-team-to-pulumi/index.md
+++ b/themes/default/content/blog/pulumiup-bring-your-whole-team-to-pulumi/index.md
@@ -6,8 +6,7 @@ meta_image: sso.png
 authors:
     - alex-mullans
 tags:
-    - auth
-    - enterprise
+    - pulumi-enterprise
     - security
 ---
 

--- a/themes/default/content/blog/pulumiup-ci-cd-assistant-all-plans/index.md
+++ b/themes/default/content/blog/pulumiup-ci-cd-assistant-all-plans/index.md
@@ -7,7 +7,6 @@ authors:
     - alex-mullans
 tags:
     - continuous-delivery
-    - PulumiUP
 ---
 
 Pulumi's CI/CD Assistant helps you bring your infrastructure under version control and create a continuous integration and delivery pipeline that deploys changes to your cloud applications and infrastructure whenever you make a change in source control. Using CI/CD secures your production delivery while ensuring that every deployment is expressed in a committed Pulumi program and quickly reflected in your deployed infrastructure.  With the CI/CD Assistant, it's easier than ever before to set up version control and a CI/CD pipeline for your favorite CI/CD system, even if you're new to CI/CD workflows.

--- a/themes/default/content/blog/pulumiup-ci-cd-assistant-all-plans/index.md
+++ b/themes/default/content/blog/pulumiup-ci-cd-assistant-all-plans/index.md
@@ -6,7 +6,7 @@ meta_image: meta.png
 authors:
     - alex-mullans
 tags:
-    - ci/cd
+    - continuous-delivery
     - PulumiUP
 ---
 

--- a/themes/default/content/blog/pulumiup-native-providers/index.md
+++ b/themes/default/content/blog/pulumiup-native-providers/index.md
@@ -7,7 +7,6 @@ authors:
     - alex-mullans
 tags:
     - native-providers
-    - PulumiUP
 ---
 
 Pulumi native providers are a new type of [Pulumi Package]({{< relref "/blog/pulumiup-pulumi-packages-multi-language-components" >}}) that give you the most complete and consistent interface for the modern cloud. Pulumi native providers bring the full power of the top cloud providers to the Pulumi Cloud Engineering Platform, faster and with more complete coverage than any other infrastructure as code offering. Today at PulumiUP, we announced native providers for Microsoft Azure (GA), [Google Cloud (public preview)]({{< relref "/blog/pulumiup-google-native-provider" >}}), and AWS (later this year). Along with an existing native provider for Kubernetes, these providers enable you to build, deploy, and manage cloud infrastructure and applications for the most common cloud vendors and technologies. This best-in-class support for the major clouds joins our library of [more than 50 cloud providers]({{< relref "/docs/intro/cloud-providers" >}}) and delivers on our promise of cloud engineering for any cloud, any architecture, and any language.

--- a/themes/default/content/blog/pulumiup-pulumi-packages-multi-language-components/index.md
+++ b/themes/default/content/blog/pulumiup-pulumi-packages-multi-language-components/index.md
@@ -6,8 +6,7 @@ meta_image: meta.png
 authors:
     - alex-mullans
 tags:
-    - pulumi-packages
-    - PulumiUP
+    - packages
 ---
 
 Pulumi Packages are the core technology that enables cloud infrastructure resource provisioning to be defined once, in your language of choice, and made available to users in all Pulumi languages. If you’ve used a Pulumi [cloud provider]({{< relref "/docs/intro/cloud-providers" >}}), including one of our new [Pulumi native providers]({{< relref "/blog/pulumiup-native-providers" >}}), you’ve used a Pulumi Package. But until today, Pulumi Packages only worked with Pulumi Resources: direct, low-level representations of individual cloud services like object storage. Many of us, however, enjoy creating Pulumi Components, which combine low-level resources into higher-level, more opinionated building blocks like the production-grade Kubernetes cluster component in [Pulumi EKS](https://github.com/pulumi/pulumi-eks/). Unfortunately, those components, though powerful and unique to Pulumi's IaC approach, were previously confined to a single language: so if your infrastructure team built a component in Python, your developers who might want to use TypeScript could not use it.

--- a/themes/default/content/blog/pulumiup/index.md
+++ b/themes/default/content/blog/pulumiup/index.md
@@ -7,7 +7,7 @@ authors:
     - wendy-smith
 tags:
     - cloud-engineering
-    - PulumiUP
+    - pulumi-events
 ---
 
 My professional background has included nearly ten years of managing field events and user conferences. I never thought I would say this, but I miss traveling. I even missed Vegas and AWS re:Invent this year. I miss connecting with customers and advocates in our communities. I wish we could all be looking forward to getting together in person in Seattle or Austin or _insert any city here_. As the year continued, it became clear we were not going back to in-person events anytime soon, and everyone in the industry pivoted to virtual programs while video conferencing became an all-day activity.

--- a/themes/default/content/blog/query-kubernetes/index.md
+++ b/themes/default/content/blog/query-kubernetes/index.md
@@ -1,7 +1,7 @@
 ---
 title: Introducing Pulumi Query for Kubernetes
 authors: ["alex-clemmer"]
-tags: ["Pulumi-News", "Kubernetes"]
+tags: ["Kubernetes"]
 meta_desc: "Announcing Pulumi Query for Kubernetes, an SDK for programmatically querying cloud resources."
 date: "2019-11-20"
 meta_image: "pulumi-crosswalk-k8s.png"

--- a/themes/default/content/blog/rabbitMQ-azure/index.md
+++ b/themes/default/content/blog/rabbitMQ-azure/index.md
@@ -6,10 +6,8 @@ meta_image: 1.png
 authors:
     - itay-podhajcer
 tags:
-    - RabbitMQ
     - Azure
     - .NET
-    - devops
 
 ---
 

--- a/themes/default/content/blog/rabbitMQ-azure/index.md
+++ b/themes/default/content/blog/rabbitMQ-azure/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - RabbitMQ
     - Azure
-    - .NET Core
+    - .NET
     - devops
 
 ---

--- a/themes/default/content/blog/reduce-cloud-costs-with-ARM/index.md
+++ b/themes/default/content/blog/reduce-cloud-costs-with-ARM/index.md
@@ -7,8 +7,6 @@ authors:
     - sophia-parafina
 tags:
     - AWS
-    - ARM
-    - EC2
 ---
 
 Whether you're migrating to the cloud or have existing infrastructure, cloud spend can be a significant barrier to your success. Too small of a budget could prevent your organization from meeting your performance metrics. You can use different strategies to reduce cloud spend, such as using [Spot Instances](https://aws.amazon.com/ec2/spot/), which cost less than On-Demand Instances or scaling your infrastructure based on peak usage times.

--- a/themes/default/content/blog/reflections-of-a-pulumi-intern/index.md
+++ b/themes/default/content/blog/reflections-of-a-pulumi-intern/index.md
@@ -3,7 +3,7 @@ title: "Reflections of a Pulumi Intern"
 meta_image: meta.png
 authors: ["albert-zhong"]
 meta_desc: "A reflection on my Pulumi intern experiences (summer 2020 edition)"
-tags: ["pulumi", "intern"]
+tags: ["pulumi-interns"]
 date: "2020-09-18"
 ---
 

--- a/themes/default/content/blog/reinvent-2020-eks-announcements/index.md
+++ b/themes/default/content/blog/reinvent-2020-eks-announcements/index.md
@@ -7,9 +7,8 @@ authors:
     - sophia-parafina
 tags:
     - kubernetes
-    - EKS
-    - events
-
+    - aws
+    - pulumi-events
 ---
 
 Amazon announced several Elastic Kubernetes Service feature releases and updates during the first week of AWS re:Invent 2020. If we look at all the announcements as a whole, we can see the Kubernetes ecosystem maturing to make deployments and management easier for organizations. Let's take a look at how they can benefit your use of EKS.

--- a/themes/default/content/blog/reinvent-2020-eks-announcements/index.md
+++ b/themes/default/content/blog/reinvent-2020-eks-announcements/index.md
@@ -8,7 +8,7 @@ authors:
 tags:
     - kubernetes
     - EKS
-    - re:Invent 2020
+    - events
 
 ---
 

--- a/themes/default/content/blog/resource-oriented-documentation-blog/index.md
+++ b/themes/default/content/blog/resource-oriented-documentation-blog/index.md
@@ -6,7 +6,7 @@ meta_image: docs.png
 authors:
     - luke-hoban
 tags:
-    - new-features
+    - features
 ---
 
 Documentation in any product is super important, and an area where folks have shared a lot of feedback! We've heard you, and this week we took a major step in rolling out a brand new approach to resource documentation.  We hope you like it as much as we do.

--- a/themes/default/content/blog/resource-oriented-documentation-blog/index.md
+++ b/themes/default/content/blog/resource-oriented-documentation-blog/index.md
@@ -6,7 +6,7 @@ meta_image: docs.png
 authors:
     - luke-hoban
 tags:
-    - documentation
+    - new-features
 ---
 
 Documentation in any product is super important, and an area where folks have shared a lot of feedback! We've heard you, and this week we took a major step in rolling out a brand new approach to resource documentation.  We hope you like it as much as we do.

--- a/themes/default/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
+++ b/themes/default/content/blog/reusable-cicd-components-with-circleci-orbs-for-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Reusable CI/CD components with CircleCI Orbs for Pulumi"
 authors: ["chris-smith"]
-tags: ["CI/CD"]
+tags: ["continuous-delivery"]
 date: "2018-11-07"
 meta_desc: "This blog post showcases Pulumi Orbs with CircleCI, using a simple job to build and update a JavaScript-based stack."
 meta_image: "circleci-ui.png"

--- a/themes/default/content/blog/rotating-secret-providers/index.md
+++ b/themes/default/content/blog/rotating-secret-providers/index.md
@@ -7,7 +7,7 @@ authors:
     - paul-stack
 
 tags:
-    - new-features
+    - features
     - Security
 ---
 

--- a/themes/default/content/blog/rotating-secret-providers/index.md
+++ b/themes/default/content/blog/rotating-secret-providers/index.md
@@ -7,7 +7,7 @@ authors:
     - paul-stack
 
 tags:
-    - Features
+    - new-features
     - Security
 ---
 

--- a/themes/default/content/blog/run-your-own-rss-server/index.md
+++ b/themes/default/content/blog/run-your-own-rss-server/index.md
@@ -7,7 +7,7 @@ meta_image: meta.png
 authors:
     - christian-nunciato
 tags:
-    - docker-containers
+    - containers
     - aws
 ---
 

--- a/themes/default/content/blog/run-your-own-rss-server/index.md
+++ b/themes/default/content/blog/run-your-own-rss-server/index.md
@@ -7,10 +7,8 @@ meta_image: meta.png
 authors:
     - christian-nunciato
 tags:
-    - containers
-    - database
+    - docker-containers
     - aws
-    - rss
 ---
 
 It's been a few years since [Google shut down Google Reader](https://googleblog.blogspot.com/2013/03/a-second-spring-of-cleaning.html), and while a number of nice commercial alternatives have sprung in its wake, none of them has ever been quite the right fit for me personally.

--- a/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
+++ b/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "ECS vs Fargate vs EKS: The Lowdown on Containers in AWS"
 authors: ["joe-duffy"]
-tags: ["AWS","docker-containers","Kubernetes"]
+tags: ["AWS","containers","Kubernetes"]
 date: "2019-06-20"
 meta_desc: "Use Pulumi's infrastucture-as-code approach to simplify working with ECS Fargate, ECS with EC2 instances, and EKS."
 meta_image: "pulumi-crosswalk-for-aws.png"

--- a/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
+++ b/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "ECS vs Fargate vs EKS: The Lowdown on Containers in AWS"
 authors: ["joe-duffy"]
-tags: ["AWS","Containers","Kubernetes","EKS"]
+tags: ["AWS","docker-containers","Kubernetes"]
 date: "2019-06-20"
 meta_desc: "Use Pulumi's infrastucture-as-code approach to simplify working with ECS Fargate, ECS with EC2 instances, and EKS."
 meta_image: "pulumi-crosswalk-for-aws.png"

--- a/themes/default/content/blog/scheduling-serverless/index.md
+++ b/themes/default/content/blog/scheduling-serverless/index.md
@@ -7,7 +7,6 @@ authors:
     - cyrus-najmabadi
 tags:
     - serverless
-    - lambda
 ---
 
 Scheduling events has long been an essential part of automation; many tasks need to run at specific times or intervals. You could be checking StackOverflow for new questions every 20 minutes or compiling a report that is emailed every other Friday at 4:00 pm. Today, many of these tasks can be efficiently accomplished in the cloud. While each cloud has its flavor of scheduled functions, this post steps you through an example using [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) with the help of Pulumi.

--- a/themes/default/content/blog/series-b/index.md
+++ b/themes/default/content/blog/series-b/index.md
@@ -2,7 +2,7 @@
 title: "Pulumi raises Series B to build the future of Cloud Engineering"
 allow_long_title: True
 authors: ["joe-duffy"]
-tags: ["Pulumi-News"]
+tags: ["pulumi-news"]
 meta_desc: "Today I'm thrilled to announce that we've raised $37.5 million in a new Series B led by NEA to bring Cloud Engineering to the market."
 date: "2020-10-27"
 meta_image: "series-b.png"

--- a/themes/default/content/blog/serving-a-static-website-on-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/serving-a-static-website-on-aws-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Serving a Static Website on AWS with Pulumi"
 authors: ["chris-smith"]
-tags: ["AWS","Infrastructure","TypeScript"]
+tags: ["AWS","TypeScript"]
 date: "2018-07-17"
 meta_desc: "With around 200 lines of code, learn how Pulumi integrates four different AWS products  to host a static website served over HTTPS and from a worldwide CDN."
 

--- a/themes/default/content/blog/simple-reproducible-kubernetes-deployments/index.md
+++ b/themes/default/content/blog/simple-reproducible-kubernetes-deployments/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Simple, Reproducible Kubernetes Deployments"
 authors: ["alex-clemmer"]
-tags: ["Infrastructure","Kubernetes","TypeScript"]
+tags: ["Kubernetes","TypeScript"]
 date: "2018-08-24"
 meta_desc: "Pulumi is an open-source infrastructure as code platform that lets you express Kubernetes programs in familiar programming languages, instead of YAML templates."
 meta_image: "diff.gif"

--- a/themes/default/content/blog/simple-serverless-programming-with-google-cloud-functions-and-pulumi/index.md
+++ b/themes/default/content/blog/simple-serverless-programming-with-google-cloud-functions-and-pulumi/index.md
@@ -2,7 +2,7 @@
 title: Simple Serverless programming with Google Cloud Functions
 h1: "Simple Serverless programming with Google Cloud Functions and Pulumi"
 authors: ["cyrus-najmabadi"]
-tags: ["Serverless","GCP"]
+tags: ["Serverless",google-cloud]
 date: "2019-04-10"
 meta_desc: "Pulumi lets you create, deploy, and manage Google Cloud applications and infrastructure in familiar languages without needing DSLs or YAML templating solutions."
 

--- a/themes/default/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
+++ b/themes/default/content/blog/simplified-outputs-in-pulumi-0.17.0/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Simplified Outputs in Pulumi 0.17"
 authors: ["cyrus-najmabadi"]
-tags: ["New-Features"]
+tags: ["features"]
 date: "2019-03-19"
 meta_desc: "Based on feedback from cloud developers, Pulumi Outputs have been simplified for JavaScript and TypeScript simplifying the user experience."
 meta_image: "comp-list.png"

--- a/themes/default/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
+++ b/themes/default/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
@@ -2,7 +2,7 @@
 title: "Kubernetes RBAC in AWS EKS with open source Pulumi packages"
 h1: "Simplify Kubernetes RBAC in Amazon EKS with open source Pulumi packages"
 authors: ["nishi-davidson"]
-tags: ["AWS","Kubernetes","TypeScript","EKS"]
+tags: ["AWS","Kubernetes","TypeScript"]
 date: "2019-04-24"
 meta_desc: "This post contrasts the traditional approach with Pulumi's modern method for simplifying Kubernetes RBAC in Amazon EKS."
 ---

--- a/themes/default/content/blog/supporting-kubernetes-with-pulumi/index.md
+++ b/themes/default/content/blog/supporting-kubernetes-with-pulumi/index.md
@@ -7,7 +7,6 @@ authors:
     - scott-lowe
 tags:
     - Kubernetes
-    - ClusterAPI
 ---
 
 Scott Lowe is a 20+ year veteran of the IT industry and a Staff Kubernetes Architect at VMWare. He’s a prolific author (seven books) and [blogger](https://blog.scottlowe.org). His technology-focused blog covers a range of topics that include cloud computing (AWS, Azure, and Kubernetes), virtualization (KVM, VMware vSphere), open-source tools (Terraform, Ansible, Vagrant, and others), and networking (Open vSwitch, Linux networking).

--- a/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
+++ b/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
@@ -4,7 +4,7 @@ date: 2020-09-18
 meta_desc: Demonstrating the simplicity, modularity, and reusability of running an application on Kubernetes using Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker-containers", "kubernetes"]
+tags: ["aws", "typescript", "containers", "kubernetes"]
 ---
 
 In this blog post, we return to the PERN application we previously [migrated to Kubernetes]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) and replace the PostgreSQL database with MongoDB. Although it might seem like a difficult task initially, the straightforward design of Pulumi and Kubernetes allows us to easily transition the application form a PERN stack to a MERN one.

--- a/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
+++ b/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
@@ -4,7 +4,7 @@ date: 2020-09-18
 meta_desc: Demonstrating the simplicity, modularity, and reusability of running an application on Kubernetes using Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "docker", "kubernetes"]
+tags: ["aws", "typescript", "docker-containers", "kubernetes"]
 ---
 
 In this blog post, we return to the PERN application we previously [migrated to Kubernetes]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) and replace the PostgreSQL database with MongoDB. Although it might seem like a difficult task initially, the straightforward design of Pulumi and Kubernetes allows us to easily transition the application form a PERN stack to a MERN one.

--- a/themes/default/content/blog/ten-pearls-with-azure-functions-in-pulumi/index.md
+++ b/themes/default/content/blog/ten-pearls-with-azure-functions-in-pulumi/index.md
@@ -53,7 +53,7 @@ Many Function Apps are .NET applications created with native tooling like Visual
 const dotnetApp = new azure.appservice.ArchiveFunctionApp("http-dotnet", {
    resourceGroupName: resourceGroup.name,
    archive: new pulumi.asset.FileArchive("./app/bin/Debug/netcoreapp2.1/publish"),
-   appSettings: { runtime: "dotnet" },
+   appSettings: { runtime: ".NET" },
 });
 ```
 

--- a/themes/default/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/themes/default/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Testing Your Infrastructure as Code with Pulumi"
 authors: ["joe-duffy"]
-tags: ["JavaScript","TypeScript","CI/CD","Cloud-Native","Python"]
+tags: ["JavaScript","TypeScript","continuous-delivery","Cloud-Native","Python"]
 date: "2019-04-17"
 meta_desc: "Leverage Pulumi for your core acceptance test workflow and unlock new automation capabilities that improve your team's productivity and confidence."
 meta_image: "InfraTesting.png"

--- a/themes/default/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
+++ b/themes/default/content/blog/testing-your-infrastructure-as-code-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Testing Your Infrastructure as Code with Pulumi"
 authors: ["joe-duffy"]
-tags: ["JavaScript","TypeScript","continuous-delivery","Cloud-Native","Python"]
+tags: ["JavaScript","TypeScript","continuous-delivery","Python"]
 date: "2019-04-17"
 meta_desc: "Leverage Pulumi for your core acceptance test workflow and unlock new automation capabilities that improve your team's productivity and confidence."
 meta_image: "InfraTesting.png"

--- a/themes/default/content/blog/the-pulumi-intern-experience/index.md
+++ b/themes/default/content/blog/the-pulumi-intern-experience/index.md
@@ -4,7 +4,7 @@ date: "2020-09-16"
 meta_desc: "A glimpse into my work and experiences at Pulumi as a summer intern"
 meta_image: intern.png
 authors: ["sashu-shankar"]
-tags: ["pulumi", "intern"]
+tags: ["pulumi-interns"]
 ---
 
 What is the cloud? Three months ago, that one word simply meant a bunch of water suspended in the atmosphere, but now it means more than that.

--- a/themes/default/content/blog/unified-logs-with-pulumi-logs/index.md
+++ b/themes/default/content/blog/unified-logs-with-pulumi-logs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unified Logs with pulumi logs"
 authors: ["luke-hoban"]
-tags: ["AWS","new-features","Logging"]
+tags: ["AWS","features","Logging"]
 date: "2019-04-02"
 meta_desc: "The Pulumi CLI provides a seamless way to do logging for your applications without requiring the additional setup of cloud and third party logging solutions."
 meta_image: "terminal-logs.png"

--- a/themes/default/content/blog/unified-logs-with-pulumi-logs/index.md
+++ b/themes/default/content/blog/unified-logs-with-pulumi-logs/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unified Logs with pulumi logs"
 authors: ["luke-hoban"]
-tags: ["AWS","Features","Logging"]
+tags: ["AWS","new-features","Logging"]
 date: "2019-04-02"
 meta_desc: "The Pulumi CLI provides a seamless way to do logging for your applications without requiring the additional setup of cloud and third party logging solutions."
 meta_image: "terminal-logs.png"

--- a/themes/default/content/blog/unit-test-infrastructure/index.md
+++ b/themes/default/content/blog/unit-test-infrastructure/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - testing
-    - test driven development
+    - testing
 ---
 
 We’re pleased to announce that unit testing with Node.js, Python, .NET, and Go is supported in recent releases. You can test resources before deploying your infrastructure using familiar tools and test frameworks. Check your resource configuration and responses without the wait of deploying them and speed up infrastructure development and production deployments.

--- a/themes/default/content/blog/unit-testing-assets/index.md
+++ b/themes/default/content/blog/unit-testing-assets/index.md
@@ -8,7 +8,6 @@ authors:
     - lee-zen
 tags:
     - Testing
-    - Infrastructure
 ---
 
 When deploying infrastructure, we want to ensure that what we're deploying matches our expectations.

--- a/themes/default/content/blog/unit-testing-cloud-deployments-with-dotnet/index.md
+++ b/themes/default/content/blog/unit-testing-cloud-deployments-with-dotnet/index.md
@@ -7,7 +7,7 @@ authors:
     - mikhail-shilkov
 tags:
     - testing
-    - dotnet
+    - .NET
 ---
 
 Because Pulumi uses general-purpose programming languages to provision cloud resources, you can take advantage of native tools and perform automated tests of your infrastructure. The full power of each language is available, including access to libraries and frameworks for testing.

--- a/themes/default/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
+++ b/themes/default/content/blog/unit-testing-infrastructure-in-nodejs-and-mocha/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unit Testing Your Infrastructure with Node.js and Mocha"
 authors: ["joe-duffy"]
-tags: ["Testing","Infrastructure"]
+tags: ["Testing"]
 date: "2019-07-13"
 meta_desc: "This post shows how to use Node.js, the Mocha test framework, and the Chai assertion library to embed tests alongside your infrastructure-as-code definitions."
 meta_image: "meta.png"

--- a/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
+++ b/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unlocking Spinnaker With Pulumi"
 authors: ["praneet-loke"]
-tags: ["continuous-delivery","Cloud-Native"]
+tags: ["continuous-delivery"]
 date: "2020-06-18"
 meta_desc: "We are excited to announce the launch of free, open-source Pulumi plugin for Spinnaker."
 meta_image: pulumi-spinnaker.png

--- a/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
+++ b/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unlocking Spinnaker With Pulumi"
 authors: ["praneet-loke"]
-tags: ["Spinnaker","CI/CD","Cloud-Native"]
+tags: ["Spinnaker","continuous-delivery","Cloud-Native"]
 date: "2020-06-18"
 meta_desc: "We are excited to announce the launch of free, open-source Pulumi plugin for Spinnaker."
 meta_image: pulumi-spinnaker.png

--- a/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
+++ b/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unlocking Spinnaker With Pulumi"
 authors: ["praneet-loke"]
-tags: ["Spinnaker","continuous-delivery","Cloud-Native"]
+tags: ["continuous-delivery","Cloud-Native"]
 date: "2020-06-18"
 meta_desc: "We are excited to announce the launch of free, open-source Pulumi plugin for Spinnaker."
 meta_image: pulumi-spinnaker.png

--- a/themes/default/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
+++ b/themes/default/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Upcoming AWS + Pulumi Webinar on Feb 5"
 authors: ["erin-xue"]
-tags: ["AWS","CI/CD","Cloud-Native"]
+tags: ["AWS","continuous-delivery","Cloud-Native"]
 date: "2019-01-09"
 meta_desc: "In February, Pulumi & Learning Machine hosted a webinar with AWS Fargate which covered how to implement cloud native infrastructure across using AWS."
 meta_image: code-comparison.png

--- a/themes/default/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
+++ b/themes/default/content/blog/upcoming-aws-pulumi-webinar-on-feb-5/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Upcoming AWS + Pulumi Webinar on Feb 5"
 authors: ["erin-xue"]
-tags: ["AWS","continuous-delivery","Cloud-Native"]
+tags: ["AWS","continuous-delivery"]
 date: "2019-01-09"
 meta_desc: "In February, Pulumi & Learning Machine hosted a webinar with AWS Fargate which covered how to implement cloud native infrastructure across using AWS."
 meta_image: code-comparison.png

--- a/themes/default/content/blog/upcoming-events-2021-jan-march/index.md
+++ b/themes/default/content/blog/upcoming-events-2021-jan-march/index.md
@@ -6,7 +6,7 @@ meta_image: events.png
 authors:
     - sophia-parafina
 tags:
-    - workshops
+    - events
     - introductio to Pulumi
     - Kubernetes
     - serverless

--- a/themes/default/content/blog/upcoming-events-2021-jan-march/index.md
+++ b/themes/default/content/blog/upcoming-events-2021-jan-march/index.md
@@ -6,8 +6,7 @@ meta_image: events.png
 authors:
     - sophia-parafina
 tags:
-    - events
-    - introductio to Pulumi
+    - pulumi-events
     - Kubernetes
     - serverless
 ---

--- a/themes/default/content/blog/using-terraform-remote-state-with-pulumi/index.md
+++ b/themes/default/content/blog/using-terraform-remote-state-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using Terraform Remote State with Pulumi"
 authors: ["paul-stack"]
-tags: ["Infrastructure","Features"]
+tags: ["new-features"]
 date: "2019-06-07"
 meta_desc: "Pulumi allows resources which were provisioned by CloudFormation, ARM, or Terraform to remain, while allowing those resources to be consumed by Pulumi."
 

--- a/themes/default/content/blog/using-terraform-remote-state-with-pulumi/index.md
+++ b/themes/default/content/blog/using-terraform-remote-state-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Using Terraform Remote State with Pulumi"
 authors: ["paul-stack"]
-tags: ["new-features"]
+tags: ["features"]
 date: "2019-06-07"
 meta_desc: "Pulumi allows resources which were provisioned by CloudFormation, ARM, or Terraform to remain, while allowing those resources to be consumed by Pulumi."
 

--- a/themes/default/content/blog/vscode-devcontainers/index.md
+++ b/themes/default/content/blog/vscode-devcontainers/index.md
@@ -6,9 +6,8 @@ meta_image: devcontainer.png
 authors:
     - sophia-parafina
 tags:
-    - "VS Code"
-    - "devcontainers"
-    - Docker
+    - development-environment
+    - docker-containers
 ---
 
 One of the major advantages of using containers for development is reducing the need to install software and associated dependencies. Developers can start writing code without configuring a development environment that emulates production. The Visual Studio Code Remote - Containers extension lets you develop inside a container. If you want to use Pulumi’s infrastructure as code engine without installing the Pulumi CLI, this blog post is for you!

--- a/themes/default/content/blog/vscode-devcontainers/index.md
+++ b/themes/default/content/blog/vscode-devcontainers/index.md
@@ -7,7 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - development-environment
-    - docker-containers
+    - containers
 ---
 
 One of the major advantages of using containers for development is reducing the need to install software and associated dependencies. Developers can start writing code without configuring a development environment that emulates production. The Visual Studio Code Remote - Containers extension lets you develop inside a container. If you want to use Pulumi’s infrastructure as code engine without installing the Pulumi CLI, this blog post is for you!

--- a/themes/default/content/blog/welcoming-gitlab-users-to-pulumi/index.md
+++ b/themes/default/content/blog/welcoming-gitlab-users-to-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Welcoming GitLab users to Pulumi"
 authors: ["praneet-loke"]
-tags: ["CI/CD"]
+tags: ["continuous-delivery"]
 date: "2018-12-03"
 meta_desc: "Pulumi supports signing in with your GitLab! Invite GitLab group members, integrate with your CI pipeline, and link your projects, branches, and commits."
 meta_image: "gl-2.gif"

--- a/themes/default/content/blog/zephyrs-summer-intern-experience-with-pulumi/index.md
+++ b/themes/default/content/blog/zephyrs-summer-intern-experience-with-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2020-09-18"
 meta_desc: "Zephyr's internship experience in Summer 2020, personal growth, skills learned and reflection"
 meta_image: zephyr-pulumi.png
 authors: ["zephyr-zhou"]
-tags: ["pulumi","intern"]
+tags: ["pulumi-interns"]
 ---
 
 Hi, I am [Zephyr Zhou](https://www.linkedin.com/in/zephyr-zhou-a17741196/), a senior Computer Science student at the University of Washington. I spent this past summer interning at Pulumi. This is my first internship ever in my life. Thanks to Pulumi for providing this opportunity even in this difficult time of the Covid-19 epidemic. Despite the sad truth that I couldn't get in touch offline, I believe this will be one of my most precious memories.

--- a/themes/default/content/docs/intro/languages/_index.md
+++ b/themes/default/content/docs/intro/languages/_index.md
@@ -20,7 +20,7 @@ The following language runtimes are currently supported by Pulumi:
 
 * [Node.js]({{< relref "javascript" >}}) - JavaScript, TypeScript, or any other Node.js compatible language
 * [Python]({{< relref "python" >}}) - Python 3.6 or greater
-* [.NET Core]({{< relref "dotnet" >}}) - C#, F#, and Visual Basic on .NET Core 3.1 or greater
+* [.NET Core]({{< relref ".NET" >}}) - C#, F#, and Visual Basic on .NET Core 3.1 or greater
 * [Go]({{< relref "go" >}}) - statically compiled Go binaries
 
 If your favorite language isn't listed, it may be on its way soon. Pulumi is [open

--- a/themes/default/content/migrate/kube2pulumi.md
+++ b/themes/default/content/migrate/kube2pulumi.md
@@ -87,7 +87,7 @@ examples:
               - services/finalizers
               - endpoints
               - persistentvolumeclaims
-              - pulumi-events
+              - events
               - configmaps
               - secrets
             verbs:

--- a/themes/default/content/migrate/kube2pulumi.md
+++ b/themes/default/content/migrate/kube2pulumi.md
@@ -87,7 +87,7 @@ examples:
               - services/finalizers
               - endpoints
               - persistentvolumeclaims
-              - events
+              - pulumi-events
               - configmaps
               - secrets
             verbs:


### PR DESCRIPTION
Fixes pulumi/docs#2532

Cleans up our tags to a smaller, easier-to-use set. I optimized for:

- Removing individual technologies/providers _unless_ we have substantial content for that technology (e.g. Kubernetes)
- Removing references to individual cloud resources
- Removing "obvious" tags like `pulumi` and `infrastructure`
- Removing customer names (and consolidating around the `guest-post` tag for guest posts)

I'd love feedback. Did I cut a tag you found useful? Are there even more tags we should cut?

![image](https://user-images.githubusercontent.com/483400/117880787-5902f200-b25d-11eb-89f1-34d09c1fedae.png)
