### PR TITLE
Add date to meta info for CES pages

### DIFF
--- a/themes/default/content/cloud-engineering-summit/_index.md
+++ b/themes/default/content/cloud-engineering-summit/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21.
 
 meta_image: /images/cloud-eng-summit-2021-meta.jpg
 

--- a/themes/default/content/cloud-engineering-summit/_index.md
+++ b/themes/default/content/cloud-engineering-summit/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
 
 meta_image: /images/cloud-eng-summit-2021-meta.jpg
 

--- a/themes/default/content/cloud-engineering-summit/agenda.md
+++ b/themes/default/content/cloud-engineering-summit/agenda.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit Agenda
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
 
 type: page
 layout: cloud-engineering-summit-agenda

--- a/themes/default/content/cloud-engineering-summit/agenda.md
+++ b/themes/default/content/cloud-engineering-summit/agenda.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit Agenda
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21.
 
 type: page
 layout: cloud-engineering-summit-agenda

--- a/themes/default/content/cloud-engineering-summit/sessions.md
+++ b/themes/default/content/cloud-engineering-summit/sessions.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit Sessions
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21.
 
 type: page
 layout: cloud-engineering-summit-session-list

--- a/themes/default/content/cloud-engineering-summit/sessions.md
+++ b/themes/default/content/cloud-engineering-summit/sessions.md
@@ -1,6 +1,6 @@
 ---
-title: Sessions
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between.
+title: Cloud Engineering Summit Sessions
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
 
 type: page
 layout: cloud-engineering-summit-session-list

--- a/themes/default/content/cloud-engineering-summit/speakers.md
+++ b/themes/default/content/cloud-engineering-summit/speakers.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit Speakers
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
 
 type: page
 layout: cloud-engineering-summit-speakers

--- a/themes/default/content/cloud-engineering-summit/speakers.md
+++ b/themes/default/content/cloud-engineering-summit/speakers.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Engineering Summit Speakers
-meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21, 2021.
+meta_desc: The Cloud Engineering Summit is a day of learning for cloud practitioners about cloud infrastructure, modern applications, and everything in between. Oct 20-21.
 
 type: page
 layout: cloud-engineering-summit-speakers


### PR DESCRIPTION
I noticed that in open graph previews (slack, etc) the date of the event isn't in text, and thought it might be helpful to add that.

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>