### PR TITLE
Update the times of the Cloud Engineering Summit workshops

### DIFF
--- a/themes/default/content/cloud-engineering-summit/_index.md
+++ b/themes/default/content/cloud-engineering-summit/_index.md
@@ -17,7 +17,7 @@ workshops:
       icon: puzzle
       icon_color: violet
       link: /resources/build-reusable-infrastructure-as-code-patterns
-      times: [ "2021-10-21T09:00:00-07:00" ]
+      times: [ "2021-10-21T12:00:00-07:00" ]
       description: |
         In this workshop, we’ll guide you through an example of building a reusable Pulumi component for a hypothetical “production ready application” in Python.
 
@@ -25,7 +25,7 @@ workshops:
       icon: cloud-with-nodes
       icon_color: salmon
       link: /resources/getting-started-with-automation-api
-      times: [ "2021-10-21T09:00:00-07:00", "2021-10-21T12:00:00-07:00" ]
+      times: [ "2021-10-21T12:00:00-07:00" ]
       description: |
         In this workshop, you’ll build a Python & Flask web application that lets you and your developers deploy applications at the click of a button.
 
@@ -33,7 +33,7 @@ workshops:
       icon: code
       icon_color: yellow
       link: /resources/getting-started-with-aws
-      times: [ "2021-10-21T06:00:00-07:00" ]
+      times: [ "2021-10-21T09:00:00-07:00" ]
       description: |
         In this workshop, you will learn the fundamentals of Infrastructure as Code on AWS through a series of exercises using Pulumi’s Cloud Engineering platform.
 
@@ -41,7 +41,7 @@ workshops:
       icon: code
       icon_color: blue
       link: /resources/getting-started-with-azure-native
-      times: [ "2021-10-21T09:00:00-07:00", "2021-10-21T21:00:00-07:00" ]
+      times: [ "2021-10-21T09:00:00-07:00" ]
       description: |
         In this workshop, you’ll use the Azure native provider to build infrastructure using TypeScript SDK and examine some of the features not previously possible.
 
@@ -49,7 +49,7 @@ workshops:
       icon: code
       icon_color: fuchsia
       link: /resources/getting-started-with-google-cloud-platform
-      times: [ "2021-10-21T06:00:00-07:00" ]
+      times: [ "2021-10-21T09:00:00-07:00" ]
       description: |
         In this workshop, we’ll use the Google Cloud native provider to build infrastructure using TypeScript and examine some of Pulumi's newest features.
 

--- a/themes/default/content/cloud-engineering-summit/_index.md
+++ b/themes/default/content/cloud-engineering-summit/_index.md
@@ -49,7 +49,7 @@ workshops:
       icon: code
       icon_color: fuchsia
       link: /resources/getting-started-with-google-cloud-platform
-      times: [ "2021-10-21T09:00:00-07:00" ]
+      times: [ "2021-10-21T12:00:00-07:00" ]
       description: |
         In this workshop, we’ll use the Google Cloud native provider to build infrastructure using TypeScript and examine some of Pulumi's newest features.
 

--- a/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
+++ b/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
@@ -50,7 +50,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/3BaDCrCw5FM"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-10-21T09:00:00-07:00
+    sortable_date: 2021-10-21T12:00:00-07:00
     # Duration of the webinar.
     duration: "2 hours"
     # Datetime of the webinar.

--- a/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
+++ b/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
@@ -52,9 +52,9 @@ main:
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2021-10-21T12:00:00-07:00
     # Duration of the webinar.
-    duration: "2 hours"
+    duration: "1 hour"
     # Datetime of the webinar.
-    datetime: "JUNE 17th, 2021"
+    datetime: "OCTOBER 21st, 2021"
     # Description of the webinar.
     description: |
         One of the great benefits of adopting [Infrastructure as Code](/what-is/what-is-infrastructure-as-code/) is that you can drastically reduce the amount of repetition when declaring your infrastructure. Using familiar languages like Python means you can use functions, loops and object oriented programming paradigms to reduce the boilerplate.
@@ -64,8 +64,8 @@ main:
 
     # The webinar presenters
     presenters:
-        - name: Matt Stratton
-          role: Staff Developer Advocate, Pulumi
+        - name: Lee Briggs
+          role: Sales Engineer, Pulumi
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:

--- a/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
+++ b/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
@@ -52,9 +52,9 @@ main:
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2021-10-21T14:00:00-07:00
     # Duration of the webinar.
-    duration: "1 hour"
+    duration: "1.5 hour"
     # Datetime of the webinar.
-    datetime: "TUE JUL 20, 2021"
+    datetime: "OCTOBER 21st, 2021"
     # Description of the webinar.
     description: |
         Setting up your production Kubernetes environment brings many benefits including scalability and portability for your applications. Before you reach production, It’s important to understand key Kubernetes concepts and architectures available to keep your clusters secure and scalable. Ingress controllers are vital parts of any Kubernetes platform and NGINX ingress controller provides the best in class traffic management solution for cloud native apps and containerized environments.

--- a/themes/default/content/resources/getting-started-with-automation-api/index.md
+++ b/themes/default/content/resources/getting-started-with-automation-api/index.md
@@ -55,11 +55,11 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/24qnvC-dvvw"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-05-20T09:00:00-07:00
+    sortable_date: 2021-10-21T12:00:00-07:00
     # Duration of the webinar.
-    duration: "2 hours"
+    duration: "1 hour"
     # Datetime of the webinar.
-    datetime: "MAY 20, 2020"
+    datetime: "OCTOBER 21st, 2020"
     # Description of the webinar.
     description: |
         Pulumi’s Automation API opens new horizons for infrastructure provisioning. In this workshop, you’ll examine the powerful new capabilities of Pulumi’s latest feature by building a Python & Flask web application that lets developers deploy applications at the click of a button.
@@ -67,8 +67,6 @@ main:
     # The webinar presenters
     presenters:
         - name: Kat Cosgrove
-          role: Staff Developer Advocate, Pulumi
-        - name: Matty Stratton
           role: Staff Developer Advocate, Pulumi
 
 

--- a/themes/default/content/resources/getting-started-with-automation-api/index.md
+++ b/themes/default/content/resources/getting-started-with-automation-api/index.md
@@ -45,9 +45,6 @@ hero:
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2021-10-21T09:00:00-07:00
-      hubspot_form_id: a752def5-b8c1-4aff-bfc9-da43ba994f52
-
     - datetime: 2021-10-21T12:00:00-07:00
       hubspot_form_id: 3d0bc178-ef35-4424-8cc2-93c34ac6a089
 

--- a/themes/default/content/resources/getting-started-with-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-aws/index.md
@@ -48,10 +48,7 @@ hero:
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2021-09-28T08:00:00-07:00
-      hubspot_form_id: 1bb45b7f-b1ad-44ac-9e0a-fb045cb8fd06
-
-    - datetime: 2021-10-21T06:00:00-07:00
+    - datetime: 2021-10-21T09:00:00-07:00
       hubspot_form_id: 0c727231-dfc1-4fa6-ab76-69247ac652c8
 
 # Content for the left hand side section of the page.

--- a/themes/default/content/resources/getting-started-with-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-aws/index.md
@@ -58,7 +58,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2020-02-05T10:00:00-07:00
+    sortable_date: 2020-10-21T09:00:00-07:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.

--- a/themes/default/content/resources/getting-started-with-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-aws/index.md
@@ -74,6 +74,8 @@ main:
     presenters:
         - name: "Laura Santamaria"
           role: "Developer Advocate, Pulumi"
+        - name: Marina Novikova
+          role: Partner Solutions Architect, AWS
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:

--- a/themes/default/content/resources/getting-started-with-azure-native/index.md
+++ b/themes/default/content/resources/getting-started-with-azure-native/index.md
@@ -41,9 +41,6 @@ multiple:
     - datetime: 2021-10-21T09:00:00-07:00
       hubspot_form_id: 7de43dee-4699-46e9-9ce3-9a6fffd56aa5
 
-    - datetime: 2021-10-21T21:00:00-07:00
-      hubspot_form_id: a3ca0bab-312f-4779-b3d1-11884f181629
-
 # The content of the hero section.
 hero:
     # The title text in the hero. This also serves as the pages H1.

--- a/themes/default/content/resources/getting-started-with-azure-native/index.md
+++ b/themes/default/content/resources/getting-started-with-azure-native/index.md
@@ -55,11 +55,11 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/yzTSUDp2KXU"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-04-28T09:00:00-07:00
+    sortable_date: 2021-10-21T09:00:00-07:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.
-    datetime: "April 28th, 2021"
+    datetime: "OCTOBER 21st, 2021"
     # Description of the webinar.
     description: |
         Microsoft Azure’s product offering is continuously evolving, and infrastructure tools often can’t keep up with the speed of innovation. Pulumi’s Azure Native provider is built directly from the Azure API, bringing power of familiar programming languages to Azure without sacrificing on latest features.
@@ -68,8 +68,8 @@ main:
 
     # The webinar presenters
     presenters:
-        - name: Lee Briggs
-          role: Sales Engineer, Pulumi
+        - name: Matt Stratton
+          role: Staff Developer Advocate, Pulumi
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:

--- a/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
+++ b/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
@@ -50,11 +50,11 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/2CHXNWiREBE"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-10-21T09:00:00-07:00
+    sortable_date: 2021-10-21T12:00:00-07:00
     # Duration of the webinar.
-    duration: "2 hours"
+    duration: "1 hour"
     # Datetime of the webinar.
-    datetime: "JUNE 10TH, 2021"
+    datetime: "OCTOBER 21st, 2021"
     # Description of the webinar.
     description: |
         Google Cloud’s product offering is continuously evolving, and infrastructure tools often can’t keep up with the speed of innovation. Pulumi’s Google Cloud Native provider is built directly from the Google Cloud API, bringing power of familiar programming languages to Google Cloud without sacrificing on latest features.
@@ -64,8 +64,6 @@ main:
     # The webinar presenters
     presenters:
         - name: "Kat Cosgrove"
-          role: "Staff Developer Advocate, Pulumi"
-        - name: "Matty Stratton"
           role: "Staff Developer Advocate, Pulumi"
 
     # A bullet point list containing what the user will learn during the webinar.

--- a/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
+++ b/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
@@ -50,7 +50,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/2CHXNWiREBE"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-10-21T06:00:00-07:00
+    sortable_date: 2021-10-21T09:00:00-07:00
     # Duration of the webinar.
     duration: "2 hours"
     # Datetime of the webinar.


### PR DESCRIPTION
This PR does just as the title states and cleans up the workshop times for the Cloud Engineering Summit.