### PR TITLE
Pin Swiper's CDN-hosted CSS bundle to the right version

### DIFF
--- a/themes/default/assets/sass/components/_swiper.scss
+++ b/themes/default/assets/sass/components/_swiper.scss
@@ -1,4 +1,4 @@
-@import url("https://unpkg.com/swiper/swiper-bundle.min.css");
+@import url("https://unpkg.com/swiper@6.5.6/swiper-bundle.min.css");
 
 pulumi-swiper {
     .swiper-container {


### PR DESCRIPTION
Fixes #543. This pins with the same version we're using [in the component](https://github.com/pulumi/pulumi-hugo/blob/ea81098b8b5bc12df7019302dc2c61cfd2b238bf/themes/default/components/package.json#L37).