### PR TITLE
Consolidate contact us forms

### DIFF
--- a/themes/default/assets/sass/_icons.scss
+++ b/themes/default/assets/sass/_icons.scss
@@ -5,7 +5,7 @@ $fa-font-path: "/fonts/fontawesome";
 @import "fontawesome/fa-regular.scss";
 @import "fontawesome/fa-brands.scss";
 
-@each $icon in "abstract-shapes" "accordion-closed" "accordion-open" "alert" "buildings" "clipboard" "clode-with-nodes" "cloud-with-nodes" "cloud" "clouds" "code-window" "code" "collab" "cycle" "download-from-cloud" "exchange" "eye" "gavel" "gear" "global" "guage" "hamburger-closed" "hamburger-open" "lightning" "lock" "monitor" "nodes-and-rays" "nodes" "pen" "program" "puzzle" "security" "shield" "type-cursor" {
+@each $icon in "team" "abstract-shapes" "accordion-closed" "accordion-open" "alert" "buildings" "clipboard" "clode-with-nodes" "cloud-with-nodes" "cloud" "clouds" "code-window" "code" "collab" "cycle" "download-from-cloud" "exchange" "eye" "gavel" "gear" "global" "guage" "hamburger-closed" "hamburger-open" "lightning" "lock" "monitor" "nodes-and-rays" "nodes" "pen" "program" "puzzle" "security" "shield" "type-cursor" {
     .icon-#{ $icon } {
         @apply rounded-full inline-block p-4 w-20 h-20;
 

--- a/themes/default/components/src/components.d.ts
+++ b/themes/default/components/src/components.d.ts
@@ -34,6 +34,11 @@ export namespace Components {
         "selection": ChooserKey;
         "type": ChooserType;
     }
+    interface PulumiContactUsForm {
+        "items": string;
+        "labelClass"?: string;
+        "selectClass"?: string;
+    }
     interface PulumiConvert {
         "endpoint": string;
         "examples": string;
@@ -130,6 +135,12 @@ declare global {
     var HTMLPulumiChooserElement: {
         prototype: HTMLPulumiChooserElement;
         new (): HTMLPulumiChooserElement;
+    };
+    interface HTMLPulumiContactUsFormElement extends Components.PulumiContactUsForm, HTMLStencilElement {
+    }
+    var HTMLPulumiContactUsFormElement: {
+        prototype: HTMLPulumiContactUsFormElement;
+        new (): HTMLPulumiContactUsFormElement;
     };
     interface HTMLPulumiConvertElement extends Components.PulumiConvert, HTMLStencilElement {
     }
@@ -232,6 +243,7 @@ declare global {
         "pulumi-banner": HTMLPulumiBannerElement;
         "pulumi-choosable": HTMLPulumiChoosableElement;
         "pulumi-chooser": HTMLPulumiChooserElement;
+        "pulumi-contact-us-form": HTMLPulumiContactUsFormElement;
         "pulumi-convert": HTMLPulumiConvertElement;
         "pulumi-date-countdown": HTMLPulumiDateCountdownElement;
         "pulumi-datetime": HTMLPulumiDatetimeElement;
@@ -274,6 +286,11 @@ declare namespace LocalJSX {
         "options"?: string;
         "selection"?: ChooserKey;
         "type"?: ChooserType;
+    }
+    interface PulumiContactUsForm {
+        "items"?: string;
+        "labelClass"?: string;
+        "selectClass"?: string;
     }
     interface PulumiConvert {
         "endpoint"?: string;
@@ -348,6 +365,7 @@ declare namespace LocalJSX {
         "pulumi-banner": PulumiBanner;
         "pulumi-choosable": PulumiChoosable;
         "pulumi-chooser": PulumiChooser;
+        "pulumi-contact-us-form": PulumiContactUsForm;
         "pulumi-convert": PulumiConvert;
         "pulumi-date-countdown": PulumiDateCountdown;
         "pulumi-datetime": PulumiDatetime;
@@ -374,6 +392,7 @@ declare module "@stencil/core" {
             "pulumi-banner": LocalJSX.PulumiBanner & JSXBase.HTMLAttributes<HTMLPulumiBannerElement>;
             "pulumi-choosable": LocalJSX.PulumiChoosable & JSXBase.HTMLAttributes<HTMLPulumiChoosableElement>;
             "pulumi-chooser": LocalJSX.PulumiChooser & JSXBase.HTMLAttributes<HTMLPulumiChooserElement>;
+            "pulumi-contact-us-form": LocalJSX.PulumiContactUsForm & JSXBase.HTMLAttributes<HTMLPulumiContactUsFormElement>;
             "pulumi-convert": LocalJSX.PulumiConvert & JSXBase.HTMLAttributes<HTMLPulumiConvertElement>;
             "pulumi-date-countdown": LocalJSX.PulumiDateCountdown & JSXBase.HTMLAttributes<HTMLPulumiDateCountdownElement>;
             "pulumi-datetime": LocalJSX.PulumiDatetime & JSXBase.HTMLAttributes<HTMLPulumiDatetimeElement>;

--- a/themes/default/components/src/components.d.ts
+++ b/themes/default/components/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { ChooserKey, ChooserMode, ChooserType, OSKey } from "./components/chooser/chooser";
 import { ChooserKey as ChooserKey1, ChooserMode as ChooserMode1, ChooserOptionStyle, ChooserType as ChooserType1 } from "./components/chooser/chooser";
 import { SourceKind } from "./components/convert/convert";
+import { MultiSelectFormItem } from "./components/pulumi-multi-select-form/pulumi-multi-select-form";
 export namespace Components {
     interface PulumiAudio {
         "pausedText": string;
@@ -61,6 +62,13 @@ export namespace Components {
     }
     interface PulumiInstall {
         "os"?: OSKey;
+    }
+    interface PulumiMultiSelectForm {
+        "defaultFormId": string;
+        "items": MultiSelectFormItem[];
+        "labelClass"?: string;
+        "labelText": string;
+        "selectClass"?: string;
     }
     interface PulumiRoot {
     }
@@ -171,6 +179,12 @@ declare global {
         prototype: HTMLPulumiInstallElement;
         new (): HTMLPulumiInstallElement;
     };
+    interface HTMLPulumiMultiSelectFormElement extends Components.PulumiMultiSelectForm, HTMLStencilElement {
+    }
+    var HTMLPulumiMultiSelectFormElement: {
+        prototype: HTMLPulumiMultiSelectFormElement;
+        new (): HTMLPulumiMultiSelectFormElement;
+    };
     interface HTMLPulumiRootElement extends Components.PulumiRoot, HTMLStencilElement {
     }
     var HTMLPulumiRootElement: {
@@ -226,6 +240,7 @@ declare global {
         "pulumi-greenhouse-jobs-list": HTMLPulumiGreenhouseJobsListElement;
         "pulumi-hubspot-form": HTMLPulumiHubspotFormElement;
         "pulumi-install": HTMLPulumiInstallElement;
+        "pulumi-multi-select-form": HTMLPulumiMultiSelectFormElement;
         "pulumi-root": HTMLPulumiRootElement;
         "pulumi-slot-machine": HTMLPulumiSlotMachineElement;
         "pulumi-swipeable": HTMLPulumiSwipeableElement;
@@ -289,6 +304,13 @@ declare namespace LocalJSX {
     interface PulumiInstall {
         "os"?: OSKey;
     }
+    interface PulumiMultiSelectForm {
+        "defaultFormId"?: string;
+        "items"?: MultiSelectFormItem[];
+        "labelClass"?: string;
+        "labelText"?: string;
+        "selectClass"?: string;
+    }
     interface PulumiRoot {
         "onRendered"?: (event: CustomEvent<any>) => void;
     }
@@ -334,6 +356,7 @@ declare namespace LocalJSX {
         "pulumi-greenhouse-jobs-list": PulumiGreenhouseJobsList;
         "pulumi-hubspot-form": PulumiHubspotForm;
         "pulumi-install": PulumiInstall;
+        "pulumi-multi-select-form": PulumiMultiSelectForm;
         "pulumi-root": PulumiRoot;
         "pulumi-slot-machine": PulumiSlotMachine;
         "pulumi-swipeable": PulumiSwipeable;
@@ -359,6 +382,7 @@ declare module "@stencil/core" {
             "pulumi-greenhouse-jobs-list": LocalJSX.PulumiGreenhouseJobsList & JSXBase.HTMLAttributes<HTMLPulumiGreenhouseJobsListElement>;
             "pulumi-hubspot-form": LocalJSX.PulumiHubspotForm & JSXBase.HTMLAttributes<HTMLPulumiHubspotFormElement>;
             "pulumi-install": LocalJSX.PulumiInstall & JSXBase.HTMLAttributes<HTMLPulumiInstallElement>;
+            "pulumi-multi-select-form": LocalJSX.PulumiMultiSelectForm & JSXBase.HTMLAttributes<HTMLPulumiMultiSelectFormElement>;
             "pulumi-root": LocalJSX.PulumiRoot & JSXBase.HTMLAttributes<HTMLPulumiRootElement>;
             "pulumi-slot-machine": LocalJSX.PulumiSlotMachine & JSXBase.HTMLAttributes<HTMLPulumiSlotMachineElement>;
             "pulumi-swipeable": LocalJSX.PulumiSwipeable & JSXBase.HTMLAttributes<HTMLPulumiSwipeableElement>;

--- a/themes/default/components/src/components/contact-us-form/contact-us-form.css
+++ b/themes/default/components/src/components/contact-us-form/contact-us-form.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/themes/default/components/src/components/contact-us-form/contact-us-form.tsx
+++ b/themes/default/components/src/components/contact-us-form/contact-us-form.tsx
@@ -1,0 +1,65 @@
+import { Component, Prop, State, h } from "@stencil/core";
+import { MultiSelectFormItem } from "../pulumi-multi-select-form/pulumi-multi-select-form";
+import { getQueryVariable } from "../../util/util";
+
+interface ContactUsItem {
+    key: string;
+    hubspot_form_id: string;
+}
+
+@Component({
+    tag: "pulumi-contact-us-form",
+    styleUrl: "contact-us-form.css",
+    shadow: false,
+})
+export class ContactUsForm {
+    // The JSON string of the sessions.
+    @Prop()
+    items: string;
+
+    // The class for the select input.
+    @Prop()
+    selectClass?: string;
+
+    // The labelClass defines the class for the label.
+    @Prop()
+    labelClass?: string;
+
+    // The parsed and transformed session string.
+    @State()
+    parsedItems: MultiSelectFormItem[];
+
+    @State()
+    defaultFormId: string = "";
+
+    componentWillLoad() {
+        this.parsedItems = JSON.parse(this.items).map((item: ContactUsItem) => {
+            return {
+                key: item.key.charAt(0).toUpperCase() + item.key.slice(1),
+                hubspotFormId: item.hubspot_form_id
+            };
+        });
+
+        const formQueryParam = getQueryVariable("form");
+        if (formQueryParam) {
+            const selectedForm = this.parsedItems.find((item) => (item.key as string).toLowerCase() === formQueryParam.toLowerCase());
+
+            if (selectedForm) {
+                this.defaultFormId = selectedForm.hubspotFormId;
+                return;
+            }
+        }
+    }
+
+    render() {
+        return (
+            <pulumi-multi-select-form
+                items={this.parsedItems}
+                selectClass={this.selectClass}
+                labelClass={this.labelClass}
+                labelText="Why are you contacting us today?"
+                defaultFormId={this.defaultFormId}
+            />
+        );
+    }
+}

--- a/themes/default/components/src/components/contact-us-form/test/contact-us-form.e2e.ts
+++ b/themes/default/components/src/components/contact-us-form/test/contact-us-form.e2e.ts
@@ -3,9 +3,9 @@ import { newE2EPage } from '@stencil/core/testing';
 describe('contact-us-form', () => {
   it('renders', async () => {
     const page = await newE2EPage();
-    await page.setContent('<contact-us-form></contact-us-form>');
+    await page.setContent('<pulumi-contact-us-form items="[]"></pulumi-contact-us-form>');
 
-    const element = await page.find('contact-us-form');
+    const element = await page.find('pulumi-contact-us-form');
     expect(element).toHaveClass('hydrated');
   });
 });

--- a/themes/default/components/src/components/contact-us-form/test/contact-us-form.e2e.ts
+++ b/themes/default/components/src/components/contact-us-form/test/contact-us-form.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('contact-us-form', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<contact-us-form></contact-us-form>');
+
+    const element = await page.find('contact-us-form');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/themes/default/components/src/components/contact-us-form/test/contact-us-form.spec.tsx
+++ b/themes/default/components/src/components/contact-us-form/test/contact-us-form.spec.tsx
@@ -8,11 +8,7 @@ describe('contact-us-form', () => {
       html: `<contact-us-form></contact-us-form>`,
     });
     expect(page.root).toEqualHtml(`
-      <contact-us-form>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
-      </contact-us-form>
+      <contact-us-form></contact-us-form>
     `);
   });
 });

--- a/themes/default/components/src/components/contact-us-form/test/contact-us-form.spec.tsx
+++ b/themes/default/components/src/components/contact-us-form/test/contact-us-form.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { ContactUsForm } from '../contact-us-form';
+
+describe('contact-us-form', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [ContactUsForm],
+      html: `<contact-us-form></contact-us-form>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <contact-us-form>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </contact-us-form>
+    `);
+  });
+});

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.css
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.css
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.css
@@ -1,3 +1,3 @@
 :host {
-  display: block;
+    display: block;
 }

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -1,0 +1,109 @@
+import { Component, Prop, State, h } from "@stencil/core";
+
+export interface MultiSelectFormItem {
+    key: string | Date;
+    hubspotFormId: string;
+}
+
+@Component({
+  tag: "pulumi-multi-select-form",
+  styleUrl: "pulumi-multi-select-form.css",
+  shadow: false,
+})
+export class PulumiMultiSelectForm {
+    // The JSON string of the items for the selector.
+    @Prop()
+    items: MultiSelectFormItem[];
+
+    // The class for the select input.
+    @Prop()
+    selectClass?: string;
+
+    // The labelClass defines the class for the label.
+    @Prop()
+    labelClass?: string;
+
+    // The text to be displayed as the label for the selector.
+    @Prop()
+    labelText: string;
+
+    // The default key for the selector to set to when rendered. If the key
+    // is blank then the first item in the array will be selected.
+    @Prop()
+    defaultFormId: string = "";
+
+    // The currently selected item.
+    @State()
+    selectedItem: MultiSelectFormItem;
+
+    @State()
+    formSubmitted = false;
+
+    // The window event listener used to handle submitting form data to Segment.
+    private windowEventHandler: (this: Window, ev: MessageEvent) => any;
+
+    // When the component loads we need to parse the items string.
+    componentWillLoad() {
+        if (this.defaultFormId !== "") {
+            this.selectedItem = this.items.find((item) => item.hubspotFormId === this.defaultFormId);
+            console.log(this.selectedItem);
+
+            if (this.selectedItem) {
+                return;
+            }
+        }
+
+        this.selectedItem = this.items[0];
+    }
+
+    // After the form submits we should hide the session selector.
+    componentDidLoad() {
+        this.windowEventHandler = this.handleWindowMessage.bind(this);
+        window.addEventListener("message", this.windowEventHandler);
+    }
+
+    disconnectedCallback() {
+        window.removeEventListener("message", this.windowEventHandler);
+    }
+
+    // Handle an incoming window message.
+    private handleWindowMessage(event: MessageEvent) {
+        if (event.data.type === "hsFormCallback" && event.data.eventName === "onFormReady") {
+            const form = document.querySelector("form.hs-form") as HTMLFormElement;
+            form.addEventListener("submit", this.handleFormSubmit.bind(this));
+        }
+    }
+
+    // Set the formSubmitted to true when the form has been submitted.
+    private handleFormSubmit() {
+        this.formSubmitted = true;
+    }
+
+    // When the select input changes we need to update the state accordingly.
+    private handleSelectChange(hubspotFormId: string) {
+        this.selectedItem = this.items.find((item) => item.hubspotFormId === hubspotFormId);
+    }
+
+    render() {
+        const selectedFormId = this.selectedItem.hubspotFormId;
+        return (
+            <div>
+                { this.formSubmitted ? null :
+                    <span>
+                        <span class={this.labelClass || ""}>{ this.labelText }</span>
+                        <select class={this.selectClass || ""} onInput={(event: any) => this.handleSelectChange(event.target.value)}>
+                            {this.items.map((item) => {
+                                const isSelected = item.hubspotFormId === selectedFormId;
+                                return <option value={item.hubspotFormId} selected={isSelected}>{item.key}</option>;
+                            })}
+                        </select>
+                    </span>
+                }
+                <pulumi-hubspot-form
+                    key={this.selectedItem.hubspotFormId}
+                    form-id={this.selectedItem.hubspotFormId}
+                ></pulumi-hubspot-form>
+            </div>
+        );
+    }
+}

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, State, h } from "@stencil/core";
+import { Component, Prop, State, Element, h } from "@stencil/core";
 
 export interface MultiSelectFormItem {
     key: string | Date;
@@ -6,11 +6,14 @@ export interface MultiSelectFormItem {
 }
 
 @Component({
-  tag: "pulumi-multi-select-form",
-  styleUrl: "pulumi-multi-select-form.css",
-  shadow: false,
+    tag: "pulumi-multi-select-form",
+    styleUrl: "pulumi-multi-select-form.css",
+    shadow: false,
 })
 export class PulumiMultiSelectForm {
+    @Element()
+    el: Element;
+
     // The JSON string of the items for the selector.
     @Prop()
     items: MultiSelectFormItem[] = [];
@@ -68,7 +71,7 @@ export class PulumiMultiSelectForm {
     // Handle an incoming window message.
     private handleWindowMessage(event: MessageEvent) {
         if (event.data.type === "hsFormCallback" && event.data.eventName === "onFormReady") {
-            const form = document.querySelector("form.hs-form") as HTMLFormElement;
+            const form = this.el.querySelector("form.hs-form") as HTMLFormElement;
             form.addEventListener("submit", this.handleFormSubmit.bind(this));
         }
     }

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -13,7 +13,7 @@ export interface MultiSelectFormItem {
 export class PulumiMultiSelectForm {
     // The JSON string of the items for the selector.
     @Prop()
-    items: MultiSelectFormItem[];
+    items: MultiSelectFormItem[] = [];
 
     // The class for the select input.
     @Prop()
@@ -46,7 +46,6 @@ export class PulumiMultiSelectForm {
     componentWillLoad() {
         if (this.defaultFormId !== "") {
             this.selectedItem = this.items.find((item) => item.hubspotFormId === this.defaultFormId);
-            console.log(this.selectedItem);
 
             if (this.selectedItem) {
                 return;
@@ -85,8 +84,8 @@ export class PulumiMultiSelectForm {
     }
 
     render() {
-        const selectedFormId = this.selectedItem.hubspotFormId;
-        console.log(selectedFormId);
+        const selectedFormId = this.selectedItem?.hubspotFormId;
+
         return (
             <div>
                 { this.formSubmitted ? null :

--- a/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/pulumi-multi-select-form.tsx
@@ -86,6 +86,7 @@ export class PulumiMultiSelectForm {
 
     render() {
         const selectedFormId = this.selectedItem.hubspotFormId;
+        console.log(selectedFormId);
         return (
             <div>
                 { this.formSubmitted ? null :
@@ -100,8 +101,8 @@ export class PulumiMultiSelectForm {
                     </span>
                 }
                 <pulumi-hubspot-form
-                    key={this.selectedItem.hubspotFormId}
-                    form-id={this.selectedItem.hubspotFormId}
+                    key={selectedFormId}
+                    form-id={selectedFormId}
                 ></pulumi-hubspot-form>
             </div>
         );

--- a/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.e2e.ts
+++ b/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.e2e.ts
@@ -1,11 +1,11 @@
-import { newE2EPage } from '@stencil/core/testing';
+import { newE2EPage } from "@stencil/core/testing";
 
-describe('pulumi-multi-select-form', () => {
-  it('renders', async () => {
-    const page = await newE2EPage();
-    await page.setContent('<pulumi-multi-select-form></pulumi-multi-select-form>');
+describe("pulumi-multi-select-form", () => {
+    it("renders", async () => {
+        const page = await newE2EPage();
+        await page.setContent("<pulumi-multi-select-form></pulumi-multi-select-form>");
 
-    const element = await page.find('pulumi-multi-select-form');
-    expect(element).toHaveClass('hydrated');
-  });
+        const element = await page.find("pulumi-multi-select-form");
+        expect(element).toHaveClass("hydrated");
+    });
 });

--- a/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.e2e.ts
+++ b/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('pulumi-multi-select-form', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<pulumi-multi-select-form></pulumi-multi-select-form>');
+
+    const element = await page.find('pulumi-multi-select-form');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
@@ -9,9 +9,13 @@ describe('pulumi-multi-select-form', () => {
     });
     expect(page.root).toEqualHtml(`
       <pulumi-multi-select-form>
-        <mock:shadow-root>
-          <slot></slot>
-        </mock:shadow-root>
+        <div>
+           <span>
+             <span></span>
+             <select></select>
+           </span>
+           <pulumi-hubspot-form></pulumi-hubspot-form>
+        </div>
       </pulumi-multi-select-form>
     `);
   });

--- a/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
+++ b/themes/default/components/src/components/pulumi-multi-select-form/test/pulumi-multi-select-form.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { PulumiMultiSelectForm } from '../pulumi-multi-select-form';
+
+describe('pulumi-multi-select-form', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [PulumiMultiSelectForm],
+      html: `<pulumi-multi-select-form></pulumi-multi-select-form>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <pulumi-multi-select-form>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </pulumi-multi-select-form>
+    `);
+  });
+});

--- a/themes/default/content/contact.md
+++ b/themes/default/content/contact.md
@@ -3,5 +3,12 @@ title: Contact Us
 meta_desc: Contact Pulumi for any general inquiries, including requests for pricing, support, or training.
 layout: contact
 form:
-    hubspot_form_id: 8381e562-5fdf-4736-bb10-86096705e4ee
+    - key: general
+      hubspot_form_id: 71507f4e-e34e-4dc9-9da6-b44953cac811
+
+    - key: sales
+      hubspot_form_id: 8381e562-5fdf-4736-bb10-86096705e4ee
+
+    - key: onboarding
+      hubspot_form_id: c7b85755-7132-4b47-8767-bbc2d2496d17
 ---

--- a/themes/default/layouts/migrate/cloudformation.html
+++ b/themes/default/layouts/migrate/cloudformation.html
@@ -102,6 +102,6 @@ exports.publicHostName = server.publicDns;` }}
     {{ partial "get-started.html" . }}
 
     <div id="contact">
-        {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+        {{ partial "hand-raise-section" . }}
     </div>
 {{ end }}

--- a/themes/default/layouts/migrate/terraform.html
+++ b/themes/default/layouts/migrate/terraform.html
@@ -242,5 +242,5 @@ output "bucket_name" {
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/page/confirmation.html
+++ b/themes/default/layouts/page/confirmation.html
@@ -7,5 +7,5 @@
 {{ define "main" }}
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/page/contact.html
+++ b/themes/default/layouts/page/contact.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
     {{ partial "contact-us.html" . }}
-    {{ partial "social.html" . }}
+    {{ partial "get-started.html" . }}
 {{ end }}

--- a/themes/default/layouts/page/show.html
+++ b/themes/default/layouts/page/show.html
@@ -23,5 +23,5 @@
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/partials/contact-us.html
+++ b/themes/default/layouts/partials/contact-us.html
@@ -1,57 +1,17 @@
-<section id="contact" class="py-16 px-4">
-    <div class="container md:mx-auto md:flex">
-        <div class="md:w-1/2 md:mr-8">
-            <div class="mb-8">
-                <h2 class="text-4xl">How can we help you?</h2>
-                <h3>Ask Us About</h3>
-                <ul>
-                    <li>
-                        How to deliver
-                        <a href="{{ relref . "/why-pulumi/delivering-cloud-native-infrastructure-as-code" }}">
-                            cloud native infrastructure as code</a>, with general purpose programming languages.
-                    </li>
-                    <li>
-                        How Pulumi supports infrastructure, managed services,
-                        <a href="{{ relref . "/topics/containers" }}">containers</a>,
-                        <a href="{{ relref . "/topics/kubernetes" }}">Kubernetes</a>, and
-                        <a href="{{ relref . "/topics/serverless" }}">serverless</a> infrastructure and apps.
-                    </li>
-                    <li>
-                        How Pulumi's <a href="{{ relref . "/pricing" }}">Team and Enterprise Editions</a>
-                        support the collaboration needs and advanced use cases of larger
-                        Development and DevOps teams.
-                    </li>
-                    <li>
-                        How to get started with an initial Pulumi project.
-                    </li>
-                    <li>
-                        Any other questions about Pulumi.
-                    </li>
-                </ul>
-            </div>
-
-            <div class="mb-8">
-                <h3>The Value of Pulumi</h3>
-                <ul>
-                    <li>Use your favorite programming language to define cloud native infrastructure.</li>
-                    <li>Target any cloud native infrastructure provider including Kubernetes anywhere.</li>
-                    <li>Development and DevOps teams can define, deploy, and manage infrastructure</li>
-                </ul>
-            </div>
-
-            <div>
-                <h3>Our Address</h3>
-                <p class="m-0">
-                    Pulumi Corporation<br>
-                    1525 4th Avenue, Suite 800<br>
-                    Seattle, WA 98101
-                </p>
-            </div>
+<section id="contact" class="pt-16 px-4">
+    <div class="container mx-auto text-center ">
+        <h2 class="text-4xl my-6">How can we help you?</h2>
+        <div class="hs-form hs-form-fg-dark my-6 inline-block">
+            {{ partial "form-section" (dict "form" .Params.form) }}
         </div>
-        <div class="md:w-1/2">
-            <div class="hs-form hs-form-fg-dark">
-                {{ partial "form-section" (dict "form" .Params.form) }}
-            </div>
+
+        <div class="mt-16">
+            <h3>Our Address</h3>
+            <p class="m-0">
+                Pulumi Corporation<br>
+                1525 4th Avenue, Suite 800<br>
+                Seattle, WA 98101
+            </p>
         </div>
     </div>
 </section>

--- a/themes/default/layouts/partials/contact-us.html
+++ b/themes/default/layouts/partials/contact-us.html
@@ -1,8 +1,20 @@
 <section id="contact" class="pt-16 px-4">
     <div class="container mx-auto text-center ">
         <h2 class="text-4xl my-6">How can we help you?</h2>
-        <div class="hs-form hs-form-fg-dark my-6 inline-block">
-            {{ partial "form-section" (dict "form" .Params.form) }}
+        <div class="w-full md:max-w-2xl md:mx-auto">
+
+            <div class="mt-4 mx-auto md:w-full md:mt-0 p-10 bg-white rounded rounded-lg shadow-lg border border-gray-300">
+                <div class="mx-auto flex justify-center">
+                    <div class="hs-form hs-form-fg-dark font-normal">
+                        <pulumi-contact-us-form
+                            items={{ .Params.form | jsonify }}
+                            label-class="block mb-2 font-normal text-sm"
+                            select-class="w-full px-2 py-1 text-sm rounded block text-gray-700 border border-gray-300 rounded bg-white focus:outline-none focus:ring"
+                        ></pulumi-contact-us-form>
+                    </div>
+                </div>
+            </div>
+
         </div>
 
         <div class="mt-16">

--- a/themes/default/layouts/partials/hand-raise-section.html
+++ b/themes/default/layouts/partials/hand-raise-section.html
@@ -1,4 +1,4 @@
-<div>
+<div class="my-16">
     <h2 class="text-center">Need Help?</h2>
 
     <div class="container mx-auto lg:flex lg:flex-wrap">

--- a/themes/default/layouts/partials/hand-raise-section.html
+++ b/themes/default/layouts/partials/hand-raise-section.html
@@ -2,77 +2,79 @@
     <h2 class="text-center">Need Help?</h2>
 
     <div class="container mx-auto lg:flex lg:flex-wrap">
-        <div class="lg:w-1/2 p-3">
-            <div class="card text-center p-6">
-                <a class="hover:underline" href="https://support.pulumi.com/">
-                    <div class="icon-section">
-                        {{ partial "color-icon.html" (dict "icon" "code" "icon_color" "salmon") }}
-                    </div>
-                    <div>
-                        <h5>Need technical help?</h5>
-                    </div>
-                    <div class="description">
-                        <p>
-                            Need help with a technical problem? Use our Support Portal to get
-                            engineering help.
-                        </p>
-                    </div>
-                </a>
+         <div class="lg:w-1/2 px-3 py-6">
+            <div class="card text-center p-6 relative">
+                <div class="icon-section">
+                    {{ partial "color-icon.html" (dict "icon" "code" "icon_color" "salmon") }}
+                </div>
+                <div>
+                    <h5>Need technical help?</h5>
+                </div>
+                <div class="description">
+                    <p>
+                        Use our Support Portal to get in touch.
+                    </p>
+                </div>
+                <div class="card-cta-btn">
+                    <a href="https://support.pulumi.com/" class="btn-primary">Submit support ticket</a>
+                </div>
             </div>
         </div>
 
-         <div class="lg:w-1/2 p-3">
-            <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=onboarding">
-                    <div class="icon-section">
-                        {{ partial "color-icon.html" (dict "icon" "rocketship" "icon_color" "violet") }}
-                    </div>
-                    <div>
-                        <h5>Need help getting started?</h5>
-                    </div>
-                    <div class="description">
-                        <p>
-                            Need help with getting started with Pulumi? Send us a note
-                            and someone will reach out to help you get started with Pulumi.
-                        </p>
-                    </div>
-                </a>
+         <div class="lg:w-1/2 px-3 py-6">
+            <div class="card text-center p-6 relative">
+                <div class="icon-section">
+                    {{ partial "color-icon.html" (dict "icon" "rocketship" "icon_color" "violet") }}
+                </div>
+                <div>
+                    <h5>Need help getting started?</h5>
+                </div>
+                <div class="description">
+                    <p>
+                        Send us a note, and someone will reach out to help you.
+                    </p>
+                </div>
+                <div class="card-cta-btn">
+                    <a href="{{ relref . "/contact.md" }}?form=onboarding" class="btn-primary">Get help</a>
+                </div>
             </div>
         </div>
 
-         <div class="lg:w-1/2 p-3">
-            <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=sales">
-                    <div class="icon-section">
-                        {{ partial "color-icon.html" (dict "icon" "team" "icon_color" "blue") }}
-                    </div>
-                    <div>
-                        <h5>Want to speak with sales?</h5>
-                    </div>
-                    <div class="description">
-                        <p>
-                            Want to speak with someone about pricing or purchasing?
-                        </p>
-                    </div>
-                </a>
+         <div class="lg:w-1/2 px-3 py-6">
+            <div class="card text-center p-6 relative">
+                <div class="icon-section">
+                    {{ partial "color-icon.html" (dict "icon" "team" "icon_color" "blue") }}
+                </div>
+                <div>
+                    <h5>Want to speak with sales?</h5>
+                </div>
+                <div class="description">
+                    <p>
+                        Contact us -- we're happy to help.
+                    </p>
+                </div>
+                <div class="card-cta-btn">
+                    <a href="{{ relref . "/contact.md" }}?form=sales" class="btn-primary">Talk to sales</a>
+                </div>
             </div>
         </div>
 
-         <div class="lg:w-1/2 p-3">
-            <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=general">
-                    <div class="icon-section">
-                        {{ partial "color-icon.html" (dict "icon" "pen" "icon_color" "yellow") }}
-                    </div>
-                    <div>
-                        <h5>Other Inquiries</h5>
-                    </div>
-                    <div class="description">
-                        <p>
-                            Have something else to discuss? Send us a note.
-                        </p>
-                    </div>
-                </a>
+         <div class="lg:w-1/2 px-3 py-6">
+            <div class="card text-center p-6 relative">
+                <div class="icon-section">
+                    {{ partial "color-icon.html" (dict "icon" "pen" "icon_color" "yellow") }}
+                </div>
+                <div>
+                    <h5>Something else on your mind?</h5>
+                </div>
+                <div class="description">
+                    <p>
+                        Send us a note.
+                    </p>
+                </div>
+                <div class="card-cta-btn">
+                    <a href="{{ relref . "/contact.md" }}?form=general" class="btn-primary">Ask a question</a>
+                </div>
             </div>
         </div>
     </div>

--- a/themes/default/layouts/partials/hand-raise-section.html
+++ b/themes/default/layouts/partials/hand-raise-section.html
@@ -23,7 +23,7 @@
 
          <div class="lg:w-1/2 p-3">
             <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=onboarding">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=onboarding">
                     <div class="icon-section">
                         {{ partial "color-icon.html" (dict "icon" "rocketship" "icon_color" "violet") }}
                     </div>
@@ -42,7 +42,7 @@
 
          <div class="lg:w-1/2 p-3">
             <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=sales">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=sales">
                     <div class="icon-section">
                         {{ partial "color-icon.html" (dict "icon" "team" "icon_color" "blue") }}
                     </div>
@@ -60,7 +60,7 @@
 
          <div class="lg:w-1/2 p-3">
             <div class="card text-center p-6">
-                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=other">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?form=general">
                     <div class="icon-section">
                         {{ partial "color-icon.html" (dict "icon" "pen" "icon_color" "yellow") }}
                     </div>

--- a/themes/default/layouts/partials/hand-raise-section.html
+++ b/themes/default/layouts/partials/hand-raise-section.html
@@ -1,0 +1,79 @@
+<div>
+    <h2 class="text-center">Need Help?</h2>
+
+    <div class="container mx-auto lg:flex lg:flex-wrap">
+        <div class="lg:w-1/2 p-3">
+            <div class="card text-center p-6">
+                <a class="hover:underline" href="https://support.pulumi.com/">
+                    <div class="icon-section">
+                        {{ partial "color-icon.html" (dict "icon" "code" "icon_color" "salmon") }}
+                    </div>
+                    <div>
+                        <h5>Need technical help?</h5>
+                    </div>
+                    <div class="description">
+                        <p>
+                            Need help with a technical problem? Use our Support Portal to get
+                            engineering help.
+                        </p>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+         <div class="lg:w-1/2 p-3">
+            <div class="card text-center p-6">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=onboarding">
+                    <div class="icon-section">
+                        {{ partial "color-icon.html" (dict "icon" "rocketship" "icon_color" "violet") }}
+                    </div>
+                    <div>
+                        <h5>Need help getting started?</h5>
+                    </div>
+                    <div class="description">
+                        <p>
+                            Need help with getting started with Pulumi? Send us a note
+                            and someone will reach out to help you get started with Pulumi.
+                        </p>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+         <div class="lg:w-1/2 p-3">
+            <div class="card text-center p-6">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=sales">
+                    <div class="icon-section">
+                        {{ partial "color-icon.html" (dict "icon" "team" "icon_color" "blue") }}
+                    </div>
+                    <div>
+                        <h5>Want to speak with sales?</h5>
+                    </div>
+                    <div class="description">
+                        <p>
+                            Want to speak with someone about pricing or purchasing?
+                        </p>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+         <div class="lg:w-1/2 p-3">
+            <div class="card text-center p-6">
+                <a class="hover:underline" href="{{ relref . "/contact.md" }}?type=other">
+                    <div class="icon-section">
+                        {{ partial "color-icon.html" (dict "icon" "pen" "icon_color" "yellow") }}
+                    </div>
+                    <div>
+                        <h5>Other Inquiries</h5>
+                    </div>
+                    <div class="description">
+                        <p>
+                            Have something else to discuss? Send us a note.
+                        </p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/themes/default/layouts/partials/icons/team.html
+++ b/themes/default/layouts/partials/icons/team.html
@@ -1,0 +1,6 @@
+<svg width="48" height="49" viewBox="0 0 48 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M29 14.25C29 17.9775 32.0225 22.5 35.75 22.5C39.4775 22.5 42.5 17.9775 42.5 14.25C42.5 10.5225 39.4775 7.5 35.75 7.5C32.0225 7.5 29 10.5225 29 14.25Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M36.4998 37.5H46.9998V34.257C46.9998 32.4225 45.8973 30.7635 44.1933 30.0855C42.2433 29.3085 39.3498 28.5 35.7498 28.5C32.1498 28.5 29.2563 29.3085 27.3063 30.0855C26.5023 30.4065 25.8363 30.9405 25.3518 31.6125" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30.5 42H2V37.7775C2 35.4885 3.2915 33.393 5.3495 32.391C7.751 31.221 11.4155 30 16.25 30C21.0845 30 24.749 31.221 27.1505 32.391C29.2085 33.393 30.5 35.4885 30.5 37.7775V42Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24.5 14.25C24.5 18.807 20.807 24 16.25 24C11.693 24 8 18.807 8 14.25C8 9.693 11.693 6 16.25 6C20.807 6 24.5 9.693 24.5 14.25Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/themes/default/layouts/partner/aws.html
+++ b/themes/default/layouts/partner/aws.html
@@ -306,5 +306,5 @@
         </div>
     </section>
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/partner/azure.html
+++ b/themes/default/layouts/partner/azure.html
@@ -251,5 +251,5 @@
         </div>
     </section>
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/partner/gcp.html
+++ b/themes/default/layouts/partner/gcp.html
@@ -231,5 +231,5 @@ export let url = greetingFunction.httpsTriggerUrl;` }}
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/topics/containers.html
+++ b/themes/default/layouts/topics/containers.html
@@ -89,5 +89,5 @@
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/topics/kubernetes.html
+++ b/themes/default/layouts/topics/kubernetes.html
@@ -236,5 +236,7 @@
 
     {{ partial "get-started.html" . }}
 
+    {{ partial "hand-raise-section" . }}
+
     {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
 {{ end }}

--- a/themes/default/layouts/topics/kubernetes.html
+++ b/themes/default/layouts/topics/kubernetes.html
@@ -237,6 +237,4 @@
     {{ partial "get-started.html" . }}
 
     {{ partial "hand-raise-section" . }}
-
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
 {{ end }}

--- a/themes/default/layouts/topics/serverless.html
+++ b/themes/default/layouts/topics/serverless.html
@@ -122,5 +122,5 @@
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "form-section" (dict "form" .Params.contact_us_form) }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/static/icons/team.svg
+++ b/themes/default/static/icons/team.svg
@@ -1,0 +1,6 @@
+<svg width="48" height="49" viewBox="0 0 48 49" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M29 14.25C29 17.9775 32.0225 22.5 35.75 22.5C39.4775 22.5 42.5 17.9775 42.5 14.25C42.5 10.5225 39.4775 7.5 35.75 7.5C32.0225 7.5 29 10.5225 29 14.25Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M36.4998 37.5H46.9998V34.257C46.9998 32.4225 45.8973 30.7635 44.1933 30.0855C42.2433 29.3085 39.3498 28.5 35.7498 28.5C32.1498 28.5 29.2563 29.3085 27.3063 30.0855C26.5023 30.4065 25.8363 30.9405 25.3518 31.6125" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30.5 42H2V37.7775C2 35.4885 3.2915 33.393 5.3495 32.391C7.751 31.221 11.4155 30 16.25 30C21.0845 30 24.749 31.221 27.1505 32.391C29.2085 33.393 30.5 35.4885 30.5 37.7775V42Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24.5 14.25C24.5 18.807 20.807 24 16.25 24C11.693 24 8 18.807 8 14.25C8 9.693 11.693 6 16.25 6C20.807 6 24.5 9.693 24.5 14.25Z" stroke="#19041E" stroke-width="2" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-hugo/issues/119

This PR replaces the Contact Us forms throughout the marketing site with a four card section that directs people to "different" places based on their request. Mainly we are hoping to ensure our Support questions are routed through the correct system and so we can differentiate between different types of requests.

<img width="1361" alt="hand-raise-section-new" src="https://user-images.githubusercontent.com/15146337/125969140-a9d9aeae-bc02-4ef1-901d-d241e612bad7.png">

I also updated the Contact Us page to be much simpler and have a selector on the type of the form so the user can pick what type of "Contact Us" they want. 

![contact-form-switch-gif](https://user-images.githubusercontent.com/15146337/121751157-7b896480-cac2-11eb-95cd-f39f3830b5a9.gif)
