### PR TITLE
Improved explanation of Azure Native vs Azure Classic

### DIFF
--- a/themes/default/content/docs/intro/cloud-providers/azure-classic/_index.md
+++ b/themes/default/content/docs/intro/cloud-providers/azure-classic/_index.md
@@ -9,7 +9,9 @@ menu:
 ---
 
 {{% notes %}}
-We recommend using the [native Azure provider for Pulumi]({{< relref "/docs/intro/cloud-providers/azure" >}}) to provision Azure infrastructure.
+We recommend using the [Azure Native provider]({{< relref "/docs/intro/cloud-providers/azure" >}}) to provision Azure infrastructure. Azure Native provides complete coverage of Azure resources and same-day access to new resources and resource updates because it’s built and automatically from the Azure Resource Manager API.
+
+Azure Classic is based on the Terraform AzureRM provider. It has fewer resources and resource options and receives new Azure features more slowly than Azure Native. However, Azure Classic remains fully-supported for existing usage.
 {{% /notes %}}
 
 <img src="/logos/tech/azure.svg" align="right" class="h-16 px-8 pb-4">


### PR DESCRIPTION
This PR improves the note on the Azure Classic intro page to make it clearer why you might use Azure Native instead.﻿
