### PR TITLE
add usd to faq prices

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -250,7 +250,7 @@
                     <p>
                         Hourly usage is measured in the number of Pulumi Credits, and you are billed one Pulumi Credit
                         to manage one <a class="underline" href="{{ relref . "/docs/intro/concepts/resources" }}">resource</a>
-                        for one hour. Each credit costs $0.00025.
+                        for one hour. Each credit costs $0.00025 USD.
                     </p>
                     <p>
                         Each month you get 150,000 free Pulumi Credits, so you only pay for the credits used beyond
@@ -258,7 +258,7 @@
                     </p>
                     <p>
                         Example: If you manage 625 resources with Pulumi every month, you will use 450,000 Pulumi
-                        Credits each month. Your monthly bill would be $75 = (450,000 total credits - 150,000 free credits) * $0.00025.
+                        Credits each month. Your monthly bill would be $75 USD = (450,000 total credits - 150,000 free credits) * $0.00025.
                     </p>
                 </div>
             </li>
@@ -291,17 +291,17 @@
                     </p>
                     <p>
                         <span class="font-bold">150,000 Credits</span><br />
-                        estimated cost: $0<br />
+                        estimated cost: $0 USD<br />
                         one small production environment, about 200 resources
                     </p>
                     <p>
                         <span class="font-bold">350,000 Credits</span><br />
-                        estimated cost: $50/month<br />
+                        estimated cost: $50 USD/month<br />
                         two production environments, about 450 resources
                     </p>
                     <p>
                         <span class="font-bold">1,000,000 Credits</span><br />
-                        estimated cost: $225/month<br />
+                        estimated cost: $225 USD/month<br />
                         production deployment with five environments, about 1,300 resources
                     </p>
                 </div>
@@ -394,7 +394,7 @@
                         Yes! If you plan to use Pulumi by yourself, then try the free Individual Edition.
                         If you and your team want to collaborate on infrastructure projects, then try the
                         Team Edition which has a 30-day free trial. After the trial, you get 150K free
-                        Pulumi Credits every month (additional credits are $0.00025 each). 150K credits is
+                        Pulumi Credits every month (additional credits are $0.00025 USD each). 150K credits is
                         enough to manage a small environment with about 200 resources. To upgrade to Enterprise,
                         please <a class="underline" href="{{ relref . "/contact.md" }}">contact us</a>.
                     </p>


### PR DESCRIPTION
## overview
in talking with @ericrudder he suggested we at least mention that prices are in USD in the faq. this does that, super open to feedback!

changes to `/pricing/` page