### PR TITLE
Filter blog tags to Top 40, and add back some metadata

### DIFF
--- a/themes/default/content/blog/amazon-ecr-public/index.md
+++ b/themes/default/content/blog/amazon-ecr-public/index.md
@@ -4,7 +4,7 @@ date: "2020-12-01"
 meta_desc: "Pulumi container images now available on Amazon ECR Public"
 meta_image: "pulumi-images-ecr.png"
 authors: ["paul-stack"]
-tags: ["aws", "containers"]
+tags: ["aws", "containers", "ecr"]
 ---
 
 At re:Invent, the AWS team unveiled the new Amazon Elastic Container Registry Public (Amazon ECR Public), creating a new

--- a/themes/default/content/blog/amazon-eks-distro/index.md
+++ b/themes/default/content/blog/amazon-eks-distro/index.md
@@ -10,6 +10,7 @@ authors:
 tags:
     - kubernetes
     - aws
+    - eks
 ---
 
 As Kubernetes grows in popularity, the number of options for Kubernetes users continues to increase. Providers of managed Kubernetes offerings will often learn lessons about operating large numbers of clusters at scale; it's increasingly common that they will contribute this knowledge back to the ecosystem, allowing those organizations who need more control and flexibility to reap the benefits.

--- a/themes/default/content/blog/announcing-crossguard-preview/index.md
+++ b/themes/default/content/blog/announcing-crossguard-preview/index.md
@@ -4,7 +4,7 @@ date: 2019-12-02
 meta_desc: "Today we are announcing Pulumi CrossGuard, a Policy as Code solution that enforces custom infrastructure policies, is available for all users to preview."
 meta_image: crossguard.svg
 authors: ["erin-krengel"]
-tags: ["policy-as-code", "features"]
+tags: ["policy-as-code", "features", "pulumi-news"]
 ---
 
 Over the past few months, we have been hard at work on Pulumi CrossGuard, a Policy as Code solution. Using CrossGuard, you can express flexible business and security rules using code. CrossGuard enables organization administrators to enforce these policies across their organization or just on specific stacks. CrossGuard allows you to verify or enforce custom policies on changes before they are applied to your resources. CrossGuard is 100% open source and available to all users of Pulumi, including the Community Edition. Advanced organization-wide policy management features are available to Team Pro and Enterprise customers.

--- a/themes/default/content/blog/announcing-enum-support/index.md
+++ b/themes/default/content/blog/announcing-enum-support/index.md
@@ -7,6 +7,11 @@ authors:
 - komal-ali
 tags:
 - features
+- enums
+- python
+- go
+- c#
+- typescript
 ---
 
 Here at Pulumi, we believe in leveraging the best features of programming languages to create a delightful development experience for our users. Today, we continue our contributions in this area by announcing cross-language support for `enum` types in our provider SDKs, available in all Pulumi languages - Python, TypeScript, .NET and Go.

--- a/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
+++ b/themes/default/content/blog/architect-aws-application-infra-with-pulumi-stack-references/index.md
@@ -5,7 +5,7 @@ date: "2019-10-17"
 meta_desc: "How to architect your AWS infrastructure to optimize team collaboration with Pulumi Stack References"
 meta_image: "application-architecture.png"
 authors: ["paul-stack"]
-tags: ["AWS"]
+tags: ["aws", "stack-reference"]
 ---
 
 In this post, we will talk about the best way to architect your Pulumi applications. We are going to build out the following

--- a/themes/default/content/blog/architecture-as-code-intro/index.md
+++ b/themes/default/content/blog/architecture-as-code-intro/index.md
@@ -6,9 +6,10 @@ meta_image: architecture.png
 authors:
     - sophia-parafina
 tags:
-    - Kubernetes
+    - kubernetes
     - serverless
     - architecture-as-code
+    - microservices
 ---
 
 Abstraction is key to building resilient systems because it encapsulates behavior and decouples code, letting each component perform its function independently. The same principles apply to infrastructure, where we want to declare behavior or state and not implementation details. As an industry, we've moved away from monolithic applications to distributed systems such as serverless, microservices, Kubernetes, and virtual machine deployments. In this article, we'll take a closer look at the characteristics of these architectures and how Pulumi can abstract the components that comprise these systems.

--- a/themes/default/content/blog/architecture-as-code-microservices/index.md
+++ b/themes/default/content/blog/architecture-as-code-microservices/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - architecture-as-code
+    - microservices
 ---
 
 This article is the third in a series about Architecture as Code. The [first article]({{< relref "/blog/architecture-as-code-intro">}}) provided an overview of virtual machines, microservices, serverless, and Kubernetes. The [second]({{< relref "/blog/architecture-as-code-vm" >}}) one went in-depth on deploying virtual machines as reusable components. In this third installment, we'll look at microservices and how to implement them as reusable components with Pulumi.

--- a/themes/default/content/blog/architecture-as-code-vm/index.md
+++ b/themes/default/content/blog/architecture-as-code-vm/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - architecture-as-code
+    - virtual-machines
 ---
 
 In a [previous article]({{< relref "/blog/architecture-as-code-intro" >}}), we presented an overview of four infrastructure patterns for deploying modern applications. The article reviewed virtual machines, serverless, Kubernetes, and microservices. In this post, we'll examine virtual machines in-depth.

--- a/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
+++ b/themes/default/content/blog/auditing-your-organizations-infrastructure-as-code-activity/index.md
@@ -4,7 +4,7 @@ date: "2020-02-20"
 meta_desc: "Pulumi now supports Audit Logs. Learn how to audit your organization's infrastructure as code activity"
 meta_image: "auditlogs.png"
 authors: ["sean-holung"]
-tags: ["features", "pulumi-enterprise"]
+tags: ["features", "pulumi-enterprise", "audit-logs"]
 ---
 
 We are excited to announce the release of Audit Logs on

--- a/themes/default/content/blog/automation-api-as-platform/index.md
+++ b/themes/default/content/blog/automation-api-as-platform/index.md
@@ -6,7 +6,7 @@ meta_image: automation_api.png
 authors:
     - sophia-parafina
 tags:
-    - Automation API
+    - automation-api
 ---
 
 If you could create infrastructure without using a cloud provider's console, a CLI, or a templating engine, what would you build? Pulumi's Automation API lets you create declarative infrastructure defined by your best practices and expose it behind a REST, gRPC, or custom API.

--- a/themes/default/content/blog/aws-eks-managed-nodes-fargate/index.md
+++ b/themes/default/content/blog/aws-eks-managed-nodes-fargate/index.md
@@ -2,7 +2,7 @@
 title: "AWS EKS - How to Scale Your Cluster"
 h1: "How to Scale Your Amazon EKS Cluster: EC2, Managed Node Groups, and Fargate"
 authors: ["joe-duffy"]
-tags: ["AWS", "Kubernetes"]
+tags: ["aws", "kubernetes", "eks"]
 meta_desc: "Pulumi supports simplify the scaling your Elastic Kubernetes Service (EKS) clusters with Managed Node Groups and Fargate."
 date: "2019-12-05"
 meta_image: "pulumi-eks-fargate.png"

--- a/themes/default/content/blog/aws-lambda-efs/index.md
+++ b/themes/default/content/blog/aws-lambda-efs/index.md
@@ -6,8 +6,10 @@ meta_image: aws-lambda-efs.png
 authors:
     - luke-hoban
 tags:
-    - AWS
+    - aws
     - serverless
+    - lambda
+    - efs
 ---
 
 Ever since AWS Lambda was released in 2015, users have wanted persistent file storage beyond the small 512MB `/tmp` disk allocated to each Lambda function.  The following year, Amazon launched EFS,  offering a simple managed file system service for AWS, but initially only available to mount onto Amazon EC2 instances. Over the last few months, AWS has been extending access to EFS to all of the modern compute offerings.  First [EKS](https://aws.amazon.com/about-aws/whats-new/2019/09/amazon-eks-announces-beta-release-of-amazon-efs-csi-driver/) for Kubernetes, then [ECS and Fargate](https://aws.amazon.com/about-aws/whats-new/2020/04/amazon-ecs-aws-fargate-support-amazon-efs-filesystems-generally-available/) for containers.  Today, AWS announced that [EFS is now also supported in Lambda](https://aws.amazon.com/blogs/aws/new-a-shared-file-system-for-your-lambda-functions/), providing easy access to network file systems from your serverless functions.

--- a/themes/default/content/blog/aws-serverless-analytics/index.md
+++ b/themes/default/content/blog/aws-serverless-analytics/index.md
@@ -1,7 +1,7 @@
 ---
 title: "AWS Serverless Analytics"
 authors: ["evan-boyle"]
-tags: ["AWS", "data-and-analytics"]
+tags: ["aws", "data-and-analytics", "serverless", "architecture-as-code"]
 date: "2020-01-30"
 meta_desc: "Building a serverless data warehouse on AWS using architecture as code."
 meta_image: "ServerlessArchitecture.png"

--- a/themes/default/content/blog/bigdata-boutique-guest-post/index.md
+++ b/themes/default/content/blog/bigdata-boutique-guest-post/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - guest-post
     - testing
+    - elasticsearch
 
 ---
 

--- a/themes/default/content/blog/build-publish-containers-iac/index.md
+++ b/themes/default/content/blog/build-publish-containers-iac/index.md
@@ -2,7 +2,7 @@
 title: "Build and publish container images to any cloud with Infrastructure as Code"
 allow_long_title: True
 authors: ["joe-duffy"]
-tags: ["containers", "Kubernetes"]
+tags: ["containers", "docker", "Kubernetes"]
 meta_desc: "Go from Dockerfile to a fully running containerized service on your cloud of choice using infrastructure as code."
 date: "2020-12-08"
 meta_image: "containers.png"

--- a/themes/default/content/blog/cicd-pipelines-with-codefresh-and-pulumi/index.md
+++ b/themes/default/content/blog/cicd-pipelines-with-codefresh-and-pulumi/index.md
@@ -8,6 +8,7 @@ authors:
     - kostis-kapelonis
 tags:
     - continuous-delivery
+    - codefresh
     - Kubernetes
 
 ---

--- a/themes/default/content/blog/controlling-aws-costs-with-lambda-and-pulumi/index.md
+++ b/themes/default/content/blog/controlling-aws-costs-with-lambda-and-pulumi/index.md
@@ -2,7 +2,7 @@
 date: "2020-04-09"
 title: "Controlling AWS Costs with Pulumi and AWS Lambda"
 authors: ["paul-stack"]
-tags: ["AWS", "serverless"]
+tags: ["aws", "serverless", "lambda"]
 meta_desc: "Learn how to use Pulumi and AWS Lambda to create and deploy an application that can control cloud costs."
 meta_image: "cost.png"
 ---

--- a/themes/default/content/blog/create-eks-clusters-in-your-favorite-language/index.md
+++ b/themes/default/content/blog/create-eks-clusters-in-your-favorite-language/index.md
@@ -8,6 +8,7 @@ authors:
     - levi-blackstone
 tags:
     - aws
+    - eks
     - .net
     - python
     - go

--- a/themes/default/content/blog/create-secure-jupyter-notebooks-on-kubernetes-using-pulumi/index.md
+++ b/themes/default/content/blog/create-secure-jupyter-notebooks-on-kubernetes-using-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Create Secure Jupyter Notebooks on Kubernetes using Pulumi"
 authors: ["nishi-davidson"]
-tags: ["Kubernetes","google-cloud","data-and-analytics"]
+tags: ["Kubernetes", "google-cloud", "gke", "data-and-analytics", "jupyter"]
 meta_desc: "In this blog, we'll walk through how to use Pulumi to create Jupyter Notebooks on Kubernetes. "
 date: "2019-05-30"
 

--- a/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
+++ b/themes/default/content/blog/creating-a-python-aws-application-using-flask-and-redis/index.md
@@ -4,7 +4,7 @@ date: 2020-08-13T15:06:26-07:00
 meta_desc: A tutorial on how to create a Python AWS application using Flask, Redis, and Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "containers"]
+tags: ["aws", "python", "containers", "docker", "ecs"]
 ---
 
 *Meet Vova Ivanov---one of the Pulumi summer interns. He'll be writing about his experiences learning Pulumi while modernizing a web app and its underlying infrastructure.*

--- a/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
+++ b/themes/default/content/blog/creating-and-reusing-cloud-components-using-package-managers/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Creating and Reusing Cloud Components using Package Managers"
 authors: ["chris-smith"]
-tags: [packages]
+tags: ["packages", "architecture-as-code"]
 meta_desc: "Pulumi's code-centric approach to infrastructure can make you more productive programming the cloud. Package up, share, and reuse our code."
 date: "2018-08-09"
 

--- a/themes/default/content/blog/cumundi-guest-post/index.md
+++ b/themes/default/content/blog/cumundi-guest-post/index.md
@@ -7,6 +7,7 @@ authors:
     - ringo-de-smet
 tags:
     - aliases
+    - refactoring
 ---
 
 **Guest Article:** [Ringo De Smet](https://www.linkedin.com/in/ringodesmet/), Founder of Cumundi, standardizes on Pulumi for writing infrastructure as reusable code libraries for his customers. Pulumi enables him to rapidly iterate through the build-test-release cycle of these building blocks.

--- a/themes/default/content/blog/data-science-in-the-cloud/index.md
+++ b/themes/default/content/blog/data-science-in-the-cloud/index.md
@@ -7,8 +7,10 @@ authors:
     - sophia-parafina
 tags:
     - data-and-analytics
-    - Automation API
-    - Python
+    - automation-api
+    - python
+    - jupyter
+    - data-science
 ---
 
 Data science has advanced because tools like Jupyter Notebook hide complexity by running high level code for the specific problem they are trying to solve. Increasing the level of abstraction lets a data scientist be more productive by reducing the effort to try multiple approaches to near zero, which encourages experimentation and better results.

--- a/themes/default/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
+++ b/themes/default/content/blog/data-science-on-demand-spinning-up-a-wallaroo-cluster-is-easy-with-pulumi/index.md
@@ -5,7 +5,7 @@ date: "2018-11-02"
 meta_desc: "Find out how Wallaroo powered their cluster provisioning with Pulumi, for data science on demand."
 meta_image: "tty-fast.gif"
 authors: ["marc-holmes", "simon-zelazny"]
-tags: ["guest-post"]
+tags: ["guest-post", "data-science"]
 ---
 
 *This guest post is from Simon Zelazny of

--- a/themes/default/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
+++ b/themes/default/content/blog/day-2-kubernetes-migrating-eks-nodegroups-with-zero-downtime/index.md
@@ -2,7 +2,7 @@
 title: "Day 2 Kubernetes: Migrate EKS Node Groups with Zero Downtime"
 h1: "Day 2 Kubernetes: Migrating EKS Node Groups with Zero Downtime"
 authors: ["mike-metral"]
-tags: ["Kubernetes"]
+tags: ["Kubernetes", "eks"]
 meta_desc: "Use Pulumi's for Day 2 Kubernetes. Spin up a new EKS cluster, add one more node groups, and migrate the workloads with zero downtime using code and kubectl."
 date: "2019-07-23"
 

--- a/themes/default/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
+++ b/themes/default/content/blog/delivering-cloud-native-infrastructure-as-code-a-pulumi-white-paper/index.md
@@ -5,7 +5,7 @@ date: "2018-12-05"
 meta_desc: "In our latest white paper, Delivering Cloud Native Infrastructure as Code, we make the case for a consistent programming model for the cloud."
 meta_image: "graph.png"
 authors: ["marc-holmes"]
-tags: ["pulumi-news"]
+tags: ["pulumi-news", "cloud-native"]
 ---
 
 **Enterprise software has undergone a slow shift from containerless

--- a/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-django-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-08-28
 meta_desc: Using Pulumi to create and deploy a simple Django MySQL application to AWS
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python", "containers"]
+tags: ["aws", "python", "containers", "docker", "mysql"]
 ---
 
 In this blog post, we will finish swapping out the frontend and backend of our [Python AWS application]({{< relref "/blog/creating-a-python-aws-application-using-flask-and-redis" >}}). Although Flask and Redis are different from Django and MySQL in many ways, the underlying infrastructure behind their deployment is nonetheless very similar, and can be effortlessly updated as we transition from one to the other.

--- a/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
+++ b/themes/default/content/blog/deploying-a-pern-stack-application-to-aws/index.md
@@ -4,7 +4,7 @@ date: 2020-09-04
 meta_desc: Creating and quickly deploying a PERN stack application to the cloud Using Pulumi
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "containers"]
+tags: ["aws", "typescript", "containers", "docker"]
 ---
 
 In this blog post, we will explore PERN stack applications and deploy one to AWS. *PERN* is an acronym for PostgreSQL, Express, React, and Node. A PERN stack application is a project that uses PostgreSQL, Express as an application framework, React as a user interface framework, and runs on Node. We will also use [Pulumi Crosswalk]({{< relref "/docs/guides/crosswalk/aws" >}}) to reduce the amount of code and provide a quick and straightforward path for deploying the application.

--- a/themes/default/content/blog/deploying-minecraft-on-azure/index.md
+++ b/themes/default/content/blog/deploying-minecraft-on-azure/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - Azure
+    - virtual-machines
 ---
 
 This article demonstrates how to deploy and provision a virtual machine in Azure using the Pulumi [Azure-Native provider]({{< relref "/blog/full-coverage-of-azure-resources-with-azure-native" >}}). While there are numerous examples of using the Azure console, the Azure CLI, or ARM templates to deploy and provision virtual machines, we'll use Python to implement a repeatable deployment.

--- a/themes/default/content/blog/deploying-mysql-schemas-using-dynamic-providers/index.md
+++ b/themes/default/content/blog/deploying-mysql-schemas-using-dynamic-providers/index.md
@@ -4,7 +4,7 @@ date: 2020-08-18
 meta_desc: Leveraging Pulumi Dynamic Providers to expand opportunities in cloud architecture design
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "python"]
+tags: ["aws", "python", "mysql"]
 ---
 
 In our [previous post]({{< relref "/blog/creating-a-python-aws-application-using-flask-and-redis" >}}), we created a Python voting application using Flask and Redis. This blog post will explore creating a MySQL database and initializing it with a schema and data. What seems to be a simple step is much more interesting than it appears, because Pulumi's MySQL provider does not support creating and populating tables. To do it, we will extend it with a Dynamic Provider.

--- a/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
+++ b/themes/default/content/blog/deploying-netlify-cms-on-aws/index.md
@@ -5,7 +5,7 @@ draft: false
 meta_desc: "Implementing Netlify CMS without Netlify, deploying the Netlify CMS on AWS."
 meta_image: cms.png
 authors: ["zephyr-zhou"]
-tags: ["aws", "github-actions"]
+tags: ["aws", "github-actions", "netlify", "s3", "cloudfront", "certificate-manager", "route53"]
 ---
 
 [Netlify CMS](https://www.netlifycms.org/docs/intro/) is an open-source content management system that provides UI for editing content and adopting Git workflow. Initially, we want to take advantage of it to increase efficiency to edit Pulumi's website. However, during development, we found few examples are deploying the CMS application on AWS instead of Netlify, its home platform. Therefore, in this blog post, we would like to share how to organize Netlify's file structure and use Pulumi to store the content on S3 buckets, connect to CloudFront, and configure certificate in Certificate Manager.

--- a/themes/default/content/blog/deploying-the-infrastructure-of-oauth-server-for-cms-app/index.md
+++ b/themes/default/content/blog/deploying-the-infrastructure-of-oauth-server-for-cms-app/index.md
@@ -5,7 +5,7 @@ draft: false
 meta_desc: "Implementing and deploying an OAuth server for Netlify CMS on Fargate."
 meta_image: cms-oauth.png
 authors: ["zephyr-zhou"]
-tags: ["aws","github-actions"]
+tags: ["aws","github-actions", "netlify", "oauth", "ecs", "fargate"]
 ---
 
 In our [previous post]({{< relref "/blog/deploying-netlify-cms-on-aws" >}}), we deployed our CMS app on AWS instead of Netlify. We couldn't use [Netlify's Identity Service](https://docs.netlify.com/visitor-access/identity/#enable-identity-in-the-ui), which manages GitHub access to Netlify CMS, because we deployed on AWS. As a result, we needed to implement an external [OAuth Server](https://www.netlifycms.org/docs/external-oauth-clients/#header).

--- a/themes/default/content/blog/deploying-with-octopus-and-pulumi/index.md
+++ b/themes/default/content/blog/deploying-with-octopus-and-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Continuous Delivery on Octopus Deploy using Pulumi"
 authors: ["sophia-parafina"]
-tags: ["continuous-delivery"]
+tags: ["continuous-delivery", "octopus"]
 meta_image: "octopus-pulumi.png"
 meta_desc: "Continuous delivery of Pulumi apps with Octopus Deploy "
 date: "2019-10-22"

--- a/themes/default/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
+++ b/themes/default/content/blog/easily-create-and-manage-aws-eks-kubernetes-clusters-with-pulumi/index.md
@@ -10,6 +10,7 @@ authors:
 tags:
   - aws
   - kubernetes
+  - eks
 ---
 
 Provisioning, managing, and monitoring a Kubernetes cluster is

--- a/themes/default/content/blog/eks-oidc/index.md
+++ b/themes/default/content/blog/eks-oidc/index.md
@@ -2,7 +2,7 @@
 date: "2020-06-02"
 title: "Access Control for Pods on Amazon EKS"
 authors: ["mike-metral"]
-tags: ["aws", "Kubernetes"]
+tags: ["aws", "Kubernetes", "eks", "rbac"]
 meta_desc: "Amazon EKS clusters can use IAM roles and policies for Pods to assign fine-grained access control of AWS services."
 meta_image: cluster.png
 ---

--- a/themes/default/content/blog/getting-started-with-pac/index.md
+++ b/themes/default/content/blog/getting-started-with-pac/index.md
@@ -7,6 +7,8 @@ authors:
     - sophia-parafina
 tags:
     - policy-as-code
+    - s3
+    - elasticsearch
 ---
 
 Modern applications have brought many benefits and improvements, including the ability to scale and rapid iterations to update software. However, this has come at the cost of complexity. Modern infrastructure is composed of many resources that require detailed configuration to work correctly and securely. Even managed solutions from cloud service providers need additional configuration to ensure that services are secure and free of defects. Cloud providers, such as AWS, do allow you to create policies to ensure that applications are secure, but they are specific to resources that are already deployed. A significant benefit of Policy as Code is the ability to verify and spot problems before deploying your infrastructure.

--- a/themes/default/content/blog/github-token-scanning-service/index.md
+++ b/themes/default/content/blog/github-token-scanning-service/index.md
@@ -2,7 +2,7 @@
 title: GitHub & Pulumi Join Forces To Ensure Pulumi Tokens Are Safe
 h1: "GitHub And Pulumi Join Forces To Ensure Your Pulumi Tokens Are Safe"
 authors: ["praneet-loke"]
-tags: ["Security"]
+tags: ["Security", "GitHub"]
 date: "2019-08-19"
 
 meta_desc: "Protect your Pulumi Access Tokens with GitHub Token Scanning."

--- a/themes/default/content/blog/gitlab-project-integration/index.md
+++ b/themes/default/content/blog/gitlab-project-integration/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Amp-up GitLab Merge Requests With Pulumi"
 authors: ["praneet-loke"]
-tags: [continuous-delivery]
+tags: ["continuous-delivery", "gitlab"]
 date: "2020-08-26"
 meta_desc: "We are excited to announce the launch of first-class support for integrating GitLab Merge Requests with Pulumi."
 meta_image: pulumi_gitlab.png

--- a/themes/default/content/blog/how-to-registries/index.md
+++ b/themes/default/content/blog/how-to-registries/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - containers
+    - docker
 ---
 
 Whether you are working with Kubernetes or serverless, your application uses containers. If you use the Docker desktop client, images are pushed to Docker Hub by default. Pulling images from Docker Hub is convenient, but there are many reasons to store images in your own registry. For example, Docker Hub doesn’t guarantee to produce the same image on repeated pulls, i.e., your base image might have changed. It’s also possible to inadvertently expose secrets in an intermediate image used to build the image stored on Docker Hub. There is also the possibility of vulnerabilities in even official images. This article shows how to create a repository and how to build and push images to that repository

--- a/themes/default/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
+++ b/themes/default/content/blog/if-you-liked-ksonnet-youll-love-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-02-13"
 meta_desc: "Like ksonnet, Pulumi provides complete access to the raw Kubernetes API, and supports additional features like modules/imports, components, functions, and more."
 meta_image: "kube-update.gif"
 authors: ["mike-metral"]
-tags: ["Kubernetes"]
+tags: ["Kubernetes", "cloud-native"]
 ---
 
 The Kubernetes landscape is constantly evolving as end users and

--- a/themes/default/content/blog/introducing-new-docker-images/index.md
+++ b/themes/default/content/blog/introducing-new-docker-images/index.md
@@ -8,6 +8,7 @@ authors:
     - lee-briggs
 tags:
     - features
+    - docker
 
 ---
 

--- a/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
+++ b/themes/default/content/blog/introducing-pulumi-crosswalk-for-aws-the-easiest-way-to-aws/index.md
@@ -4,7 +4,7 @@ date: "2019-06-10"
 meta_desc: "Pulumi Crosswalk for AWS is an open source library of infrastructure-as-code components that make it easier to get from zero to production on AWS."
 meta_image: "crosswalk-for-aws.png"
 authors: ["luke-hoban"]
-tags: ["Serverless","AWS","containers","pulumi-news","Kubernetes","containers"]
+tags: ["Serverless","AWS","containers","pulumi-news","Kubernetes","containers", "eks", "lambda", "api-gateway", "docker"]
 ---
 
 Amazon Web Services provides an incredible platform for developers to

--- a/themes/default/content/blog/jamstack-with-pulumi/index.md
+++ b/themes/default/content/blog/jamstack-with-pulumi/index.md
@@ -7,6 +7,7 @@ authors:
     - sophia-parafina
 tags:
     - aws
+    - jamstack
 ---
 
 A Jamstack is a modern architecture for building websites; JAM stands for JavaScript, APIs, and Markup. Jamstacks are deployed on a [CDN](https://en.wikipedia.org/wiki/Content_delivery_network), and content is stored on a cloud services provider. In addition to the speed and simplicity of deploying static content served from a CDN, there are other advantages such as maintaining content with git, modern build tools to generate the static content, automated builds, atomic deploys, and instant cache validation.

--- a/themes/default/content/blog/kenshoo-migrates-to-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/kenshoo-migrates-to-aws-with-pulumi/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - AWS
     - guest-post
+    - migration
 ---
 
 > Danny Zalkind is the DevOps group manager for Kenshoo, an award-winning intelligent marketing platform. He brings his 15 years of exprience of managing tech teams to his current role where he's dedicated to allow Kenshoo R&D to efficiently produce and serve software. You can find him on [Linkedin](https://www.linkedin.com/in/danny-zalkind-01602b56/).

--- a/themes/default/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
+++ b/themes/default/content/blog/kubernetes-ingress-with-aws-alb-ingress-controller-and-pulumi-crosswalk/index.md
@@ -5,7 +5,7 @@ date: "2019-07-09"
 meta_desc: "In this post, we work through a simple example of running ALB based Kubernetes Ingresses with Pulumi EKS, AWS, and AWSX packages."
 meta_image: "featured-img-albingresscontroller.png"
 authors: ["nishi-davidson"]
-tags: ["Kubernetes"]
+tags: ["Kubernetes", "eks"]
 ---
 
 [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)

--- a/themes/default/content/blog/kubernetes-yaml-generation/index.md
+++ b/themes/default/content/blog/kubernetes-yaml-generation/index.md
@@ -8,6 +8,7 @@ authors:
     - levi-blackstone
 tags:
     - kubernetes
+    - yaml
     
 ---
 

--- a/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-containers-on-aws-with-pulumi/index.md
@@ -8,6 +8,9 @@ authors:
 tags:
     - AWS
     - containers
+    - eks
+    - ecs
+    - lambda
 ---
 
 The Amazon Web Services (AWS) Cloud ecosystem is large and vibrant, so vast and vibrant that at times, it can be challenging to know where best to start! In the case of [containers](https://www.pulumi.com/containers/), [Abby Fuller](https://twitter.com/abbyfuller) tweeted a descriptive summary about using AWS container services.

--- a/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-f5-big-ip-systems-with-pulumi/index.md
@@ -3,7 +3,7 @@ title: "Managing F5 BIG-IP Systems with Pulumi"
 date: "2019-02-07"
 meta_desc: "In this post, we look at what's possible the F5 BIG-IP provider for Pulumi, as well as the power and the flexibility that Pulumi brings."
 authors: ["cameron-stokes"]
-tags: ["features"]
+tags: ["features", "cloud-native"]
 ---
 
 The [Pulumi](/) ecosystem is continuously growing

--- a/themes/default/content/blog/managing-github-webhooks-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-github-webhooks-with-pulumi/index.md
@@ -93,7 +93,7 @@ webhook and fill in my information:
   [random.org](https://www.random.org/) to do so, but any random
   string will suffice. We'll use this string to validate that the
   request came from GitHub.
-- pulumi-events: I only care about `pull_request` events, so I picked "Let me
+- Events: I only care about `pull_request` events, so I picked "Let me
   select individual events" and then checked "Pull requests" and
   unchecked the other event types.
 - Active: Since we want GitHub to deliver events, we'll keep this

--- a/themes/default/content/blog/managing-your-mysql-databases-with-pulumi/index.md
+++ b/themes/default/content/blog/managing-your-mysql-databases-with-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-05-28"
 meta_desc: "In this post, we'll walk through a quick tutorial of how to use the Pulumi MySQL provider to manage new and existing MySQL databases."
 meta_image: "hero.png"
 authors: ["linio-engineering"]
-tags: [guest-post]
+tags: ["guest-post", "mysql"]
 ---
 
 One of the most critical components of an application’s infrastructure is its

--- a/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
+++ b/themes/default/content/blog/migrating-a-cloud-application-to-kubernetes/index.md
@@ -4,7 +4,7 @@ date: 2020-09-14
 meta_desc: Using Pulumi to integrate applications with Kubernetes for on-demand scalability and freedom of design.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "containers", "kubernetes"]
+tags: ["aws", "typescript", "containers", "kubernetes", "docker"]
 ---
 
 In this blog post, we will explore and demonstrate the advantages of Kubernetes by converting and deploying our [PERN application]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) to Amazon EKS. With the help of Pulumi, the process becomes greatly simplified and allows us to focus more on the big picture of designing our cloud architecture.

--- a/themes/default/content/blog/multicloud-app/index.md
+++ b/themes/default/content/blog/multicloud-app/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Multicloud Kubernetes: Running Apps Across EKS, AKS, and GKE"
 authors: ["mike-metral"]
-tags: ["Kubernetes","aws", "azure", "google-cloud"]
+tags: ["Kubernetes","aws", "azure", "google-cloud", "eks", "aks", "gke"]
 meta_desc: "Run Kubernetes apps using a multicloud strategy. We'll walk through how to leverage multiple Kubernetes providers for deployments across AWS, Azure, and GCP."
 date: "2019-08-14"
 

--- a/themes/default/content/blog/observability-with-infrastructure-as-code/index.md
+++ b/themes/default/content/blog/observability-with-infrastructure-as-code/index.md
@@ -9,6 +9,8 @@ authors:
 tags:
 - guest-post
 - automation-api
+- observability
+- honeycomb
 
 meta_image: "reaktor.png"
 ---

--- a/themes/default/content/blog/opa-support-for-crossguard/index.md
+++ b/themes/default/content/blog/opa-support-for-crossguard/index.md
@@ -7,6 +7,7 @@ authors:
     - luke-hoban
 tags:
     - policy-as-code
+    - opa
 ---
 
 We're excited to announce the addition of Open Policy Agent (OPA) Rego language support to Pulumi's CrossGuard policy-as-code framework. This enables Pulumi CrossGuard policy to be authored in either JavaScript/TypeScript/Python or in the popular Rego language using OPA.

--- a/themes/default/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
+++ b/themes/default/content/blog/persisting-kubernetes-workloads-with-amazon-efscsi-volumes-using-pulumi-sdks/index.md
@@ -3,7 +3,7 @@ title: "Persisting Kubernetes workloads with Amazon EFS CSI volumes"
 title_tag: "Persisting Kubernetes workloads with Amazon EFS CSI volumes"
 date: "2019-07-15"
 authors: ["nishi-davidson"]
-tags: ["AWS", "Kubernetes"]
+tags: ["AWS", "Kubernetes", "eks"]
 meta_desc: "In this blog, we will show how to use AWS EFS CSI storage components with Kubernetes workloads running on Amazon EKS worker nodes (EKS, AWS, and AWSX)."
 meta_image: "featured-img-efs-csi-driver.png"
 ---

--- a/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
+++ b/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
@@ -4,7 +4,7 @@ date: "2019-04-24"
 meta_desc: "With Pulumi's new AWSX package, you can quickly define a Lambda and an AWS Lambda authorizer to protect it in three easy steps."
 meta_image: "lambda-authorizer.jpg"
 authors: ["erin-krengel"]
-tags: ["Serverless","AWS"]
+tags: ["Serverless","AWS", "lambda", "api-gateway"]
 ---
 
 Creating serverless applications just got even easier! You can now

--- a/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
+++ b/themes/default/content/blog/pulumi-and-docker-development-to-production/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Pulumi and Docker: Development to Production"
 authors: ["sean-gillespie"]
-tags: ["containers","Kubernetes","containers"]
+tags: ["containers","Kubernetes","docker"]
 date: "2019-05-15"
 meta_desc: "Use Pulumi's infrastructure as software capability to define your Docker resources without running YAML or Docker Compose."
 

--- a/themes/default/content/blog/pulumi-auth0/index.md
+++ b/themes/default/content/blog/pulumi-auth0/index.md
@@ -8,6 +8,7 @@ authors:
     - fernando-carletti
 tags:
     - guest-post
+    - auth0
 ---
 
 *Guest author Lead Devops Engineer Fernando Carletti, writes about using the Pulumi Auth0 provider to manage resources at Credijusto.*

--- a/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
+++ b/themes/default/content/blog/pulumi-import-generate-iac-for-existing-cloud-resources/index.md
@@ -4,7 +4,7 @@ date: "2020-11-24"
 meta_desc: "Introducing the new pulumi import command that will automatically scaffold your Pulumi application code when importing existing cloud resources."
 meta_image: cloud_engineering.png
 authors: ["paul-stack"]
-tags: ["features", "features"]
+tags: ["features", "migration", "import"]
 ---
 
 Most infrastructure projects require working with existing cloud resources, either by building on top of existing resources

--- a/themes/default/content/blog/pulumi-kubernetes-operator/index.md
+++ b/themes/default/content/blog/pulumi-kubernetes-operator/index.md
@@ -2,7 +2,7 @@
 date: "2020-08-12"
 title: "Introducing the Pulumi Kubernetes Operator"
 authors: ["mike-metral"]
-tags: ["Kubernetes", "Continuous-Delivery"]
+tags: ["Kubernetes", "Continuous-Delivery", "operators"]
 meta_desc: "Introducing the Pulumi Kubernetes Operator: Deploy infrastructure in Pulumi Stacks"
 meta_image: operator.png
 ---

--- a/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
+++ b/themes/default/content/blog/pulumi-with-aiven-for-influxdb/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - aws
     - python
+    - aiven
 ---
 
 In this article, I’ll show how Pulumi can be used with Aiven’s services to create infrastructure that can be migrated from cloud to cloud with no downtime.

--- a/themes/default/content/blog/rabbitMQ-azure/index.md
+++ b/themes/default/content/blog/rabbitMQ-azure/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - Azure
     - .NET
+    - rabbitmq
 
 ---
 

--- a/themes/default/content/blog/reduce-cloud-costs-with-ARM/index.md
+++ b/themes/default/content/blog/reduce-cloud-costs-with-ARM/index.md
@@ -7,6 +7,8 @@ authors:
     - sophia-parafina
 tags:
     - AWS
+    - ec2
+    - virtual-machines
 ---
 
 Whether you're migrating to the cloud or have existing infrastructure, cloud spend can be a significant barrier to your success. Too small of a budget could prevent your organization from meeting your performance metrics. You can use different strategies to reduce cloud spend, such as using [Spot Instances](https://aws.amazon.com/ec2/spot/), which cost less than On-Demand Instances or scaling your infrastructure based on peak usage times.

--- a/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
+++ b/themes/default/content/blog/running-containers-in-aws-the-lowdown-ecs-fargate-and-eks/index.md
@@ -1,7 +1,7 @@
 ---
 title: "ECS vs Fargate vs EKS: The Lowdown on Containers in AWS"
 authors: ["joe-duffy"]
-tags: ["AWS","containers","Kubernetes"]
+tags: ["AWS","containers","Kubernetes","ecs", "eks", "fargate"]
 date: "2019-06-20"
 meta_desc: "Use Pulumi's infrastucture-as-code approach to simplify working with ECS Fargate, ECS with EC2 instances, and EKS."
 meta_image: "pulumi-crosswalk-for-aws.png"

--- a/themes/default/content/blog/scheduling-serverless/index.md
+++ b/themes/default/content/blog/scheduling-serverless/index.md
@@ -7,6 +7,7 @@ authors:
     - cyrus-najmabadi
 tags:
     - serverless
+    - lambda
 ---
 
 Scheduling events has long been an essential part of automation; many tasks need to run at specific times or intervals. You could be checking StackOverflow for new questions every 20 minutes or compiling a report that is emailed every other Friday at 4:00 pm. Today, many of these tasks can be efficiently accomplished in the cloud. While each cloud has its flavor of scheduled functions, this post steps you through an example using [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) with the help of Pulumi.

--- a/themes/default/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
+++ b/themes/default/content/blog/simplify-kubernetes-rbac-in-amazon-eks-with-open-source-pulumi-packages/index.md
@@ -2,7 +2,7 @@
 title: "Kubernetes RBAC in AWS EKS with open source Pulumi packages"
 h1: "Simplify Kubernetes RBAC in Amazon EKS with open source Pulumi packages"
 authors: ["nishi-davidson"]
-tags: ["AWS","Kubernetes","TypeScript"]
+tags: ["AWS","Kubernetes","TypeScript","EKS"]
 date: "2019-04-24"
 meta_desc: "This post contrasts the traditional approach with Pulumi's modern method for simplifying Kubernetes RBAC in Amazon EKS."
 ---

--- a/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
+++ b/themes/default/content/blog/switching-the-application-stack-from-pern-to-mern/index.md
@@ -4,7 +4,7 @@ date: 2020-09-18
 meta_desc: Demonstrating the simplicity, modularity, and reusability of running an application on Kubernetes using Pulumi.
 meta_image: meta.png
 authors: ["vova-ivanov"]
-tags: ["aws", "typescript", "containers", "kubernetes"]
+tags: ["aws", "typescript", "containers", "kubernetes", "docker"]
 ---
 
 In this blog post, we return to the PERN application we previously [migrated to Kubernetes]({{< relref "/blog/deploying-a-pern-stack-application-to-aws" >}}) and replace the PostgreSQL database with MongoDB. Although it might seem like a difficult task initially, the straightforward design of Pulumi and Kubernetes allows us to easily transition the application form a PERN stack to a MERN one.

--- a/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
+++ b/themes/default/content/blog/unlocking-spinnaker-with-pulumi/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Unlocking Spinnaker With Pulumi"
 authors: ["praneet-loke"]
-tags: ["continuous-delivery"]
+tags: ["continuous-delivery","spinnaker"]
 date: "2020-06-18"
 meta_desc: "We are excited to announce the launch of free, open-source Pulumi plugin for Spinnaker."
 meta_image: pulumi-spinnaker.png

--- a/themes/default/content/blog/vscode-devcontainers/index.md
+++ b/themes/default/content/blog/vscode-devcontainers/index.md
@@ -8,6 +8,7 @@ authors:
 tags:
     - development-environment
     - containers
+    - docker
 ---
 
 One of the major advantages of using containers for development is reducing the need to install software and associated dependencies. Developers can start writing code without configuring a development environment that emulates production. The Visual Studio Code Remote - Containers extension lets you develop inside a container. If you want to use Pulumi’s infrastructure as code engine without installing the Pulumi CLI, this blog post is for you!

--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -44,8 +44,16 @@
         </div>
         <hr class="my-8">
         <ul class="list-none p-0 mb-4 inline-flex flex-wrap text-xs">
+            {{/* Only show the top N blog tags. We create a dict of them first so they're in alphabetical order. */}}
+            {{/* Note, we could have just deleted the other tags, but this will change over time. Also, we want  */}}
+            {{/* to preserve the metadata -- some day we might even have a "View More ..." link at the bottom... */}}
+            {{ $topTags := dict }}
+            {{ range first 40 .Site.Taxonomies.tags.ByCount }}
+                {{ $topTags = merge $topTags (dict .Name .Count) }}
+            {{ end }}
             {{ range $tag, $_ := .Site.Taxonomies.tags }}
-                {{ if $tag }}
+                {{ $count := index $topTags $tag }}
+                {{ if gt $count 0 }}
                     <li>
                         <a data-track="blog-tag-{{ $tag | urlize }}" class="tag tag-blog text-xs {{ if eq (lower $tag) (urlize ((lower $.Title))) }} active {{ end }}" href="{{ .Page.Permalink }}">
                             {{ $tag }}


### PR DESCRIPTION
In #215, [I had suggested](https://github.com/pulumi/pulumi-hugo/pull/215#issuecomment-840917671) that instead of physically deleting tags we didn't want to show, we compute it algorithmically, by only showing the "Top N" tags. It wasn't clear if this was possible, but alas, it is! This commit introduces said functionality.

This has a few advantages:

* Preserves old metadata (the authors added the tags because they felt they were meaningful and captured information about the posts).

* Enables us to surface those tags differently in the future (who knows, maybe someday we'll want to run a "spinnaker" campaign).

* Notably, also keeps the tag index pages, which Google has indexed.

* Enables us to add a "View More ..." link at the bottom of the page if folks want to see the entire list.

* Perhaps most importantly, protects against future bloat. For example, since this tag cleanup happened, we have added top-level tags for "aliases", "app-runner", "iam", "open-source", and "refactoring", each of which has only a single post.

I chose 40 as the N in Top N, because that's how many we show today. I could see an argument for filtering this based on post count instead (e.g., only those with >3 posts).

The change also adds back some of the previous tags now that we filter out the unpopular ones. I preserved all of the great cleanup that happened in that change and elided many that were clearly superfluous and/or unhelpful.