### PR TITLE
Update comment in blog post archetype for clarity

### DIFF
--- a/themes/default/archetypes/blog-post/index.md
+++ b/themes/default/archetypes/blog-post/index.md
@@ -11,10 +11,9 @@ date: {{ .Date }}
 # Set this property to `false` before submitting your post for review.
 draft: true
 
-# Use the optional meta_desc property to provide a brief summary (one or two sentences)
+# Use the meta_desc property to provide a brief summary (one or two sentences)
 # of the content of the post, which is useful for targeting search results or social-media
-# previews. If omitted or left blank, the content preceding the `<!--more-->` token
-# will be used in its place.
+# previews. This field is required or the build will fail the linter test.
 meta_desc:
 
 # The meta_image appears in social-media previews and on the blog home page.


### PR DESCRIPTION
The linter task will flag/block if this field is omitted, so it's not optional. This provides clarity for folks doing blogs for the first time.