### PR TITLE
remove cloud buttons from docs landing page

### DIFF
--- a/themes/default/content/docs/_index.md
+++ b/themes/default/content/docs/_index.md
@@ -18,23 +18,6 @@ Pulumi is an <a href="https://github.com/pulumi/pulumi" target="_blank">open sou
     <a class="btn btn-lg mx-1 my-1" href="{{< relref "/docs/get-started" >}}">Get Started</a>
 </div>
 
-<div class="bg-gray-100 rounded max-w-6xl my-4 px-4 py-2">
-    <div class="md:flex justify-between items-center">
-        <a class="block rounded hover:bg-gray-200 transition-all my-2 py-4 text-center px-6" href="{{< relref "/docs/get-started/aws" >}}">
-            <img class="inline-block h-8 w-auto -mb-2" src="/logos/tech/aws.svg">
-        </a>
-        <a class="block rounded hover:bg-gray-200 transition-all my-2 text-center md:mx-2 py-4 px-6" href="{{< relref "/docs/get-started/azure" >}}">
-            <img class="inline-block h-8 w-auto" src="/logos/tech/azure.svg">
-        </a>
-        <a class="block rounded hover:bg-gray-200 transition-all my-2 text-center md:mx-2 py-4 px-6" href="{{< relref "/docs/get-started/gcp" >}}">
-            <img class="inline-block h-8 w-auto" src="/logos/tech/gcp.svg">
-        </a>
-        <a class="block rounded hover:bg-gray-200 transition-all my-2 py-4 text-center px-6" href="{{< relref "/docs/get-started/kubernetes" >}}">
-            <img class="inline-block h-8 w-auto" src="/logos/tech/k8s.svg">
-        </a>
-    </div>
-</div>
-
 <div class="my-4 md:flex py-8">
     <div class="md:w-1/3">
         <h3 class="no-anchor">Why Pulumi?</h3>


### PR DESCRIPTION
## overview

in https://github.com/pulumi/pulumi-hugo/pull/190#issuecomment-833925032 it was mentioned that we should remove the "cloud buttons" from the docs landing page, this pr does that.

## screenshots
### before
![docs-landing-before](https://user-images.githubusercontent.com/5489125/118520943-5c7bfa80-b6ef-11eb-8171-80e49733791e.png)

### after
![docs-landing-after](https://user-images.githubusercontent.com/5489125/118520932-58e87380-b6ef-11eb-8120-3f6f082b64df.png)
