### PR TITLE
Fixed typo in Asset Archive Python docs.

### DIFF
--- a/themes/default/content/docs/intro/concepts/assets-archives.md
+++ b/themes/default/content/docs/intro/concepts/assets-archives.md
@@ -171,7 +171,7 @@ let assetArchive = new pulumi.asset.AssetArchive({
 ```python
 file_archive = pulumi.FileArchive("./file.zip")
 remote_archive = pulumi.RemoteArchive("http://contoso.com/file.zip")
-asset_archive = pulumiAssetArchive({
+asset_archive = pulumi.AssetArchive({
     "file": pulumi.StringAsset("Hello, world!"),
     "folder": pulumi.FileArchive("./folder")
 })


### PR DESCRIPTION
Added missing period (.) to the Python Asset Archive use example.