### PR TITLE
docs: fish completion generator example fix

### DIFF
--- a/themes/default/content/docs/reference/cli/_index.md
+++ b/themes/default/content/docs/reference/cli/_index.md
@@ -119,7 +119,7 @@ pulumi gen-completion fish | source
 To load the completions for each session, you need to save the completion to a file:
 
 ```bash
-pulumi gen-completion fish > ~/.config/fish/completions/yourprogram.fish
+pulumi gen-completion fish > ~/.config/fish/completions/pulumi.fish
 ```
 
 Finally, after saving the `pulumi` fish completion script, you need to reopen your terminal for the scripts to take effect.


### PR DESCRIPTION
I believe there is a mistake in the docs when generating auto completion for fish shell.

It looks like a general code snippet has been used and the `yourprogram` has not been replaced with `pulumi`.

This did not work until I changed the fish completion filename to `pulumi.fish` which I have done in the example command shown in the docs.