### PR TITLE
Fix some SEO issues and warnings

### DIFF
--- a/themes/default/layouts/page/pulumi-up.html
+++ b/themes/default/layouts/page/pulumi-up.html
@@ -6,8 +6,10 @@
             </video>
             <div class="pulumiup-title">
                 <div class="neon-container">
-                    <span class="blue-neon-sign-xl">Pulumi</span>
-                    <span class="green-neon-sign-xl">UP</span>
+                    <h1>
+                        <span class="blue-neon-sign-xl">Pulumi</span>
+                        <span class="green-neon-sign-xl">UP</span>
+                    </h1>
                 </div>
                 <div class="flex justify-center items-center">
                     <a href="#main-event" class="btn btn-orange inline-block ml-8 orange-neon">Watch The Announcements</a>

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -89,7 +89,14 @@
         {{ else }}
             <meta class="swiftype" name="title" data-type="string" content="{{ .Title }}" />
         {{ end }}
-        <title>{{ .Title }} | Pulumi</title>
+
+        <!-- The blog tags, specifically the tag lists, end up clashing with other page titles on the website. We
+             add "Blog" to the title so that the titles no longer clash. -->
+        {{ if and (eq .Type "blog") .IsPage}}
+            <title>{{ .Title }} | Pulumi Blog</title>
+        {{ else }}
+            <title>{{ .Title }} | Pulumi</title>
+        {{ end }}
     {{ else if not (or .Params.redirect_to .Params.private) }}
         <!--
             TODO[pulumi/docs#1127]: can't enable this until Python docs are fixed.

--- a/themes/default/layouts/partials/right-nav-ad.html
+++ b/themes/default/layouts/partials/right-nav-ad.html
@@ -1,5 +1,5 @@
 <div class="mt-8">
-    <a href="/cloud-engineering-summit/replay">
+    <a href="/cloud-engineering-summit/replay/">
         <img src="/images/cloud-engineering-summit-on-demand-banner.png" alt="Watch the Cloud Engineering Summit sessions on-demand." />
     </a>
 </div>


### PR DESCRIPTION
This PR fixes some SEO issues identified within SEMrush. The biggest issue we have are some duplicate Title tags, mostly from Blog "tag" pages. There were also a ton a 302 redirect warnings because there was a missing `/` at the end of the CES CTA.