### PR TITLE
Update min Go version

### DIFF
--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -10,7 +10,7 @@ menu:
 
 <img src="/logos/tech/logo-golang.png" align="right" width="150" style="padding:8px; margin-top: -64px">
 
-Pulumi supports writing your infrastructure as code using the Go language. Go 1.14 or later is required.
+Pulumi supports writing your infrastructure as code using the Go language. Go 1.16 or later is required.
 
 <a class="btn" href="https://golang.org/doc/install" target="_blank" title="Install Go">INSTALL GO</a>
 


### PR DESCRIPTION
I go an error with the message

> embed: package embed is not in GOROOT

when using Pulumi with Golang version 1.15.

Since `embed` was introduced in version 1.16 I believe this is the minimum version, updating to this version did solve the problem with embed.