### PR TITLE
Remove July 27th Twilio webinar

### DIFF
--- a/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
+++ b/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: ""
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.


### PR DESCRIPTION
This PR removes the Twilio webinar from the resources page.