### PR TITLE
fix github actions

### DIFF
--- a/themes/default/content/docs/guides/continuous-delivery/github-actions.md
+++ b/themes/default/content/docs/guides/continuous-delivery/github-actions.md
@@ -206,6 +206,7 @@ branch:
 
 ```yaml
 name: Pulumi
+on:
   push:
     branches:
       - master
@@ -238,6 +239,7 @@ jobs:
 
 ```yaml
 name: Pulumi
+on:
   push:
     branches:
       - master
@@ -270,6 +272,7 @@ jobs:
 
 ```yaml
 name: Pulumi
+on:
   push:
     branches:
       - master
@@ -302,6 +305,7 @@ jobs:
 
 ```yaml
 name: Pulumi
+on:
   push:
     branches:
       - master


### PR DESCRIPTION
while toying around with pulumi on github actions, I've copied & pasted the examples from the website and accidentally run `prettier` on them:

```
$ prettier .
.github/workflows/pulumi-deploy.yml
[error] .github/workflows/pulumi-deploy.yml: SyntaxError: All collection items must start at the same column (1:1)
[error] >  1 | name: Pulumi
[error]      | ^^^^^^^^^^^^
[error] >  2 |   push:
[error]      | ^^^^^^^
[error] >  3 |     branches:
[error]      | ^^^^^^^
[error] >  4 |       - master
[error]      | ^^^^^^^
[error] >  5 | jobs:
[error]      | ^^^^^^^
```

which made me wonder _why_, until I've realized the `on:` definition is missing from them
