### PR TITLE
Specify we should use the project ID with GCP

### DIFF
--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -1,10 +1,10 @@
 When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install)
 and then [authorize access access with a user account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). 
 
-If `gcloud` is not configured to interact with your Google Cloud project, set it through the `config` command.
+If `gcloud` is not configured to interact with your Google Cloud project, set it with the `config` command using the project's ID:
 
 ```bash
-gcloud config set project <YOUR_GCP_PROJECT_HERE>
+gcloud config set project <YOUR_GCP_PROJECT_ID>
 ```
 
 Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials.


### PR DESCRIPTION
This just specifies the GCP project field to use when configuring `gcloud`.