### PR TITLE
Add Registry to sections which use anchor-js

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -134,7 +134,7 @@
     {{- end }}
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->
-    {{ if and (not .IsHome) (.Section) (in "docs blog authors tags" .Section) }}
+    {{ if and (not .IsHome) (.Section) (in "docs blog authors tags registry" .Section) }}
         <script async defer src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js"></script>
         <script>
             // Wait for the window's `load` event to ensure the deferred anchor.js script has finished loading as well.


### PR DESCRIPTION
AnchorJS, which we use for our auto-anchor links to sections in our docs, is not running in the Registry section of the site. This adds such support.

## Related issues
1/2 of fixes for https://github.com/pulumi/registry/issues/239

See [this PR](https://github.com/pulumi/registry/pull/308) for remaining work.