### PR TITLE
Fix poor Python API docs formatting

### DIFF
--- a/themes/default/assets/sass/_api-python.scss
+++ b/themes/default/assets/sass/_api-python.scss
@@ -22,8 +22,8 @@ div.section[id^="pulumi"] {
     }
 }
 
-// We rely on the Python docs that begin with `<div class="section" id="foo">` to target these styles.
-div.section[id]:not([id=""]) {
+// This selector is for the Pulumi Python SDK page.
+section[id="pulumi-python-sdk"] {
     // Don't show the header link - there's an anchorjs link on this header that does the
     // job just as well.
     h1[id$="\B6"],

--- a/themes/default/assets/sass/_api-python.scss
+++ b/themes/default/assets/sass/_api-python.scss
@@ -24,6 +24,9 @@ div.section[id^="pulumi"] {
 
 // This selector is for the Pulumi Python SDK page.
 section[id="pulumi-python-sdk"] {
+    // Add a custom property just so that we can run tests to validate its presence.
+    --pulumi-python-sdk: true;
+
     // Don't show the header link - there's an anchorjs link on this header that does the
     // job just as well.
     h1[id$="\B6"],


### PR DESCRIPTION
It appears we made a change at some point that made it so that our
CSS selector no longer selected the Python API docs as intended, leading
to virtually illegible rendering of those docs. Unless I'm mistaken, we
only use these docs for the Pulumi SDK now-a-days, and not the other
providers, so the fix just targets the styles to that section.

This isn't the first time this has happened (see
https://github.com/pulumi/docs/pull/1397), so I'd love to know if there
are any ideas on what we can do to structurally avoid this breaking again!

# Example
## Before
![image](https://user-images.githubusercontent.com/3953235/122657361-bff6af00-d117-11eb-84d1-29d30578b09c.png)
## After
![image](https://user-images.githubusercontent.com/3953235/122657365-c4bb6300-d117-11eb-8bdc-95e695a66458.png)
