### PR TITLE
Add Registry for local dev and PR previews

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,9 +27,10 @@ jobs:
       - name: Check out branch
         uses: actions/checkout@v2
 
-      - name: Fetch the latest pulumi/theme
+      - name: Fetch the latest pulumi/theme and pulumi/registry
         run: |
-          hugo mod get github.com/pulumi/theme
+          hugo mod get github.com/pulumi/theme@release
+          hugo mod get github.com/pulumi/registry/themes/default
           hugo mod tidy
 
       - name: Commit any changes to go.mod/go.sum

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -13,6 +13,18 @@ module:
           target: static
         - source: layouts
           target: layouts
+    - path: github.com/pulumi/registry/themes/default
+      mounts:
+        - source: content
+          target: content
+        - source: static
+          target: static
+        - source: layouts
+          target: layouts
+        - source: data
+          target: data
+        - source: assets
+          target: assets
     - path: github.com/pulumi/pulumi-hugo/themes/default
       mounts:
         - source: content

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.16
 
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b // indirect
-	github.com/pulumi/theme v0.0.0-20211108163233-0230241dd112 // indirect
+	github.com/pulumi/registry/themes/default v0.0.0-20211119210730-9f5be7c53a5d // indirect
+	github.com/pulumi/theme v0.0.0-20211108163359-c36ffaafaf67 // indirect
 )
 
 replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b h1:/+gZBBNEk+X2/VazRUy/hvlnLN4smDxI+Ny6GuvT//0=
-github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
+github.com/pulumi/registry/themes/default v0.0.0-20211119210730-9f5be7c53a5d h1:UvuoeB+cI0Qh+QulWNlC/ANDkDQyCmC7GYEe3ST741g=
+github.com/pulumi/registry/themes/default v0.0.0-20211119210730-9f5be7c53a5d/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=
 github.com/pulumi/theme v0.0.0-20211108163233-0230241dd112 h1:a6YtuozPiFFLjzRXebxBLac+BrxeHq1o6nVJoucu55I=
 github.com/pulumi/theme v0.0.0-20211108163233-0230241dd112/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20211108163359-c36ffaafaf67 h1:Qb27rluTgRxp4eJHvzhLwGPkhjXb0hLfuUdNOtS2Ypw=
+github.com/pulumi/theme v0.0.0-20211108163359-c36ffaafaf67/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=


### PR DESCRIPTION
It's a bit cumbersome not to have at least some Registry content available while developing in this module. So this change just makes the Registry module available for development and PR previews.