### PR TITLE
fix nav toggle button

### DIFF
--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -6,9 +6,8 @@
     <!-- Sidebar menu toggle for mobile. -->
     <div class="lg:hidden">
         <button class="blog-sidebar-toggle items-center px-3 py-2 border rounded text-purple border-purple">
-            <i class="fas fa-bars"></i>
+            Toggle Blog Navigation
         </button>
-        <a data-track="sidebar" href="{{ relref . "/blog" }}">Pulumi Blog</a>
     </div>
 
     {{ if eq .Page.Title "Blog" }}


### PR DESCRIPTION
## whats the problem
we present 2 hamburger nav buttons on the blog page for small screens
fixes comment in https://github.com/pulumi/pulumi-hugo/pull/306#issuecomment-858064052

i also removed the link to the blog from the blog because I did not understand why that was there... pls let me know if its serving a purpose I'm overlooking

## proposed fix
use a text label instead of an icon

### screenshots

#### before
<img width="397" alt="blog-nav-before" src="https://user-images.githubusercontent.com/5489125/121449746-43ade000-c94f-11eb-9dd4-de906659606d.png">

#### after
<img width="479" alt="blog-nav-after" src="https://user-images.githubusercontent.com/5489125/121449758-47d9fd80-c94f-11eb-9c66-33756e88b403.png">
