### PR TITLE
Add a push workflow, always use latest theme

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Fetch the latest pulumi/theme
         run: |
           hugo mod get github.com/pulumi/theme
+          hugo mod tidy
 
       - name: Commit any changes to go.mod/go.sum
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,38 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '14.x'
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Install Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.82.0'
+          extended: true
+
+      - name: Check out branch
+        uses: actions/checkout@v2
+
+      - name: Fetch the latest pulumi/theme
+        run: |
+          hugo mod get github.com/pulumi/theme
+
+      - name: Commit any changes to go.mod/go.sum
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: go.*
+          commit_message: Update go.mod


### PR DESCRIPTION
This change adds a `push` workflow that runs `hugo mod get github.com/pulumi/theme` whenever a change is merged to `master` and commit any `go.*` diffs to `master` as well. Most of the time, this won't have any effect. But on the off chance a change gets merged into `master` containing a  deliberately applied `go.mod` reference -- for example, when a developer is working concurrently on a branch of `pulumi/theme`, and wants to pin to that branch during development or for PR previews -- other runners of `make serve` or `make ci-pull-request` won't accidentally get an outdated (or even no-longer-existing) version of `pulumi/theme`.

This change only affects local development and PR previews. It won't have any effect on pulumi/docs builds or on other consumers of this module. The motivation is just to reduce potential confusion by making sure we're always tracking with the latest `pulumi/theme`. If this looks okay, I'll probably do the same on `pulumi/registry` and `pulumi/hugo-internal`, as it'd keep us from having to use the awkward `git update-index --no-skip-worktree` hack to selectively apply Hugo module pins.