### PR TITLE
Support page-level noindex

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -10,6 +10,10 @@
         <meta http-equiv="refresh" content="0; url={{ .Params.redirect_to }}" />
     {{ end }}
 
+    {{ if eq .Params.block_external_search_index true }}
+        <meta name="robots" content="noindex">
+    {{ end }}
+
     <!--
         Metadata tags for OpenGraph and Twitter.
     -->


### PR DESCRIPTION
We currently expose a frontmatter param, `block_external_search_index`, that seems intended to prevent a page from being indexed. However it looks like that only keeps the page from being listed [in sitemap.xml](https://github.com/pulumi/pulumi-hugo/blob/4d443d97ef9a44f0b9e2a6ea985337fb326aa1fd/themes/default/layouts/_default/sitemap.xml#L4), it doesn't actually keep it from being indexed by other means. This change adds a check to the `head` partial to add a `noindex` meta tag when `block_external_search_index` is `true`.