### PR TITLE
Add a few missing env variables to "Environment Variables" page.

### DIFF
--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -6,15 +6,37 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
 <dl class="tabular tabular-5-col">
     <dt>
         <span class="font-mono">
-            PULUMI_HOME
+            PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK
         </span>
     </dt>
     <dd>
         <p>
-            Overrides the folder where the Pulumi CLI stores its artifacts: plugins, workspaces, templates, and
-            credentials file. By default, artifacts are stored next to Pulumi binaries in <code>~/.pulumi</code>.
+            Skips the minimum CLI version check used by Automation API to ensure compatibility. We do not recommend using this variable as it may result in unexpected behavior or confusing error messages from Automation API.
         </p>
-        <pre><code class="text-xs">PULUMI_HOME="/path/to/artifacts"</code></pre>
+        <pre><code class="text-xs">PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK=true</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_ACCESS_TOKEN
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Set this environment variable to authenticate into the Pulumi Service backend and bypass the access
+            token prompt when running {{% md %}}`pulumi login`{{% /md %}}.
+        </p>
+        <pre><code class="text-xs">PULUMI_ACCESS_TOKEN="your-access-token"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_BACKEND_URL
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Set this environment variable to use a specified backend instead of the default backend.  See <a href="/docs/intro/concepts/state">State and Backends</a> for details on valid backend URLs.
+        </p>
+        <pre><code class="text-xs">PULUMI_BACKEND_URL=s3://your-pulumi-state-bucket</code></pre>
     </dd>
     <dt>
         <span class="font-mono">
@@ -26,9 +48,49 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
             Sets <a href="/docs/intro/concepts/config">configuration</a> for <a href="/docs/guides/testing/unit">unit testing</a>. Must be in JSON format.
         </p>
         <p>
-            <b>This environment variable is ignored during normal Pulumi operations - e.g. {{% md %}}`up`, `pre`, etc{{% /md %}}</b>
+            <b>This environment variable is ignored during normal Pulumi operations - e.g. {{% md %}}`up`, `pre`, etc{{% /md %}}.</b>
         </p>
         <pre><code class="text-xs">PULUMI_HOME="{'project:myTag':'val1','project:mySecret':'val2'}"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_CONFIG_PASSPHRASE
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Set this as an environment variable to protect and unlock your configuration values and secrets. Your passphrase
+            is used to generate a unique key for your stack, and configuration and encrypted state values are then encrypted
+            using {{% md %}}`AES-256-GCM`{{% /md %}}.
+            Read <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#secrets-and-pluggable-encryption">the change log</a>
+            and <a href="/docs/intro/concepts/config">Configuration and Secrets</a> to learn more about Pulumi's configuration
+            and secrets management system.
+        </p>
+        <pre><code class="text-xs">PULUMI_CONFIG_PASSPHRASE="your-passphrase"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_CONSOLE_DOMAIN
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Overrides the domain used when generating links to the Pulumi Console.
+        </p>
+        <pre><code class="text-xs">PULUMI_CONSOLE_DOMAIN="yourhost.domain.com"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_DEBUG_PROMISE_LEAKS
+        </span>
+    </dt>
+    <dd>
+        <p>
+            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0166-2018-11-28"><code>v0.12.2</code></a>,
+            the promise leak experience has been improved and shows a simple error message. Set this environment variable to
+            get more verbose error messages when debugging promise leaks.
+        </p>
+        <pre><code class="text-xs">PULUMI_DEBUG_PROMISE_LEAKS=true</code></pre>
     </dd>
     <dt>
         <span class="font-mono">
@@ -59,48 +121,6 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dd>
     <dt>
         <span class="font-mono">
-            PULUMI_TEST_MODE
-        </span>
-    </dt>
-    <dd>
-        <p>
-            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0177-2019-04-17"><code>v0.17.7</code></a>,
-            you can enable a new "test mode" by setting this to {{% md %}}`true`{{% /md %}} in either the Node.js or Python SDK. This mode allows you
-            to unit test your Pulumi programs without needing to run them using the Pulumi CLI. Read the change log for details
-            on limitations and other environment variables that must be set.
-        </p>
-        <pre><code class="text-xs">PULUMI_TEST_MODE=true</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
-            PULUMI_CONFIG_PASSPHRASE
-        </span>
-    </dt>
-    <dd>
-        <p>
-            Set this as an environment variable to protect and unlock your configuration values and secrets. Your passphrase
-            is used to generate a unique key for your stack, and configuration and encrypted state values are then encrypted
-            using {{% md %}}`AES-256-GCM`{{% /md %}}.
-            Read <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#secrets-and-pluggable-encryption">the change log</a>
-            and <a href="/docs/intro/concepts/config">Configuration and Secrets</a> to learn more about Pulumi's configuration
-            and secrets management system.
-        </p>
-        <pre><code class="text-xs">PULUMI_CONFIG_PASSPHRASE="your-passphrase"</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
-            PULUMI_SKIP_UPDATE_CHECK
-        </span>
-    </dt>
-    <dd>
-        <p>
-            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0179-2019-04-30"><code>v0.17.9</code></a>,
-            you may skip the Pulumi version update check by setting this environment variable.
-        </p>
-        <pre><code class="text-xs">PULUMI_SKIP_UPDATE_CHECK=true</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
             PULUMI_ENABLE_LEGACY_PLUGIN_SEARCH
         </span>
     </dt>
@@ -112,6 +132,29 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
             environment variable to opt into the legacy plugin load behavior.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_PLUGIN_SEARCH=true</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_HOME
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Overrides the folder where the Pulumi CLI stores its artifacts: plugins, workspaces, templates, and
+            credentials file. By default, artifacts are stored next to Pulumi binaries in <code>~/.pulumi</code>.
+        </p>
+        <pre><code class="text-xs">PULUMI_HOME="/path/to/artifacts"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
+            PULUMI_PREFER_YARN
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Set this environment variable to opt-in to using {{% md %}}`yarn`{{% /md %}} instead of {{% md %}}`npm`{{% /md %}} for installing Node.js dependencies.
+        </p>
+        <pre><code class="text-xs">PULUMI_PREFER_YARN=true</code></pre>
     </dd>
     <dt>
         <span class="font-mono">
@@ -128,53 +171,6 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dd>
     <dt>
         <span class="font-mono">
-            PULUMI_ACCESS_TOKEN
-        </span>
-    </dt>
-    <dd>
-        <p>
-            Set this environment variable to authenticate into the Pulumi Service backend and bypass the access
-            token prompt when running {{% md %}}`pulumi login`{{% /md %}}.
-        </p>
-        <pre><code class="text-xs">PULUMI_ACCESS_TOKEN="your-access-token"</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
-            PULUMI_BACKEND_URL
-        </span>
-    </dt>
-    <dd>
-        <p>
-            Set this environment variable to use a specified backend instead of the default backend.  See <a href="/docs/intro/concepts/state">State and Backends</a> for details on valid backend URLs.
-        </p>
-        <pre><code class="text-xs">PULUMI_BACKEND_URL=s3://your-pulumi-state-bucket</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
-            PULUMI_DEBUG_PROMISE_LEAKS
-        </span>
-    </dt>
-    <dd>
-        <p>
-            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0166-2018-11-28"><code>v0.12.2</code></a>,
-            the promise leak experience has been improved and shows a simple error message. Set this environment variable to
-            get more verbose error messages when debugging promise leaks.
-        </p>
-        <pre><code class="text-xs">PULUMI_DEBUG_PROMISE_LEAKS=true</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
-            PULUMI_PREFER_YARN
-        </span>
-    </dt>
-    <dd>
-        <p>
-            Set this environment variable to opt-in to using {{% md %}}`yarn`{{% /md %}} instead of {{% md %}}`npm`{{% /md %}} for installing Node.js dependencies.
-        </p>
-        <pre><code class="text-xs">PULUMI_PREFER_YARN=true</code></pre>
-    </dd>
-    <dt>
-        <span class="font-mono">
             PULUMI_SKIP_CONFIRMATIONS
         </span>
     </dt>
@@ -188,25 +184,29 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dd>
     <dt>
         <span class="font-mono">
-            PULUMI_CONSOLE_DOMAIN
+            PULUMI_SKIP_UPDATE_CHECK
         </span>
     </dt>
     <dd>
         <p>
-            Overrides the domain used when generating links to the Pulumi Console.
+            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0179-2019-04-30"><code>v0.17.9</code></a>,
+            you may skip the Pulumi version update check by setting this environment variable.
         </p>
-        <pre><code class="text-xs">PULUMI_CONSOLE_DOMAIN="yourhost.domain.com"</code></pre>
+        <pre><code class="text-xs">PULUMI_SKIP_UPDATE_CHECK=true</code></pre>
     </dd>
     <dt>
         <span class="font-mono">
-            PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK
+            PULUMI_TEST_MODE
         </span>
     </dt>
     <dd>
         <p>
-            Skips the minimum CLI version check used by Automation API to ensure compatibility. We do not recommend using this variable as it may result in unexpected behavior or confusing error messages from Automation API.
+            As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0177-2019-04-17"><code>v0.17.7</code></a>,
+            you can enable a new "test mode" by setting this to {{% md %}}`true`{{% /md %}} in either the Node.js or Python SDK. This mode allows you
+            to unit test your Pulumi programs without needing to run them using the Pulumi CLI. Read the change log for details
+            on limitations and other environment variables that must be set.
         </p>
-        <pre><code class="text-xs">PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK=true</code></pre>
+        <pre><code class="text-xs">PULUMI_TEST_MODE=true</code></pre>
     </dd>
     <dt>
         <span class="font-mono">

--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -70,6 +70,17 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dd>
     <dt>
         <span class="font-mono">
+            PULUMI_CONFIG_PASSPHRASE_FILE
+        </span>
+    </dt>
+    <dd>
+        <p>
+            An alternative method to providing {{% md %}}`PULUMI_CONFIG_PASSPHRASE`{{% /md %}}. Set this to a path to a file that contains the passphrase value.
+        </p>
+        <pre><code class="text-xs">PULUMI_CONFIG_PASSPHRASE_FILE="/tmp/passphrase.txt"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
             PULUMI_CONSOLE_DOMAIN
         </span>
     </dt>

--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -36,7 +36,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
         <p>
             Set this environment variable to use a specified backend instead of the default backend.  See <a href="/docs/intro/concepts/state">State and Backends</a> for details on valid backend URLs.
         </p>
-        <pre><code class="text-xs">PULUMI_BACKEND_URL=s3://your-pulumi-state-bucket</code></pre>
+        <pre><code class="text-xs">PULUMI_BACKEND_URL="s3://your-pulumi-state-bucket"</code></pre>
     </dd>
     <dt>
         <span class="font-mono">
@@ -45,10 +45,10 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dt>
     <dd>
         <p>
-            Sets <a href="/docs/intro/concepts/config">configuration</a> for <a href="/docs/guides/testing/unit">unit testing</a>. Must be in JSON format.
+            Sets <a href="{{< relref "/docs/intro/concepts/config" >}}">configuration</a> for <a href="{{< relref "/docs/guides/testing/unit" >}}">unit testing</a>. Must be in JSON format.
         </p>
         <p>
-            <b>This environment variable is ignored during normal Pulumi operations - e.g. {{% md %}}`up`, `pre`, etc{{% /md %}}.</b>
+            <strong>This environment variable is ignored during normal Pulumi operations -- e.g., <code>up</code>, <code>preview</code>, etc.</strong>
         </p>
         <pre><code class="text-xs">PULUMI_HOME="{'project:myTag':'val1','project:mySecret':'val2'}"</code></pre>
     </dd>
@@ -61,7 +61,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
         <p>
             Set this as an environment variable to protect and unlock your configuration values and secrets. Your passphrase
             is used to generate a unique key for your stack, and configuration and encrypted state values are then encrypted
-            using {{% md %}}`AES-256-GCM`{{% /md %}}.
+            using <code>AES-256-GCM</code>.
             Read <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#secrets-and-pluggable-encryption">the change log</a>
             and <a href="/docs/intro/concepts/config">Configuration and Secrets</a> to learn more about Pulumi's configuration
             and secrets management system.
@@ -75,7 +75,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dt>
     <dd>
         <p>
-            An alternative method to providing {{% md %}}`PULUMI_CONFIG_PASSPHRASE`{{% /md %}}. Set this to a path to a file that contains the passphrase value.
+            An alternative method to providing <code>PULUMI_CONFIG_PASSPHRASE</code>. Set this to the path of a file that contains the passphrase value.
         </p>
         <pre><code class="text-xs">PULUMI_CONFIG_PASSPHRASE_FILE="/tmp/passphrase.txt"</code></pre>
     </dd>
@@ -111,8 +111,8 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#100-beta1-2019-08-13"><code>1.0.0-beta1</code></a>,
-            input properties are no longer propagated to missing output properties during a {{% md %}}`pulumi preview`{{% /md %}}. If this causes issues
-            in your Pulumi program, set this to {{% md %}}`true`{{% /md %}} to enable the old behavior.
+            input properties are no longer propagated to missing output properties during a <code>pulumi preview</code>. If this causes issues
+            in your Pulumi program, set this to <code>true</code> to enable the old behavior.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_APPLY=true</code></pre>
     </dd>
@@ -125,8 +125,8 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#01723-2019-07-16"><code>v0.17.23</code></a>,
             the detection of differences between the actual and desired state of a resource is left entirely up to that resource's
-            provider. This change can expose bugs in the resource providers that lead to diffs being present even if the desired
-            configuration matches the actual state of the resource. Set this to {{% md %}}`1`{{% /md %}} or {{% md %}}`true`{{% /md %}} to enable the old diff behavior.
+            provider. This change can expose bugs in resource providers that lead to diffs being present even if the desired
+            configuration matches the actual state of the resource. Set this to <code>1</code> or <code>true</code> to enable the old diff behavior.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_DIFF=true</code></pre>
     </dd>
@@ -163,7 +163,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dt>
     <dd>
         <p>
-            Set this environment variable to opt-in to using {{% md %}}`yarn`{{% /md %}} instead of {{% md %}}`npm`{{% /md %}} for installing Node.js dependencies.
+            Set this environment variable to opt-in to using <code>yarn</code> instead of <code>npm</code> for installing Node.js dependencies.
         </p>
         <pre><code class="text-xs">PULUMI_PREFER_YARN=true</code></pre>
     </dd>
@@ -175,7 +175,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0166-2018-11-28"><code>v0.16.6</code></a>,
-            the Pulumi CLI uses {{% md %}}`python3`{{% /md %}} instead of {{% md %}}`python`{{% /md %}} when running a Python program. Set this environment variable to
+            the Pulumi CLI uses <code>python3</code> instead of <code>python</code> when running a Python program. Set this environment variable to
             run a different Python binary.
         </p>
         <pre><code class="text-xs">PULUMI_PYTHON_CMD="python-version-binary"</code></pre>
@@ -213,7 +213,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0177-2019-04-17"><code>v0.17.7</code></a>,
-            you can enable a new "test mode" by setting this to {{% md %}}`true`{{% /md %}} in either the Node.js or Python SDK. This mode allows you
+            you can enable a new "test mode" by setting this to<code>true</code> in either the Node.js or Python SDK. This mode allows you
             to unit test your Pulumi programs without needing to run them using the Pulumi CLI. Read the change log for details
             on limitations and other environment variables that must be set.
         </p>

--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -38,8 +38,8 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#100-beta1-2019-08-13"><code>1.0.0-beta1</code></a>,
-            input properties are no longer propagated to missing output properties during a `pulumi preview`. If this causes issues
-            in your Pulumi program, set this to `true` to enable the old behavior.
+            input properties are no longer propagated to missing output properties during a {{% md %}}`pulumi preview`{{% /md %}}. If this causes issues
+            in your Pulumi program, set this to {{% md %}}`true`{{% /md %}} to enable the old behavior.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_APPLY=true</code></pre>
     </dd>
@@ -53,7 +53,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#01723-2019-07-16"><code>v0.17.23</code></a>,
             the detection of differences between the actual and desired state of a resource is left entirely up to that resource's
             provider. This change can expose bugs in the resource providers that lead to diffs being present even if the desired
-            configuration matches the actual state of the resource. Set this to `1` or `true` to enable the old diff behavior.
+            configuration matches the actual state of the resource. Set this to {{% md %}}`1`{{% /md %}} or {{% md %}}`true`{{% /md %}} to enable the old diff behavior.
         </p>
         <pre><code class="text-xs">PULUMI_ENABLE_LEGACY_DIFF=true</code></pre>
     </dd>
@@ -65,7 +65,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0177-2019-04-17"><code>v0.17.7</code></a>,
-            you can enable a new "test mode" by setting this to `true` in either the Node.js or Python SDK. This mode allows you
+            you can enable a new "test mode" by setting this to {{% md %}}`true`{{% /md %}} in either the Node.js or Python SDK. This mode allows you
             to unit test your Pulumi programs without needing to run them using the Pulumi CLI. Read the change log for details
             on limitations and other environment variables that must be set.
         </p>
@@ -80,7 +80,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
         <p>
             Set this as an environment variable to protect and unlock your configuration values and secrets. Your passphrase
             is used to generate a unique key for your stack, and configuration and encrypted state values are then encrypted
-            using `AES-256-GCM`.
+            using {{% md %}}`AES-256-GCM`{{% /md %}}.
             Read <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#secrets-and-pluggable-encryption">the change log</a>
             and <a href="/docs/intro/concepts/config">Configuration and Secrets</a> to learn more about Pulumi's configuration
             and secrets management system.
@@ -121,7 +121,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             As of <a href="https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md#0166-2018-11-28"><code>v0.16.6</code></a>,
-            the Pulumi CLI uses `python3` instead of `python` when running a Python program. Set this environment variable to
+            the Pulumi CLI uses {{% md %}}`python3`{{% /md %}} instead of {{% md %}}`python`{{% /md %}} when running a Python program. Set this environment variable to
             run a different Python binary.
         </p>
         <pre><code class="text-xs">PULUMI_PYTHON_CMD="python-version-binary"</code></pre>
@@ -134,7 +134,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     <dd>
         <p>
             Set this environment variable to authenticate into the Pulumi Service backend and bypass the access
-            token prompt when running `pulumi login`.
+            token prompt when running {{% md %}}`pulumi login`{{% /md %}}.
         </p>
         <pre><code class="text-xs">PULUMI_ACCESS_TOKEN="your-access-token"</code></pre>
     </dd>
@@ -169,7 +169,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dt>
     <dd>
         <p>
-            Set this environment variable to opt-in to using `yarn` instead of `npm` for installing Node.js dependencies.
+            Set this environment variable to opt-in to using {{% md %}}`yarn`{{% /md %}} instead of {{% md %}}`npm`{{% /md %}} for installing Node.js dependencies.
         </p>
         <pre><code class="text-xs">PULUMI_PREFER_YARN=true</code></pre>
     </dd>

--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -18,6 +18,20 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
     </dd>
     <dt>
         <span class="font-mono">
+            PULUMI_CONFIG
+        </span>
+    </dt>
+    <dd>
+        <p>
+            Sets <a href="/docs/intro/concepts/config">configuration</a> for <a href="/docs/guides/testing/unit">unit testing</a>. Must be in JSON format.
+        </p>
+        <p>
+            <b>This environment variable is ignored during normal Pulumi operations - e.g. {{% md %}}`up`, `pre`, etc{{% /md %}}</b>
+        </p>
+        <pre><code class="text-xs">PULUMI_HOME="{'project:myTag':'val1','project:mySecret':'val2'}"</code></pre>
+    </dd>
+    <dt>
+        <span class="font-mono">
             PULUMI_ENABLE_LEGACY_APPLY
         </span>
     </dt>


### PR DESCRIPTION
- Adds `PULUMI_CONFIG`
- Adds `PULUMI_CONFIG_PASSPHRASE_FILE`
- Alphabetize entries
- Fix code formatting