### PR TITLE
Replace old contact us forms with hand raise section

### DIFF
--- a/themes/default/layouts/migrate/arm2pulumi.html
+++ b/themes/default/layouts/migrate/arm2pulumi.html
@@ -17,6 +17,6 @@
 
     {{ partial "get-started.html" . }}
 
-    {{ partial "contact-us.html" . }}
+    {{ partial "hand-raise-section" . }}
 
 {{ end }}

--- a/themes/default/layouts/migrate/kube2pulumi.html
+++ b/themes/default/layouts/migrate/kube2pulumi.html
@@ -53,5 +53,5 @@
         </div>
     </section>
 
-    {{ partial "contact-us.html" . }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/migrate/tf2pulumi.html
+++ b/themes/default/layouts/migrate/tf2pulumi.html
@@ -54,5 +54,5 @@
         </div>
     </section>
 
-    {{ partial "contact-us.html" . }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}

--- a/themes/default/layouts/page/about.html
+++ b/themes/default/layouts/page/about.html
@@ -132,5 +132,5 @@
         </div>
     </section>
 
-    {{ partial "contact-us.html" . }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}


### PR DESCRIPTION
This PR transitions the remaining contact us forms on the website to the new Hand Raise sections offering people different options for contact our team. 