### PR TITLE
Update CES with recordings of workshops

### DIFF
--- a/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
+++ b/themes/default/content/resources/building-event-driven-communications-with-twilio-and-aws/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: ""
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
+++ b/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
@@ -7,7 +7,7 @@ meta_desc: "Join Damian Curry & Elijah Zupancic and go from zero to production o
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars

--- a/themes/default/content/resources/getting-started-with-automation-api/index.md
+++ b/themes/default/content/resources/getting-started-with-automation-api/index.md
@@ -7,7 +7,7 @@ meta_desc: "In this workshop, you’ll build a Python & Flask web application th
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars

--- a/themes/default/content/resources/getting-started-with-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-aws/index.md
@@ -10,7 +10,7 @@ aliases:
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -23,7 +23,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars
@@ -56,7 +56,7 @@ main:
     # Webinar title.
     title: "Getting Started with Infrastructure as Code on AWS"
     # URL for embedding a URL for ungated webinars.
-    youtube_url: ""
+    youtube_url: "https://www.youtube.com/embed/haTaQubGTEo"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2020-10-21T09:00:00-07:00
     # Duration of the webinar.

--- a/themes/default/content/resources/getting-started-with-azure-native/index.md
+++ b/themes/default/content/resources/getting-started-with-azure-native/index.md
@@ -7,7 +7,7 @@ meta_desc: "In this workshop, you’ll use the Azure native provider to build in
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars

--- a/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
+++ b/themes/default/content/resources/getting-started-with-google-cloud-platform/index.md
@@ -7,7 +7,7 @@ meta_desc: "In this workshop, we’ll use the Google Cloud native provider to bu
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -20,7 +20,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars

--- a/themes/default/content/resources/kubecon-na-2021/index.md
+++ b/themes/default/content/resources/kubecon-na-2021/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: ""
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/scale-kubernetes-on-any-cloud-with-spot/index.md
+++ b/themes/default/content/resources/scale-kubernetes-on-any-cloud-with-spot/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: ""
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/layouts/page/cloud-engineering-summit.html
+++ b/themes/default/layouts/page/cloud-engineering-summit.html
@@ -125,7 +125,7 @@
                                 {{ end }}
                             </div>
                             <div class="card-cta-btn">
-                                <a href="{{ $item.link }}" class="btn-primary">Save your spot</a>
+                                <a href="{{ $item.link }}" class="btn-primary">Watch on-demand</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This PR switches the workshops from CES back to their recordings. This also cleans up some old external events from the lsiting.