### PR TITLE
Add Twilio webinar and two livestream events

### DIFF
--- a/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
+++ b/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
@@ -1,0 +1,85 @@
+---
+# Name of the webinar.
+title: "Building Event-driven communications with Twilio and AWS"
+meta_desc: "In this session, the Twilio team will show you how they use Pulumi and how you can create powerful scheduling tools for your customer communications."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "building-event-driven-communications-with-twilio-and-aws"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Building Event-driven communications with Twilio, Pulumi, and AWS"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Webinar pages support multiple session via the 'multiple' property.
+# multiple:
+#   - datetime: 2020-02-05T10:00:00-07:00
+#     hubspot_form_id: ""
+#     gotowebinar_key: ""
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Building Event-driven communications with Twilio, Pulumi, and AWS"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: ""
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2021-07-27T10:00:00-07:00
+    # Duration of the webinar.
+    duration: "2 hours"
+    # Datetime of the webinar.
+    datetime: "TUE JUL 27, 2021"
+    # Description of the webinar.
+    description: |
+        With Twilio Studio, you can build communications workflows to engage your customers, but, what if you wanted to schedule regular outreach or trigger a communications workflow based on some event in AWS? In this session, the Twilio team will show you how they use Pulumi to manage infrastructure and how you can use Infrastructure as Code to create powerful scheduling tools for your customer communications.
+
+    # The webinar presenters
+    presenters:
+        - name: Lee Zen
+          role: VP Engineering, Pulumi
+        - name: Kaique Lupo
+          role: Soutions Architect, Twilio
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - How to set up services like AWS Lambda using Pulumi and your favorite programming languages.
+        - Managing Twilio with Pulumi using TypeScript.
+        - Designing scheduled and event-triggered outreach.
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: "2f4b4c3d-765a-46bb-97f9-838af34a08e2"
+---

--- a/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
+++ b/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
@@ -1,0 +1,83 @@
+---
+# Name of the webinar.
+title: "From Zero to Production in Kubernetes"
+meta_desc: "Watch as Lee Briggs & Elijah Zupancic go from zero to production on Kubernetes by using Python to build abstractions that make getting to production easier."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "from-zero-to-production-in-kubernetes"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "From Zero to Production in Kubernetes"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "From Zero to Production in Kubernetes"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: ""
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2021-07-20T10:00:00-07:00
+    # Duration of the webinar.
+    duration: "2 hours"
+    # Datetime of the webinar.
+    datetime: "TUE JUL 20, 2021"
+    # Description of the webinar.
+    description: |
+        Setting up your production Kuberentes environment brings many benefits including scalability and portability for your applications. Before you reach production, It’s important to understand key Kubernetes concepts and architectures available to keep your clusters secure and scalable. Ingress controllers are vital parts of any Kubernetes platform and NGINX ingress controller provides the best in class traffic management solution for cloud native apps and containerized environments.
+
+        It’s important to use repeatable mechanisms to handle your ingress objects and controller deployments. Adopting infrastructure as code provides a mechanism to easily deploy production-ready applications in a repeatable manner. In this livestream, we’ll explore how to leverage the power of Python with Pulumi, an infrastructure as code platform to define and manage your Kubernetes deployments and build powerful abstractions that make getting to production easier than ever before.
+
+        [Livestream link](https://youtu.be/L-8uzn6AdHM)
+
+    # The webinar presenters
+    presenters:
+        - name: Lee Briggs
+          role: Community Engineer, Pulumi
+        - name: Elijah Zupancic
+          role: Solutions Architect, NGINX
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - How to stand up Kubernetes including Amazon VPC, Amazon EKS and other dependencies.
+        - Setting up your ingress controller.
+        - Deploying an app to your cluster.
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 455d3e60-9d8d-49c9-876e-08d33d2cfe0d
+---

--- a/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
+++ b/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
@@ -1,0 +1,84 @@
+---
+# Name of the webinar.
+title: "Getting from code to cloud with VS Code and Pulumi"
+meta_desc: "Pulumi's Matty Stratton will show you how easy it is to use Pulumi and VS Code to set up Azure (or any cloud) using JavaScript/TypeScript."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "getting-from-code-to-cloud-with-vscode-and-pulumi"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: ""
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Webinar pages support multiple session via the 'multiple' property.
+# multiple:
+#   - datetime: 2020-02-05T10:00:00-07:00
+#     hubspot_form_id: ""
+#     gotowebinar_key: ""
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Getting from code to cloud with VS Code and Pulumi"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: ""
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2021-07-29T08:00:00-07:00
+    # Duration of the webinar.
+    duration: "2 hours"
+    # Datetime of the webinar.
+    datetime: "THU JUL 29th, 2021"
+    # Description of the webinar.
+    description: |
+        For app developers, setting up infrastructure can be the hardest part of getting their app into production. What if you could just configure infrastructure using the same language you’re using to build your app? Pulumi's Matty Stratton will show you how easy it is to use Pulumi and VS Code to set up Azure (or any cloud) using JavaScript/TypeScript.
+
+        [Livestream Link](https://aka.ms/code-livestream-page)
+
+    # The webinar presenters
+    presenters:
+        - name: Matty Stratton
+          role: Staff Developer Advocate, Pulumi
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - How to provision Azure resources with JavaScript/TypeScript.
+        - How to enable autocompletion for your Infrastructure as Code.
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 388c3a8d-b71a-42af-b78a-5820bf8d57fe
+---

--- a/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
+++ b/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
@@ -39,7 +39,7 @@ url_slug: "getting-from-code-to-cloud-with-vscode-and-pulumi"
 # The content of the hero section.
 hero:
     # The title text in the hero. This also serves as the pages H1.
-    title: ""
+    title: "Getting from code to cloud with VS Code and Pulumi"
     # The image the appears on the right hand side of the hero.
     image: "/icons/containers.svg"
 

--- a/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
+++ b/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
@@ -65,8 +65,6 @@ main:
     description: |
         For app developers, setting up infrastructure can be the hardest part of getting their app into production. What if you could just configure infrastructure using the same language you’re using to build your app? Pulumi's Matty Stratton will show you how easy it is to use Pulumi and VS Code to set up Azure (or any cloud) using JavaScript/TypeScript.
 
-        [Livestream Link](https://aka.ms/code-livestream-page)
-
     # The webinar presenters
     presenters:
         - name: Matty Stratton


### PR DESCRIPTION
Fixes https://github.com/pulumi/marketing/issues/41
Fixes https://github.com/pulumi/marketing/issues/42
Fixes https://github.com/pulumi/marketing/issues/40

This PR adds the Twilio Webinar, NGINX livestream, and the VSCode livestream to the resources page. The livestream registration form are wired into a reminder email that will be sent 30 minutes before the stream starts with a link to join. Below are links to those emails.

NGINX: https://app.hubspot.com/email/4429525/details/48880188690/performance
VSCode: https://app.hubspot.com/email/4429525/details/48880249158/performance