### PR TITLE
Fix headings on legal pages

### DIFF
--- a/themes/default/assets/sass/_marketing.scss
+++ b/themes/default/assets/sass/_marketing.scss
@@ -4,7 +4,7 @@
     }
 }
 
-body:not(.section-docs):not(.section-blog):not(.section-authors):not(.section-tags) {
+body:not(.section-docs):not(.section-blog):not(.section-authors):not(.section-tags):not(.section-legal) {
     overflow-x: hidden;
 
     h1 {


### PR DESCRIPTION
They're currently following the styling of marketing pages, which makes their headings look hugs. This should fix 'em up. 