### PR TITLE
Fix Python 'Import' example

### DIFF
--- a/themes/default/content/docs/guides/adopting/from_aws.md
+++ b/themes/default/content/docs/guides/adopting/from_aws.md
@@ -532,12 +532,13 @@ export const vpcId = vpc.id;
 {{% choosable language python %}}
 
 ```python
+import pulumi
 import pulumi_aws as aws
 
 vpc = aws.ec2.Vpc('myVpc',
     cidr_block='10.0.0.0/16',
     tags={ 'Name': 'Primary_CF_VPC' },
-    opts=ResourceOptions(import_='vpc-0e1a74859af1da17f')
+    opts=pulumi.ResourceOptions(import_='vpc-0e1a74859af1da17f')
 )
 
 pulumi.export('vpc_id', vpc.id)


### PR DESCRIPTION
The 'import VPC' code snippet for Python fails; `ResourceOptions` is not available without importing `pulumi` & specifying `pulumi.ResourceOptions`

Not sure if y'all prefer this style or using `from pulumi import ResourceOptions` & leaving the `opts` alone; happy to change if needbe.