### PR TITLE
adjust messaging on old pricing blog

### DIFF
--- a/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -1,17 +1,19 @@
 ---
 title: "Announcing Per User Pricing and Unlimited Stacks for Teams"
 date: "2019-04-19"
-draft: true
+draft: false
 meta_desc: "Today we are announcing Pulumi's new pricing tier, with three paid editions: Team Starter Edition, Team Pro Edition, and Enterprise Edition."
 authors: ["joe-duffy"]
 tags:
   - features
 ---
 
-{{% notes %}}
-We have updated our pricing structure in response to user feedback and the information
-in this blog post is no longer accurate. Please visit our [Pricing Page]({{< relref "/pricing" >}})
-for the most up-to-date information about pricing.
+{{% notes type="warning" %}}
+This blog post is outdated and no longer accurate.
+We have updated our pricing structure in response to user feedback.
+Learn all about it in our new blog post: [Announcing New Usage-Based Pricing For Your Whole Team]({{< relref "/blog/announcing-new-usage-based-pricing-for-your-whole-team" >}}).
+Or visit our [Pricing Page]({{< relref "/pricing" >}})
+for more details about pricing.
 {{% /notes %}}
 
 Since launching last year, thousands of users and hundreds of

--- a/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
+++ b/themes/default/content/blog/announcing-per-user-pricing-and-unlimited-stacks-for-teams/index.md
@@ -1,6 +1,7 @@
 ---
 title: "Announcing Per User Pricing and Unlimited Stacks for Teams"
 date: "2019-04-19"
+draft: true
 meta_desc: "Today we are announcing Pulumi's new pricing tier, with three paid editions: Team Starter Edition, Team Pro Edition, and Enterprise Edition."
 authors: ["joe-duffy"]
 tags:


### PR DESCRIPTION
folks are starting to get confused by this old pricing blog and the new pricing model
this drafts the old blog so folks don't continue to use the information in it

[community slack convo](https://pulumi-community.slack.com/archives/C01PF3E1B8V/p1628510974034900)
[internal slack convo](https://pulumi.slack.com/archives/C01ADF2C8KC/p1628514904003900)
[internal community chat convo](https://pulumi.slack.com/archives/CG326KPTM/p1628511070033200)