### PR TITLE
Add support for dismissing alerts in converter

### DIFF
--- a/themes/default/assets/sass/components/_convert.scss
+++ b/themes/default/assets/sass/components/_convert.scss
@@ -209,7 +209,7 @@ pulumi-convert {
                 }
 
                 .alert {
-                    @apply hidden absolute right-0 left-0 z-10 text-sm rounded-t border-2 py-2 px-4 max-h-25 overflow-y-scroll;
+                    @apply hidden absolute opacity-100 transition-opacity right-0 left-0 z-10 text-sm rounded-t border-2 py-2 px-4 max-h-25 overflow-y-scroll;
                     bottom: 100%;
 
                     p {
@@ -218,6 +218,24 @@ pulumi-convert {
                         a {
                             @apply underline;
                         }
+                    }
+
+                    .toggle {
+                        @apply absolute top-4 right-4;
+
+                        .icon {
+                            @apply mr-0 text-gray-700 transition-colors;
+                            @extend .fas;
+                            @extend .fa-times;
+
+                            &:hover {
+                                @apply text-gray-800;
+                            }
+                        }
+                    }
+
+                    &.dismissed {
+                        @apply opacity-0;
                     }
                 }
 

--- a/themes/default/components/src/components/convert/convert.tsx
+++ b/themes/default/components/src/components/convert/convert.tsx
@@ -68,6 +68,9 @@ export class Convert {
     @State()
     convertible: boolean = false;
 
+    @State()
+    alertDismissed: boolean = false;
+
     inputEditor: CodeMirror.EditorFromTextArea;
     selectedSourceFile: SourceFile;
     customSourceFile: SourceFile;
@@ -339,6 +342,11 @@ export class Convert {
             });
     }
 
+    // Hide the warning/error message box.
+    private dismissAlert() {
+        this.alertDismissed = true;
+    }
+
     // Convert the code provided.
     private async convert() {
         this.setOutputResult(null);
@@ -351,6 +359,7 @@ export class Convert {
         }
 
         this.converting = true;
+        this.alertDismissed = false;
 
         try {
             const response = await fetch([ this.endpointURL, this.endpointPath].join("/"), {
@@ -484,6 +493,12 @@ export class Convert {
         </pulumi-tooltip>
     }
 
+    private renderDismissAlertButton() {
+        return <button class="toggle" title="Dismiss this message" onClick={ this.dismissAlert.bind(this) }>
+            <span class="icon"></span>
+        </button>;
+    }
+
     // Render an editor status bar.
     private renderStatusBar(type: "input" | "output") {
         switch (type) {
@@ -499,7 +514,8 @@ export class Convert {
                 return <div class={ this.statusBarClasses }>
                     <span class="icon"></span>
                     <span class="message">{ this.outputResult?.status?.message }</span>
-                    <div class="alert alert-error">
+                    <div class={ this.combineClasses("alert", "alert-error", this.alertDismissed ? "dismissed" : undefined) }>
+                        { this.renderDismissAlertButton() }
                         <p>
                             <strong>Sorry, we were unable to convert your code.</strong>
                         </p>
@@ -515,7 +531,8 @@ export class Convert {
                             We're here to help!
                         </p>
                     </div>
-                    <div class="alert alert-warn">
+                    <div class={ this.combineClasses("alert", "alert-warn", this.alertDismissed ? "dismissed" : undefined) }>
+                        { this.renderDismissAlertButton() }
                         <p>
                             <strong>Sorry, we were unable to convert your code completely.</strong>
                         </p>

--- a/themes/default/package.json
+++ b/themes/default/package.json
@@ -8,7 +8,7 @@
     "watch": "yarn run concurrently 'yarn run watch-css' 'yarn run watch-js' 'yarn run watch-components'",
     "build": "yarn run build-css && yarn run build-js && yarn run build-components",
     "test-components": "yarn --cwd components run test",
-    "watch-css": "yarn run chokidar 'assets/sass/**/*.scss' -c \"yarn run --silent node-sass assets/sass/styles.scss | yarn run postcss --config assets/config --output ${CSS_BUNDLE}\"",
+    "watch-css": "yarn run chokidar 'assets/sass/**/*.scss' -c \"yarn run --silent sass assets/sass/styles.scss | yarn run postcss --config assets/config --output ${CSS_BUNDLE}\"",
     "watch-js": "yarn run tsc --watch --preserveWatchOutput --outFile ${JS_BUNDLE}",
     "watch-components": "yarn --cwd components run start",
     "build-css": "yarn run --silent sass assets/sass/styles.scss | yarn run postcss --config assets/config --output ${CSS_BUNDLE} --no-map",


### PR DESCRIPTION
Adds a close button to dismiss warning and error messages so as not to obscure the code we were able to render.

https://user-images.githubusercontent.com/274700/135174077-9cfac9fb-bc82-429b-b243-f571cb05e17b.mov

Fixes #636.