### PR TITLE
Fix header not to cover search modal

### DIFF
--- a/themes/default/assets/sass/_header.scss
+++ b/themes/default/assets/sass/_header.scss
@@ -43,7 +43,7 @@
 }
 
 .header-container {
-    @apply sticky z-50 bg-white py-6;
+    @apply z-50 bg-white py-6;
     top: -1px;
 
     @screen lg {
@@ -51,7 +51,7 @@
     }
 
     &.is-pinned {
-        @apply shadow;
+        @apply sticky shadow;
     }
 
     .logo-container {


### PR DESCRIPTION
When search in docs, the header container covers search modal.
So I moved `sticky` class of `.header-container` to `&.is-pinned`.

Before:
![Screen Shot 2021-08-20 at 17 04 58](https://user-images.githubusercontent.com/7205340/130202939-f13c1f9d-acbc-450a-8108-ea038f17bb86.png)

After:
![Screen Shot 2021-08-20 at 17 05 25](https://user-images.githubusercontent.com/7205340/130202961-ad962cdc-54a4-4b51-ad45-ed93dee09bbe.png)