### PR TITLE
Update GCP examples to match current API

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/kubernetes/apps.md
+++ b/themes/default/content/docs/guides/crosswalk/kubernetes/apps.md
@@ -315,11 +315,14 @@ import * as pulumi from "@pulumi/pulumi";
 // Get the GCP project registry repository.
 const registry = gcp.container.getRegistryRepository();
 
+// Get the repository URL
+const repositoryUrl = registry.then(_r => _r.repositoryUrl);
+
 // Build a Docker image from a local Dockerfile context in the
 // './node-app' directory, and push it to the registry.
 const customImage = "node-app";
 const appImage = new docker.Image(customImage, {
-    imageName: pulumi.interpolate`${registry.repositoryUrl}/${customImage}:v1.0.0`,
+    imageName: pulumi.interpolate`${repositoryUrl}/${customImage}:v1.0.0`,
     build: {
         context: `./${customImage}`,
     },
@@ -365,11 +368,14 @@ import * as pulumi from "@pulumi/pulumi";
 // Get the GCP project registry repository.
 const registry = gcp.container.getRegistryRepository();
 
+// Get the repository URL
+const repositoryUrl = registry.then(_r => _r.repositoryUrl);
+
 // Build a Docker image from a local Dockerfile context in the
 // './node-app' directory, and push it to the registry.
 const customImage = "node-app";
 const appImage = new docker.Image(customImage, {
-    imageName: pulumi.interpolate`${registry.repositoryUrl}/${customImage}:v1.0.0`,
+    imageName: pulumi.interpolate`${repositoryUrl}/${customImage}:v1.0.0`,
     build: {
         context: `./${customImage}`,
     },


### PR DESCRIPTION
Update 2 GCP examples as the property `registry.repositoryUrl`  doesn't exist anymore. Update the code according to
`gcp.container.getRegistryRepository()` [example](https://www.pulumi.com/docs/reference/pkg/gcp/container/getregistryrepository/).

This was also mentioned to me via this SO [question](https://stackoverflow.com/questions/69413119/deploying-helloworld-docker-images-to-gke-with-pulumi/69420339#69420339).