### PR TITLE
Remove author packages workshop from CES

### DIFF
--- a/themes/default/content/cloud-engineering-summit/_index.md
+++ b/themes/default/content/cloud-engineering-summit/_index.md
@@ -13,14 +13,6 @@ sessionize_id: wbl7wd7l
 workshops:
   title: Workshops
   items:
-    - title: How to Author and Publish Pulumi Packages
-      icon: puzzle
-      icon_color: violet
-      link: /resources/build-reusable-infrastructure-as-code-patterns
-      times: [ "2021-10-21T12:00:00-07:00" ]
-      description: |
-        In this workshop, we’ll guide you through an example of building a reusable Pulumi component for a hypothetical “production ready application” in Python.
-
     - title: How to Build a Self-Service Cloud with Python
       icon: cloud-with-nodes
       icon_color: salmon

--- a/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
+++ b/themes/default/content/resources/build-reusable-infrastructure-as-code-patterns/index.md
@@ -7,7 +7,7 @@ meta_desc: "In this workshop, we’ll guide you through an example of building a
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars
@@ -50,7 +50,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/3BaDCrCw5FM"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-10-21T12:00:00-07:00
+    sortable_date: 2021-06-21T12:00:00-07:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.


### PR DESCRIPTION
This PR removes the `How to author Pulumi packages` workshop from the events listings and the Cloud Engineering Summit landing page.