### PR TITLE
Fix syntax error and remove semicolons

### DIFF
--- a/themes/default/content/docs/intro/concepts/inputs-outputs.md
+++ b/themes/default/content/docs/intro/concepts/inputs-outputs.md
@@ -559,9 +559,8 @@ function split(input: pulumi.Input<string>): pulumi.Output<string[]> {
 
 ```python
 def split(input):
-    output = Output.from_input(input);
-    return output.apply(lambda v: v.split());
-}
+    output = Output.from_input(input)
+    return output.apply(lambda v: v.split())
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
The example python code contains a syntax error and semicolons that are not usually used in python.