### PR TITLE
Make the Pulumi SDK reference docs more visible

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -91,3 +91,23 @@ reference:
     parent: cli
     url: /docs/reference/cli/pulumi_whoami/
     weight: 18
+
+  - name: Node.js
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/nodejs/pulumi/pulumi
+    weight: 1
+
+  - name: Python
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/python/pulumi
+    weight: 2
+
+  - name: Go
+    parent: Pulumi SDK
+    url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
+    weight: 3
+
+  - name: .NET Core
+    parent: Pulumi SDK
+    url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
+    weight: 4

--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -238,6 +238,13 @@ Although you can use any editor, [Visual Studio Code](https://code.visualstudio.
 
 ## Pulumi Programming Model
 
+The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using
+Pulumi. [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}) describes these concepts
+with examples available in Python. These concepts are made available to you in the Pulumi SDK.
+
+The Pulumi SDK is available to .NET Core developers as a Nuget package. To learn more,
+[refer to the Pulumi SDK Reference Guide](/docs/reference/pkg/dotnet/Pulumi/Pulumi.html).
+
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with .NET and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/inputs-outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
 
 ## Continuous Delivery

--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -53,4 +53,11 @@ This `go` template is cloud agnostic, and you will need to install additional Go
 
 ## Pulumi Programming Model
 
+The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using
+Pulumi. [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}) describes these concepts
+with examples available in Python. These concepts are made available to you in the Pulumi SDK.
+
+The Pulumi SDK is available to Go developers in source form on GitHub. To learn more,
+[refer to the Pulumi SDK Reference Guide](https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi).
+
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with Go and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/inputs-outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.

--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -33,6 +33,13 @@ This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project"
 
 ## Pulumi Programming Model
 
+The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using
+Pulumi. [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}) describes these concepts
+with examples available in JavaScript and TypeScript. These concepts are made available to you in the Pulumi SDK.
+
+The Pulumi SDK is available to Node.js developers as a NPM package. To learn more, [refer to the Pulumi SDK Reference
+Guide]({{< relref "/docs/reference/pkg/nodejs/pulumi/pulumi" >}}).
+
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with JavaScript and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/inputs-outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
 
 ## Entrypoint

--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -37,6 +37,13 @@ Pulumi looks for a `python3` executable to use on `PATH`. If not found, it looks
 
 ## Pulumi Programming Model
 
+The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using
+Pulumi. [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}) describes these concepts
+with examples available in Python. These concepts are made available to you in the Pulumi SDK.
+
+The Pulumi SDK is available to Python developers as a Pip package distributed on PyPI. To learn more,
+[refer to the Pulumi SDK Reference Guide]({{< relref "/docs/reference/pkg/python/pulumi" >}}).
+
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with Python and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/inputs-outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
 
 ## Using Pulumi PyPI Packages {#pypi-packages}

--- a/themes/default/content/docs/reference/pulumi-sdk.md
+++ b/themes/default/content/docs/reference/pulumi-sdk.md
@@ -1,26 +1,27 @@
 ---
-title: Languages
-meta_desc: An overview of how to use Python, Node.js, .NET Core, and Go when writing cloud
-           applications for any Cloud Provider (AWS, Azure, GCE, Kubernetes, etc.).
+title: Pulumi SDK Reference
+linktitle: SDK Reference
+meta_desc: Documentation and examples for working with cloud providers and other services.
 menu:
-  intro:
-    identifier: languages
-    weight: 7
-
-aliases: ["/docs/reference/languages/"]
+  reference:
+    name: Pulumi SDK
+    weight: 3
 ---
 
-{{< get-started-note >}}
+The Pulumi SDK defines the core types and functions you will use in your programs
+common to all cloud provider libraries. The SDK works in tandem with the Pulumi CLI
+and engine to perform its infrastructure as code duties, and is available as a library
+in your chosen language. In addition to the core Pulumi SDK, there are additional
+helper libraries for features such as policy as code.
 
-Pulumi is a multi-language infrasructure as code tool. Each language is as capable as the
-other and supports the entire surface area of [all of the clouds available in Pulumi](
-{{< relref "/docs/intro/cloud-providers" >}}).
+> For a conceptual overview of how to use the primitives available in these libraries,
+> please see [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}).
 
-The following language runtimes are currently supported by Pulumi. Select one to learn more:
+Choose your language runtime to view the API documentation for the Pulumi SDK:
 
 <div class="tiles flex-wrap mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="{{< relref "./javascript" >}}">
+        <a class="tile p-8 pb-16 text-center" href="{{< relref "/docs/reference/pkg/nodejs/pulumi/pulumi" >}}">
             <p class="mx-auto text-xl font-semibold link">
                 Node.js
                 <span class="text-xs font-light">(JavaScript, TypeScript)</span>
@@ -31,7 +32,7 @@ The following language runtimes are currently supported by Pulumi. Select one to
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="{{< relref "./python" >}}">
+        <a class="tile p-8 pb-16 text-center" href="{{< relref "/docs/reference/pkg/python/pulumi" >}}">
             <p class="mx-auto text-xl font-semibold link">
                 Python
             </p>
@@ -39,7 +40,7 @@ The following language runtimes are currently supported by Pulumi. Select one to
         </a>
     </div>
     <div class="pb-4 md:pr-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="{{< relref "./go" >}}">
+        <a class="tile p-8 pb-16 text-center" href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi">
             <p class="mx-auto text-xl font-semibold link">
                 Go
             </p>
@@ -47,7 +48,7 @@ The following language runtimes are currently supported by Pulumi. Select one to
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="{{< relref "./dotnet" >}}">
+        <a class="tile p-8 pb-16 text-center" href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.html">
             <p class="mx-auto text-xl font-semibold link">
                 .NET Core
                 <span class="text-xs font-light">(C#, F#, VB)</span>
@@ -59,9 +60,3 @@ The following language runtimes are currently supported by Pulumi. Select one to
         </a>
     </div>
 </div>
-
-If your favorite language isn't listed, it may be on its way soon. Pulumi is
-[open source](https://github.com/pulumi/pulumi), and it is possible
-[to add your own language]({{< relref "/docs/troubleshooting/faq#how-can-i-add-support-for-my-favorite-language" >}}).
-For further questions, [contact us]({{< relref "/docs/troubleshooting#contact-us" >}}) and let us
-know what you're looking for.

--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -5,7 +5,7 @@ meta_desc: A list of configuration settings for the Pulumi project file.
 menu:
   reference:
     name: Project Configuration
-    weight: 3
+    weight: 4
 ---
 
 The `Pulumi.yaml` project file specifies metadata about your project, such as the project name, applicable runtime for your program, and other higher-level information.


### PR DESCRIPTION
This change adds the Pulumi SDK to the left-hand nav and
cross-links in a few more places (the language guides), while
also making them a little more visually appealing.

Fixes pulumi/docs#4523.

![image](https://user-images.githubusercontent.com/3953235/122653550-28369800-d0fa-11eb-8177-4277ba3394f5.png)
