### PR TITLE
fix docs search results and nav issue

### DIFF
--- a/themes/default/assets/sass/_header.scss
+++ b/themes/default/assets/sass/_header.scss
@@ -43,7 +43,7 @@
 }
 
 .header-container {
-    @apply sticky z-50 bg-white py-6;
+    @apply z-50 bg-white py-6;
     top: -1px;
 
     @screen lg {
@@ -51,7 +51,7 @@
     }
 
     &.is-pinned {
-        @apply shadow;
+        @apply sticky shadow;
     }
 
     .logo-container {
@@ -112,7 +112,7 @@
                     @apply relative cursor-pointer;
 
                     .header-nav-drop-down-menu {
-                        @apply w-full absolute hidden min-w-max pt-6 top-0;
+                        @apply w-full absolute hidden min-w-max pt-6 top-0 z-10;
 
                         ul {
                             @apply bg-white text-left rounded shadow-xl py-2 whitespace-nowrap;


### PR DESCRIPTION
## overview
a community member opened up a pr to fix the issue where the top nav is still displayed when the docs search results dialog is open but it was later discovered that this prevented the menus from appearing on top.

ref: https://github.com/pulumi/pulumi-hugo/pull/533

im adding that back in, and also adding a z-index to the nav menus

@cnunciato @zchase pls let me know if this isn't the correct way to fix this

## screenshots

### before
<img width="1370" alt="before" src="https://user-images.githubusercontent.com/5489125/133723199-5209767c-7990-4ed5-b70c-8e218e19c8b5.png">

### after
<img width="1363" alt="after" src="https://user-images.githubusercontent.com/5489125/133723323-0c86ea93-6aa9-4b12-aa12-26d00c94129b.png">
<img width="320" alt="after-2" src="https://user-images.githubusercontent.com/5489125/133723328-93d9f8f6-9cf6-43d5-a6cb-619bd25ab232.png">
