### PR TITLE
Remove CES CFP and watch link on azure workshop

### DIFF
--- a/themes/default/content/resources/getting-started-with-azure-native/index.md
+++ b/themes/default/content/resources/getting-started-with-azure-native/index.md
@@ -56,7 +56,7 @@ main:
     # Webinar title.
     title: "Getting Started with Azure and Infrastructure as Code"
     # URL for embedding a URL for ungated webinars.
-    youtube_url: "https://www.youtube.com/embed/yzTSUDp2KXU"
+    youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2021-04-28T09:00:00-07:00
     # Duration of the webinar.

--- a/themes/default/layouts/page/cloud-engineering-summit.html
+++ b/themes/default/layouts/page/cloud-engineering-summit.html
@@ -50,14 +50,6 @@
 
         <div class="container mx-auto">
             <h2 class="text-center">Summit Tracks</h2>
-            <div class="text-center max-w-4xl mx-auto">
-                <p class="mb-12">
-                    We're inviting everyone from the community to submit a talk, including infrastructure
-                    (DevOps, SREs, infra) engineers, platform engineers, application developers, full-stack engineers,
-                    and security professionals. If you have a story to tell - we'd love to hear it!
-                </p>
-                <a href="https://sessionize.com/cloud-engineering-summit-hosted-by-pulumi/" class="btn-secondary">Submit a CFP</a>
-            </div>
 
             {{ range $item := .Params.tracks_outline }}
                 <div class="lg:flex my-16">


### PR DESCRIPTION
Now the CFP for the Cloud Engineering Summit is close this PR removes the CTA. This PR also removes a "Watch Now" CTA from the Azure workshop as requested by @isaac-pulumi.