### PR TITLE
Preserve Python docs CSS

### DIFF
--- a/themes/default/assets/sass/_api-python.scss
+++ b/themes/default/assets/sass/_api-python.scss
@@ -11,6 +11,8 @@
 // the two kinds of pages that Sphinx emits: the first kind is a module page, containing
 // information on on members within a module, and the second kind is a table of contents.
 
+/* purgecss start ignore */
+
 // Use the same icon that AnchorJS uses for anchor links.
 $anchorjs-font: 1em/1 anchorjs-icons;
 $anchorjs-content: "\e9cb";
@@ -134,3 +136,4 @@ section[id="pulumi-python-sdk"] {
         word-break: break-word;
     }
 }
+/* purgecss end ignore */


### PR DESCRIPTION
This change prevents PurgeCSS from stripping out the CSS we use for our Python docs. 

I'll follow this up by making sure https://github.com/pulumi/docs/pull/6158 works as intended and we can get that merged as well to make sure we don't regress here again. (Thanks @joeduffy!)