### PR TITLE
Add Cloud Engineering Summit to header submenu

### DIFF
--- a/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
+++ b/themes/default/content/resources/getting-from-code-to-cloud-with-vscode-and-pulumi/index.md
@@ -56,11 +56,11 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-07-29T08:00:00-07:00
+    sortable_date: 2021-07-28T08:00:00-07:00
     # Duration of the webinar.
     duration: "2 hours"
     # Datetime of the webinar.
-    datetime: "THU JUL 29th, 2021"
+    datetime: "THU JUL 28th, 2021"
     # Description of the webinar.
     description: |
         For app developers, setting up infrastructure can be the hardest part of getting their app into production. What if you could just configure infrastructure using the same language you’re using to build your app? Pulumi's Matty Stratton will show you how easy it is to use Pulumi and VS Code to set up Azure (or any cloud) using JavaScript/TypeScript.

--- a/themes/default/layouts/page/cloud-engineering-summit.html
+++ b/themes/default/layouts/page/cloud-engineering-summit.html
@@ -22,7 +22,7 @@
             </pulumi-date-countdown>
             <div class="max-w-4xl mx-auto text-center">
                 <p class="mt-10">
-                    The Cloud Engineering Summit is a day of learning and speed talks for cloud practitioners
+                    The Cloud Engineering Summit is a virtual day of learning and speed talks for cloud practitioners
                     and anyone who's passionate about cloud infrastructure, modern applications, and everything
                     in between.
                 </p>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -42,6 +42,11 @@
                                     </a>
                                 </li>
                                 <li>
+                                    <a href="{{ relref . "/cloud-engineering-summit" }}">
+                                        2021 Summit
+                                    </a>
+                                </li>
+                                <li>
                                     <a href="{{ relref . "/solutions" }}">
                                         Solutions
                                     </a>
@@ -49,11 +54,6 @@
                                 <li>
                                     <a href="{{ relref . "/case-studies" }}">
                                         Case Studies
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="{{ relref . "/cloud-engineering-summit" }}">
-                                        Cloud Engineering Summit
                                     </a>
                                 </li>
                             </ul>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -51,6 +51,11 @@
                                         Case Studies
                                     </a>
                                 </li>
+                                <li>
+                                    <a href="{{ relref . "/cloud-engineering-summit" }}">
+                                        Cloud Engineering Summit
+                                    </a>
+                                </li>
                             </ul>
                         </div>
                     </li>


### PR DESCRIPTION
This PR adds the Cloud Engineering Summit landing page as submenu item to Cloud Engineering. The motivation for the change is to expose a link to the summit hype page that is discoverable. In the Cloud Engineering submenu felt like the natural place to put this link but open to other suggestions.