### PR TITLE
change resource docs from 3-col to 2-col layout

### DIFF
--- a/themes/default/assets/sass/_api-nodejs.scss
+++ b/themes/default/assets/sass/_api-nodejs.scss
@@ -36,15 +36,18 @@ h3.api {
 ul.api {
     @apply list-none p-0 m-0 overflow-hidden;
 
-    columns: 2 330px;
+    columns: 1;
+
+    @screen xl {
+        columns: 2;
+    }
 
     li {
         @apply truncate mt-0;
 
         a {
-            @apply btn truncate bg-transparent inline-block p-1;
+            @apply btn truncate bg-transparent inline-block p-1 max-w-full;
 
-            max-width: 330px;
         }
 
         .symbol {

--- a/themes/default/assets/sass/_api-nodejs.scss
+++ b/themes/default/assets/sass/_api-nodejs.scss
@@ -36,7 +36,7 @@ h3.api {
 ul.api {
     @apply list-none p-0 m-0 overflow-hidden;
 
-    columns: 3 220px;
+    columns: 2 330px;
 
     li {
         @apply truncate mt-0;
@@ -44,7 +44,7 @@ ul.api {
         a {
             @apply btn truncate bg-transparent inline-block p-1;
 
-            max-width: 250px;
+            max-width: 330px;
         }
 
         .symbol {


### PR DESCRIPTION
## overview

changing the docs to present data in a 2-col layout instead of 3-col layout which should make the content a bit easier for folks to consume

part of #234

you wont be able to use the link to view the pages, but I've included a few screenshots

## screenshots
### before
![3-col](https://user-images.githubusercontent.com/5489125/118298587-7e2d7580-b494-11eb-9da7-17dd0f9989de.png)

### after
![2-col](https://user-images.githubusercontent.com/5489125/118298591-7f5ea280-b494-11eb-851b-316dbf8241bd.png)

