### PR TITLE
Add sessions list page for Cloud Engineering Summit

### DIFF
--- a/themes/default/content/cloud-engineering-summit/sessions.md
+++ b/themes/default/content/cloud-engineering-summit/sessions.md
@@ -1,0 +1,9 @@
+---
+title: Sessions
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between.
+
+type: page
+layout: cloud-engineering-summit-session-list
+
+sessionize_id: wbl7wd7l
+---

--- a/themes/default/layouts/page/cloud-engineering-summit-session-list.html
+++ b/themes/default/layouts/page/cloud-engineering-summit-session-list.html
@@ -1,0 +1,9 @@
+{{ define "hero" }}
+    {{ partial "hero" (dict "title" .Params.title )}}
+{{ end }}
+
+{{ define "main" }}
+    <section id="sessions" class="container mx-auto my-16 text-center">
+        <script type="text/javascript" src="https://sessionize.com/api/v2/{{ .Params.sessionize_id }}/view/Sessions"></script>
+    </section>
+{{ end }}

--- a/themes/default/layouts/page/cloud-engineering-summit.html
+++ b/themes/default/layouts/page/cloud-engineering-summit.html
@@ -52,6 +52,10 @@
     <section id="speakers" class="container mx-auto text-center">
         <h1 class="m-0">Cloud Engineering Summit</h1>
         <h2 class="mt-0 mb-10">Featured Speakers</h2>
+        <div class="my-10">
+            <a class="btn-secondary" href="{{ relref . "/cloud-engineering-summit/sessions" }}">View the sessions</a>
+        </div>
+
         <div class="cloud-engineering-summit-speaker-wall">
             <script type="text/javascript" src="https://sessionize.com/api/v2/{{ .Params.sessionize_id }}/view/SpeakerWall"></script>
         </div>


### PR DESCRIPTION
Just as the title states, this PR adds a session list page to the Cloud Engineering Summit. 