### PR TITLE
Fix up event dates and typo for upcoming workshop

### DIFF
--- a/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
+++ b/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
@@ -56,7 +56,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-09-28T10:00:00-07:00
+    sortable_date: 2021-09-28T09:00:00-07:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.

--- a/themes/default/content/resources/docker-show-multi-language-components/index.md
+++ b/themes/default/content/resources/docker-show-multi-language-components/index.md
@@ -56,7 +56,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-09-23T10:00:00-07:00
+    sortable_date: 2021-09-23T09:00:00-07:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.

--- a/themes/default/content/resources/getting-started-with-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-aws/index.md
@@ -3,6 +3,9 @@
 title: "Getting Started with Infrastructure as Code on AWS"
 meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code on AWS through a series of exercises using Pulumi’s Cloud Engineering platform."
 
+aliases:
+  - /resources/gettint-started-with-aws
+
 # A featured webinar will display first in the list.
 featured: false
 
@@ -47,9 +50,6 @@ hero:
 multiple:
     - datetime: 2021-09-16T04:00:00-07:00
       hubspot_form_id: 63ed4da6-2388-4c13-b089-25088b2d0845
-
-    - datetime: 2021-09-22T18:00:00-07:00
-      hubspot_form_id: 2b26c05e-4deb-414f-bd3e-365491d3d905
 
     - datetime: 2021-09-28T08:00:00-07:00
       hubspot_form_id: 1bb45b7f-b1ad-44ac-9e0a-fb045cb8fd06


### PR DESCRIPTION
This PR removes a workshop, updates the time of two workshop/livestreams, and fixes a title in a URL.