### PR TITLE
Fix CLI installation script command for Windows

### DIFF
--- a/themes/default/content/docs/get-started/install/_index.md
+++ b/themes/default/content/docs/get-started/install/_index.md
@@ -288,7 +288,7 @@ You can specify a specific version with [Chocolatey package manager](https://cho
 1. Run our installation script (replace `<version>` with the version number):
 
 ```powershell
-> @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $version = '<version>'; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1')).Replace('${latestVersion}', $version)" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
+> @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $version = '<version>'; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1')).Replace('${Version}', $version)" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Update the PowerShell script to replace the correct placeholder for installing a specific version of the CLI

This is the result of the current script listed in https://www.pulumi.com/docs/get-started/install/#installation-script for Windows. Notice how it still downloads the latest version. It's because the placeholder `${latestVersion}` does not exist. It should be `${Version}`.

```
C:\Users\ploke>@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $version = '3.10.0'; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1')).Replace('${latestVersion}', $version)" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
Downloading https://get.pulumi.com/releases/sdk/pulumi-v3.11.0-windows-x64.zip
Copying Pulumi to C:\Users\ploke\.pulumi\bin
Pulumi is now installed!

Ensure that C:\Users\ploke\.pulumi\bin is on your $PATH to use it.

Get started with Pulumi: https://www.pulumi.com/docs/quickstart
```

...with the fix:
```
C:\Users\ploke>@"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; $version = '3.10.0'; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1')).Replace('${Version}', $version)" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
Downloading https://get.pulumi.com/releases/sdk/pulumi-v3.10.0-windows-x64.zip
Copying Pulumi to C:\Users\ploke\.pulumi\bin
Pulumi is now installed!

Ensure that C:\Users\ploke\.pulumi\bin is on your $PATH to use it.

Get started with Pulumi: https://www.pulumi.com/docs/quickstart
```