### PR TITLE
Disambiguate the kind of project you'll create

### DIFF
--- a/themes/default/content/docs/get-started/aws/begin.md
+++ b/themes/default/content/docs/get-started/aws/begin.md
@@ -95,6 +95,6 @@ $ export AWS_SECRET_ACCESS_KEY=<YOUR_SECRET_ACCESS_KEY>
 
 For additional information on setting and using AWS credentials, see [AWS Setup]({{< relref "/docs/intro/cloud-providers/aws/setup" >}}).
 
-Next, you'll create a new project.
+Next, you'll create a new Pulumi project.
 
 {{< get-started-stepper >}}

--- a/themes/default/content/docs/get-started/azure/begin.md
+++ b/themes/default/content/docs/get-started/azure/begin.md
@@ -80,6 +80,6 @@ The Azure CLI, and thus Pulumi, will use the default subscription for the accoun
 
 For additional information on authenticating with Azure, or to login with a service principal, see [Azure Setup]({{< relref "/docs/intro/cloud-providers/azure/setup" >}}).
 
-Next, you'll create a new project.
+Next, you'll create a new Pulumi project.
 
 {{< get-started-stepper >}}

--- a/themes/default/content/docs/get-started/gcp/begin.md
+++ b/themes/default/content/docs/get-started/gcp/begin.md
@@ -66,6 +66,6 @@ In this guide, you will need an IAM user account with permissions that can creat
 
 For additional information on setting and using Google Cloud credentials, see [Google Cloud Setup]({{< relref "/docs/intro/cloud-providers/gcp/setup" >}}).
 
-Next, you'll create a new project.
+Next, you'll create a new Pulumi project.
 
 {{< get-started-stepper >}}

--- a/themes/default/content/docs/get-started/kubernetes/begin.md
+++ b/themes/default/content/docs/get-started/kubernetes/begin.md
@@ -60,6 +60,6 @@ Next, we'll configure Kubernetes.
 
 <a href="{{< relref "/docs/intro/cloud-providers/kubernetes/setup" >}}" target="_blank">Configure Kubernetes</a> so the Pulumi CLI can connect to a Kubernetes cluster. If you have previously configured the <a href="https://kubernetes.io/docs/reference/kubectl/overview/" target="_blank">kubectl CLI</a>, `kubectl`, Pulumi will respect and use your configuration settings.
 
-Next, we'll create a new project.
+Next, we'll create a new Pulumi project.
 
 {{< get-started-stepper >}}


### PR DESCRIPTION
In the GCP guide in particular, it's slightly strange that we say "you'll create a new project" after just having created a Google Cloud project. This just adds the word Pulumi to each of these steps for clarity.

This came out of the usability exercise we did yesterday, btw. 