### PR TITLE
add secret decrypted to audit log event list

### DIFF
--- a/themes/default/content/docs/intro/console/auditing.md
+++ b/themes/default/content/docs/intro/console/auditing.md
@@ -172,7 +172,7 @@ This is a list of the audit log events currently being recorded.
 | Policy Pack Deleted                      | indicates the deletion of a policy pack                                                                              |
 | Policy Pack Disabled                     | indicates the disabling of a policy pack                                                                             |
 | Policy Pack Enabled                      | indicates the enabling of a policy pack                                                                              |
-| Secret Decrypted                         | indicates the decryption of a secret value associated with the specified stack                                                                  |
+| Secret Decrypted                         | indicates the decryption of a secret value associated with a stack                                                                  |
 | Stack Collaborator Added                 | indicates the adding of a collaborator to a stack                                                               |
 | Stack Collaborator Permissions Changed   | indicates a change in permissions for a stack collaborator                                         |
 | Stack Collaborator Removed               | indicates the removal of a collaborator to a stack                                                            |

--- a/themes/default/content/docs/intro/console/auditing.md
+++ b/themes/default/content/docs/intro/console/auditing.md
@@ -172,6 +172,7 @@ This is a list of the audit log events currently being recorded.
 | Policy Pack Deleted                      | indicates the deletion of a policy pack                                                                              |
 | Policy Pack Disabled                     | indicates the disabling of a policy pack                                                                             |
 | Policy Pack Enabled                      | indicates the enabling of a policy pack                                                                              |
+| Secret Decrypted                         | indicates the decryption of a secret value associated with the specified stack                                                                  |
 | Stack Collaborator Added                 | indicates the adding of a collaborator to a stack                                                               |
 | Stack Collaborator Permissions Changed   | indicates a change in permissions for a stack collaborator                                         |
 | Stack Collaborator Removed               | indicates the removal of a collaborator to a stack                                                            |


### PR DESCRIPTION
Update audit log event list to include secret decrypted event.

link to page from preview below: http://pulumi-hugo-origin-pr-229-3882ffbd.s3-website.us-west-2.amazonaws.com/docs/intro/console/auditing/

fixes #230 