### PR TITLE
Update _index.md

### DIFF
--- a/themes/default/content/docs/guides/crossguard/_index.md
+++ b/themes/default/content/docs/guides/crossguard/_index.md
@@ -8,9 +8,11 @@ menu:
         weight: 6
 ---
 
-CrossGuard is Pulumi's new Policy as Code offering. CrossGuard empowers you to set guardrails to enforce compliance for resources so developers within an organization can provision their own infrastructure while sticking to best practices and security compliance. Using Policy as Code, you can write flexible business or security policies.
+CrossGuard is Pulumi's Policy as Code offering. CrossGuard empowers you to set guardrails to enforce compliance for resources so developers within an organization can provision their own infrastructure while sticking to best practices and security compliance. Using Policy as Code, you can write flexible business or security policies.
 
 Using CrossGuard, organization administrators can apply these rules to particular stacks within their organization. When policies are executed as part of your Pulumi deployments, any violation will gate or block that update from proceeding.
+
+Learn more about [Policy as Code core concepts]({{< relref "/docs/guides/crossguard/core-concepts" >}}).
 
 ## Languages
 


### PR DESCRIPTION
The Crossguard core concepts page is buried in the getting started flow.
So I added the link early in the flow. 
Also, I didn't think we should keep calling the capability "new".