### PR TITLE
remove quote thats not a quote from shortcode

### DIFF
--- a/themes/default/layouts/shortcodes/aws-resource-note.html
+++ b/themes/default/layouts/shortcodes/aws-resource-note.html
@@ -1,7 +1,11 @@
-<blockquote>
-    <p>
-        If you do not already have an AWS account, you can <a href="https://aws.amazon.com/free/">create a free account</a>.  Most
+<div class="note note-info" role="alert">
+    <div class="note-heading">
+        <i class="fas fa-info-circle mr-1"></i>
+        <span>Note</span>
+    </div>
+    <div class="note-body">
+        If you do not already have an AWS account, you can <a href="https://aws.amazon.com/free/">create a free aws account</a>. Most
         resources in our examples fall within the AWS Free Tier, but we encourage you to follow the cleanup steps at the end
         of each section to avoid paying for resources you aren't using.
-    </p>
-</blockquote>
+    </div>
+</div>


### PR DESCRIPTION
## overview
- we should not be using quote styling for things that are not quotes, this removes it and uses the note styling instead
- note that we are repeating the note definition because you cannot use a shortcode inside of another shortcode definition

note to reviewers: i don't believe you will be able to preview this anywhere until it gets to the docs