### PR TITLE
Adjust docs & blog layout for tablets

### DIFF
--- a/themes/default/layouts/blog/list.html
+++ b/themes/default/layouts/blog/list.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 pb-8 mt-8">
-        <div class="md:flex">
+        <div class="lg:flex">
 
-            <div class="md:w-3/12 pr-8">
+            <div class="lg:w-3/12 pr-8">
                 {{ partial "blog/sidebar.html" . }}
             </div>
 
-            <div class="md:w-7/12">
+            <div class="lg:w-7/12">
                 {{ $paginator := .Paginate (where .Pages "Type" "blog").ByDate.Reverse }}
                 {{ range $paginator.Pages }}
                     <article class="mb-8 pb-8 border-b border-gray-200">
@@ -30,7 +30,7 @@
                 {{ partial "blog/paginator.html" . }}
             </div>
 
-            <div class="md:w-2/12 pl-8">
+            <div class="lg:w-2/12 pl-8">
 
             </div>
         </div>

--- a/themes/default/layouts/blog/single.html
+++ b/themes/default/layouts/blog/single.html
@@ -1,11 +1,11 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 py-8">
-        <div class="md:flex">
-            <div class="md:w-3/12 pr-8">
+        <div class="lg:flex">
+            <div class="lg:w-3/12 pr-8">
                 {{ partial "blog/sidebar.html" . }}
             </div>
 
-            <div class="md:w-7/12">
+            <div class="lg:w-7/12">
                 <article class="mb-8 pb-8 border-b border-gray-200">
 
                     {{ if and (.Params.h1) (not .Params.notitle) }}
@@ -39,7 +39,7 @@
                 </article>
             </div>
 
-            <div class="md:w-3/12 md:pl-8">
+            <div class="lg:w-3/12 lg:pl-8">
                 <div class="sticky-sidebar">
                     {{ partial "blog/right-nav.html" . }}
                     {{ partial "right-nav-ad.html" }}

--- a/themes/default/layouts/docs/list.html
+++ b/themes/default/layouts/docs/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 py-8 mt-2">
-        <div class="md:flex">
+        <div class="lg:flex">
 
-            <div class="md:w-6/12 md:px-4">
+            <div class="lg:w-6/12 lg:px-4">
                 {{ partial "docs/breadcrumb.html" . }}
 
                 {{ if and (.Params.h1) (not .Params.notitle) }}
@@ -14,9 +14,9 @@
                 {{ .Content }}
             </div>
 
-            <div class="md:w-3/12 md:pl-8">
+            <div class="lg:w-3/12 lg:pl-8">
                 <div class="sticky-sidebar">
-                    <div class="ml-2 hidden md:block">
+                    <div class="ml-2 hidden lg:block">
                         {{ partial "docs/right-nav.html" . }}
                     </div>
 
@@ -28,9 +28,9 @@
                 </div>
             </div>
 
-            <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
+            <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
                 <div class="sticky-sidebar">
-                    <div class="md:mt-1 mb-6">
+                    <div class="lg:mt-1 mb-6">
                         {{ partial "docs/search.html" . }}
                     </div>
                     <div>

--- a/themes/default/layouts/docs/single.html
+++ b/themes/default/layouts/docs/single.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 lg:px-0 py-8 mt-2">
-        <div class="md:flex">
+        <div class="lg:flex">
 
-            <div class="md:w-6/12">
+            <div class="lg:w-6/12">
                 {{ partial "docs/breadcrumb.html" . }}
 
                 {{ if and (.Params.h1) (not .Params.notitle) }}
@@ -15,9 +15,9 @@
                 </section>
             </div>
 
-            <div class="md:w-3/12 md:pl-8 mt-2">
+            <div class="lg:w-3/12 lg:pl-8 mt-2">
                 <div class="sticky-sidebar">
-                    <div class="ml-2 hidden md:block">
+                    <div class="ml-2 hidden lg:block">
                         {{ partial "docs/right-nav.html" . }}
                     </div>
                     <div>
@@ -28,8 +28,8 @@
                 </div>
             </div>
 
-            <div class="md:w-3/12 pr-8 mb-2 pt-8 md:order-first md:border-none md:pt-0 md:mt-0">
-                <div class="mt-10 pt-8 border-t-2 border-gray-400 md:border-none md:block md:mb-4 md:pt-0 md:mt-0">
+            <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
+                <div class="mt-10 pt-8 border-t-2 border-gray-400 lg:border-none lg:block lg:mb-4 lg:pt-0 lg:mt-0">
                     {{ partial "docs/search.html" . }}
                 </div>
                 <div class="sticky-sidebar">

--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -1,10 +1,10 @@
 <!--
     Blog sidebar, showing a list of tags, and a quick intro for context.
 -->
-<aside class="md:pr-8">
+<aside class="lg:pr-8">
 
     <!-- Sidebar menu toggle for mobile. -->
-    <div class="md:hidden">
+    <div class="lg:hidden">
         <button class="blog-sidebar-toggle items-center px-3 py-2 border rounded text-purple border-purple">
             <i class="fas fa-bars"></i>
         </button>
@@ -12,11 +12,11 @@
     </div>
 
     {{ if eq .Page.Title "Blog" }}
-        <h1 class="no-anchor hidden md:flex mt-2">
+        <h1 class="no-anchor hidden lg:flex mt-2">
             <a data-track="sidebar" class="text-2xl" href="{{ relref . "/blog" }}">Pulumi Blog</a>
         </h1>
     {{ else }}
-        <h2 class="no-anchor hidden md:flex mt-2">
+        <h2 class="no-anchor hidden lg:flex mt-2">
             <a data-track="sidebar" class="text-2xl" href="{{ relref . "/blog" }}">Pulumi Blog</a>
         </h2>
     {{ end }}
@@ -24,7 +24,7 @@
     <hr class="my-8">
 
     <!-- Sidebar content. Hidden on smaller displays unless toggled. -->
-    <div class="blog-sidebar-content hidden md:block">
+    <div class="blog-sidebar-content hidden lg:block">
         {{ partial "sidebar-cta" . }}
 
         <hr class="my-8">
@@ -57,7 +57,7 @@
         </ul>
     </div>
 
-    <div class="md:hidden pb-4">
+    <div class="lg:hidden pb-4">
         <!-- Vertical spacer, for mobile layouts. -->
     </div>
 </aside>

--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -29,7 +29,7 @@
 
         <hr class="my-8">
 
-        <div class="hidden lg:block my-4">
+        <div class="my-4">
             <h5 class="no-anchor">Recent Posts</h5>
             <ul class="list-none p-0">
                 {{ range $post := first 10 (where .Site.Pages "Type" "blog").ByDate.Reverse }}

--- a/themes/default/layouts/taxonomy/author.html
+++ b/themes/default/layouts/taxonomy/author.html
@@ -1,18 +1,18 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 py-8">
-        <div class="md:flex">
+        <div class="lg:flex">
 
-            <div class="md:w-3/12 pr-8">
+            <div class="lg:w-3/12 pr-8">
                 {{ partial "blog/sidebar.html" . }}
             </div>
 
-            <div class="md:w-7/12">
+            <div class="lg:w-7/12">
                 {{ $authorData := index $.Site.Data.team.team .Data.Term }}
                 {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
 
                 <header>
                     <div class="flex items-top">
-                        <span class="rounded-full mr-4 md:mr-6">
+                        <span class="rounded-full mr-4 lg:mr-6">
                             <img class="rounded-full w-32 bg-blue-200 p-1" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}">
                         </span>
                         <div>
@@ -52,7 +52,7 @@
                 {{ partial "blog/paginator.html" . }}
             </div>
 
-            <div class="md:w-2/12 pl-8">
+            <div class="lg:w-2/12 pl-8">
 
             </div>
         </div>

--- a/themes/default/layouts/taxonomy/tag.html
+++ b/themes/default/layouts/taxonomy/tag.html
@@ -1,12 +1,12 @@
 {{ define "main" }}
     <div class="container mx-auto px-4 py-8">
-        <div class="md:flex">
+        <div class="lg:flex">
 
-            <div class="md:w-3/12 pr-8">
+            <div class="lg:w-3/12 pr-8">
                 {{ partial "blog/sidebar.html" . }}
             </div>
 
-            <div class="md:w-7/12">
+            <div class="lg:w-7/12">
                 {{ $authorData := index $.Site.Data.team.team .Data.Term }}
                 {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
 
@@ -37,7 +37,7 @@
                 {{ partial "blog/paginator.html" . }}
             </div>
 
-            <div class="md:w-2/12 pl-8">
+            <div class="lg:w-2/12 pl-8">
 
             </div>
         </div>


### PR DESCRIPTION
This uses the mobile layout up to iPad width, which makes browsing the docs and blog a lot nicer on a tablet. (This used to be fine before the redesign, so I suspect between the redesign itself and the post-redesign upgrade to Tailwind 2, something must've shifted.)

Before: 

![image](https://user-images.githubusercontent.com/274700/121420142-97093980-c921-11eb-88ef-e5ea4b06ce1c.png)

After:

![image](https://user-images.githubusercontent.com/274700/121420082-88228700-c921-11eb-8cce-217aa58bbddd.png)


