### PR TITLE
Fix header button

### DIFF
--- a/themes/default/assets/sass/_header.scss
+++ b/themes/default/assets/sass/_header.scss
@@ -73,7 +73,7 @@
         }
 
         .header-btn-primary {
-            @extend .btn-primary;
+            @include gradient-button;
             @apply py-3 px-6;
 
             @screen xl {


### PR DESCRIPTION
This was my oversight, actually. 😢 It should be correct, but because the `btn-primary` class I intended to extend is [contained in a block that excludes everything that isn't a marketing page](https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/assets/sass/_marketing.scss#L7), it had no effect. This should fix it up.

fixes #220 