### PR TITLE
Fixed Swiftype Search Modal overlay on Safari

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b // indirect
-	github.com/pulumi/theme v0.0.0-20211025172707-d60f9ad59328 // indirect
+	github.com/pulumi/theme v0.0.0-20211101174505-358f8e2823f5 // indirect
 )
 
 replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b 
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
 github.com/pulumi/theme v0.0.0-20211025172707-d60f9ad59328 h1:Ni89YJeIbi6z2NoatAe3Rx41hKP0i4Oj5KtXZpB7sdo=
 github.com/pulumi/theme v0.0.0-20211025172707-d60f9ad59328/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211101174505-358f8e2823f5 h1:fYjTL8gUZ+c+1IWGlak0tYBTznXiTYmTJCzU7nYB4nw=
+github.com/pulumi/theme v0.0.0-20211101174505-358f8e2823f5/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=

--- a/themes/default/layouts/partials/docs/search.html
+++ b/themes/default/layouts/partials/docs/search.html
@@ -17,7 +17,4 @@
                 placeholder="Search the docs" />
         </form>
     </div>
-    <div id="search-results" class="relative">
-
-    </div>
 </div>

--- a/themes/default/layouts/partials/docs/search.html
+++ b/themes/default/layouts/partials/docs/search.html
@@ -17,4 +17,7 @@
                 placeholder="Search the docs" />
         </form>
     </div>
+    <div id="search-results" class="relative">
+
+    </div>
 </div>


### PR DESCRIPTION
Safari appears to have slightly different interpretations about [z-index stacking](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/) from Chromium based browsers. I'm not exactly sure what that distinction is (probably comes into play because the positioning of modals is typically done with `absolute` or `relative` positioning), but the implication is that if we render a modal that we want displayed _appearing_ at "root" level, it needs to be at that place in the DOM tree for Safari to render it how we want.

This bug occurred because creating a div with an ID of `#search-results` will override Swiftype default behavior which manages injecting the search results modal when you submit your search. By default, Swiftype injects at the first level below the `body` tag in the DOM tree, which is what we want.

Since we weren't leveraging anything, I removed the div that was overriding Swiftype and this fixed the issue in Safari (things still work in Chrome and Firefox)

## Issue
Fixes #602 