### PR TITLE
Fix the EKS networking example

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/aws/eks.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/eks.md
@@ -259,13 +259,13 @@ import * as awsx from "@pulumi/awsx";
 import * as eks from "@pulumi/eks";
 
 // Create a VPC for our cluster.
-const vpc = new awsx.ec2.Vpc("my-vpc");
-const allVpcSubnets = vpc.privateSubnetIds.concat(vpc.publicSubnetIds);
+const vpc = new awsx.ec2.Vpc("my-vpc", {});
 
 // Create an EKS cluster inside of the VPC.
-const cluster2 = new eks.Cluster("my-cluster", {
+const cluster = new eks.Cluster("my-cluster", {
     vpcId: vpc.id,
-    subnetIds: allVpcSubnets,
+    publicSubnetIds: vpc.publicSubnetIds,
+    privateSubnetIds: vpc.privateSubnetIds,
     nodeAssociatePublicIpAddress: false,
 });
 


### PR DESCRIPTION
This example doesn't compile. Unfortunately, the AWSX VPC constructor
appears to require an args bag, even though all properties of it are
optional. Also, the way you pass subnets seems to have changed in the
EKS class -- or maybe this was always a bug -- but the examples I
found in the EKS repo itself suggested this is the right way to do it.

Fixes #325.