### PR TITLE
Add dzone ref card and whitepapers to resources

### DIFF
--- a/themes/default/archetypes/whitepaper/index.md
+++ b/themes/default/archetypes/whitepaper/index.md
@@ -1,0 +1,62 @@
+---
+# Name of the whitepaper.
+title: "Name of the Webinar"
+meta_desc: "Search Description"
+
+# Set the whitepaper flag.
+whitepaper: true
+
+# A featured resource will display first in the list.
+featured: false
+
+# Resources with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated resources will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: false
+
+# The layout of the landing page.
+type: webinars
+
+# External resources will link to an external page instead of a resource
+# landing/registration page. If the resource is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the resource page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the resource landing page. If this is an external
+# resource, use the external URL as the value here.
+url_slug: "{{ .Name }}"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: ""
+
+# Content for the left hand side section of the page.
+main:
+    # Whitepaper title.
+    title: ""
+    # Sortable date. The datetime Hugo will use to sort the resources in date order.
+    sortable_date: 2020-02-05T10:00:00-07:00
+    # Duration of the whitepaper.
+    duration: "2 hours"
+    # Description of the whitepaper.
+    description: ""
+
+    # The whitepaper authors
+    presenters:
+        - name: ""
+          role: ""
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - ""
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: ""
+---

--- a/themes/default/assets/sass/_event-list.scss
+++ b/themes/default/assets/sass/_event-list.scss
@@ -11,7 +11,7 @@
         }
     }
 
-    @each $filter-name in "all", "featured", "upcoming", "videos", "pulumitv" {
+    @each $filter-name in "all" "featured" "upcoming" "videos" "pulumitv" "whitepaper" {
         ##{$filter-name}:target {
             @if $filter-name != "all" {
                 ~ .event-list-filter li[data-filter-name="all"] a {

--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-guide/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-guide/index.md
@@ -1,0 +1,66 @@
+---
+# Name of the whitepaper.
+title: "Guide: Getting Started with Infrastructure as Code"
+meta_desc: "Infrastructure as code (IaC) means that you use code to define and manage infrastructure. In this guide, learn how the fundamentals of IaC."
+
+# Set the whitepaper flag.
+whitepaper: true
+
+# A featured resource will display first in the list.
+featured: false
+
+# Resources with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated resources will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External resources will link to an external page instead of a resource
+# landing/registration page. If the resource is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the resource page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "getting-started-with-infrastructure-as-code-guide"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Guide: Getting Started with Infrastructure as Code"
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Guide: Getting Started with Infrastructure as Code"
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2021-09-09T10:00:00-07:00
+    # Duration of the whitepaper.
+    duration: "7 pages"
+    # Description of the whitepaper.
+    description: |
+         Infrastructure as code (IaC) means that you use code to define and manage infrastructure rather than using manual processes. More broadly, and perhaps more importantly, IaC is about bringing software engineering principles and approaches to cloud infrastructure. In this guide, explore the fundamentals of IaC and how to get started setting up your environment.
+
+    # The whitepaper authors
+    presenters:
+        - name: George Huang
+          role: Director of Product Marketing, Pulumi
+
+    # A bullet point list containing what the user will learn.
+    learn:
+        - Why does Infrastructure as Code (IaC) matter?
+        - Important considerations when using IaC.
+        - How to get started with IaC.
+        - IaC best practices.
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: "c726d203-f1ce-4b16-a6c9-b66a3d9132ce"
+---

--- a/themes/default/layouts/resources/list.html
+++ b/themes/default/layouts/resources/list.html
@@ -47,6 +47,7 @@
             <span id="upcoming" class="hidden"></span>
             <span id="videos" class="hidden"></span>
             <span id="pulumitv" class="hidden"></span>
+            <span id="whitepaper" class="hidden"></span>
 
             <!-- The event filter -->
             <div class="w-full mb-5 text-center event-list-filter">
@@ -81,6 +82,12 @@
                             <p class="text-xs md:text-base m-0 pt-3">PulumiTV</p>
                         </a>
                     </li>
+                    <li class="mx-3 md:mx-6" data-filter-name="whitepaper">
+                        <a href="#whitepaper" class="flex flex-col">
+                            <i class="fas fa-book text-3xl"></i>
+                            <p class="text-xs md:text-base m-0 pt-3">Whitepapers</p>
+                        </a>
+                    </li>
                 </ul>
             </div>
 
@@ -90,6 +97,7 @@
             <h3 class="hidden ml-5" data-filter-title="upcoming">Upcoming Sessions</h3>
             <h3 class="hidden ml-5" data-filter-title="videos">Videos</h3>
             <h3 class="hidden ml-5" data-filter-title="pulumitv">PulumiTV</h3>
+            <h3 class="hidden ml-5" data-filter-title="whitepaper">Whitepapers</h3>
 
             <!-- Resources list. -->
             <ul class="flex flex-wrap justify-center list-none p-0 sm:p-2 resource-list">
@@ -129,7 +137,10 @@
                         {{end }}
 
                         <!-- Set the icon and appropriate filters for the webinar. -->
-                        {{ if $data.Params.pulumi_tv }}
+                        {{ if $data.Params.whitepaper }}
+                            {{ $icon = "book" }}
+                            {{ $filters = $filters | append "whitepaper" }}
+                        {{ else if $data.Params.pulumi_tv }}
                             {{ $icon = "tv" }}
                             {{ $filters = $filters | append "pulumitv" }}
                         {{ else if $data.Params.pre_recorded}}


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-hugo/issues/554

This PR adds the Dzone ref card as a gated resources. It also adds support for a `Whitepapers` category to the resources page. I created a new archetype as I suspect we will have more of these in the furture.