### PR TITLE
Revert "Fix header not to cover search modal (#533)"

### DIFF
--- a/themes/default/assets/sass/_header.scss
+++ b/themes/default/assets/sass/_header.scss
@@ -43,7 +43,7 @@
 }
 
 .header-container {
-    @apply z-50 bg-white py-6;
+    @apply sticky z-50 bg-white py-6;
     top: -1px;
 
     @screen lg {
@@ -51,7 +51,7 @@
     }
 
     &.is-pinned {
-        @apply sticky shadow;
+        @apply shadow;
     }
 
     .logo-container {


### PR DESCRIPTION
This reverts commit 4d443d97ef9a44f0b9e2a6ea985337fb326aa1fd. (I failed to notice before merging that the change causes main-nav menus to fall behind hero content, rendering their items inaccessible.)

<img width="254" alt="image" src="https://user-images.githubusercontent.com/274700/130722900-c8164665-8dd9-4713-b218-a798cf76a108.png">

<img width="225" alt="image" src="https://user-images.githubusercontent.com/274700/130722912-ed2c1acc-f6d3-49c3-b205-c245b8d0085e.png">
 