### PR TITLE
add audit logs export to pricing page

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -1046,7 +1046,7 @@
 
                 <div class="compare-plans-table-row-container">
                     <div class="compare-plans-table-row-item">
-                        <span><a class="compare-table-link" href="{{ relref . "/blog/auditing-your-organizations-infrastructure-as-code-activity" }}">Audit Logs</a></span>
+                        <span><a class="compare-table-link" href="{{ relref . "/docs/intro/console/audit-logs" }}">Audit logs</a></span>
                     </div>
                     <div class="compare-plans-table-row-item">
                         <span></span>
@@ -1056,6 +1056,21 @@
                     </div>
                     <div class="compare-plans-table-row-item">
                         <span><i class="fa fa-check pricing-checkmark mr-2"></i></span>
+                    </div>
+                </div>
+
+                <div class="compare-plans-table-row-container">
+                    <div class="compare-plans-table-row-item">
+                        <span><a class="compare-table-link" href="{{ relref . "/docs/intro/console/audit-logs#automated-export" }}">Audit logs automated export</a></span>
+                    </div>
+                    <div class="compare-plans-table-row-item">
+                        <span></span>
+                    </div>
+                    <div class="compare-plans-table-row-item">
+                        <span></span>
+                    </div>
+                    <div class="compare-plans-table-row-item">
+                        <span>Available</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
adding the audit logs export to pricing page
it is available to select enterprise customers, so we are listing it as available