### PR TITLE
Put output declarations on separate lines

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -271,8 +271,11 @@ this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
 ```
 
 ```csharp
-[Output] public Output<string> BucketName { get; set; }
-[Output] public Output<string> BucketEndpoint { get; set; }
+[Output]
+public Output<string> BucketName { get; set; }
+
+[Output]
+public Output<string> BucketEndpoint { get; set; }
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/gcp/deploy-changes.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-changes.md
@@ -339,7 +339,8 @@ this.BucketEndpoint = Output.Format($"http://storage.googleapis.com/{bucket.Name
 ```
 
 ```csharp
-[Output] public Output<string> BucketEndpoint { get; set; }
+[Output]
+public Output<string> BucketEndpoint { get; set; }
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Our `csharp` templates [give these attributes lines of their own](https://github.com/pulumi/templates/blob/master/gcp-csharp/MyStack.cs#L15-L16), and this seems to be the convention as well. This just adjusts our guide pages to be consistent.