### PR TITLE
Include note about Go 1.16 minimum

### DIFF
--- a/themes/default/layouts/shortcodes/install-go.html
+++ b/themes/default/layouts/shortcodes/install-go.html
@@ -11,11 +11,7 @@
         <p>
             Pulumi requires Go 1.16 or later. If you're using Linux, your distribution may not
             provide an up to date version of the Go compiler. To check what version of Go you have
-            installed, <code>go version</code> will tell you:
+            installed, use:<code>go version</code>.
         </p>
-<pre><code>
-$ go version
-go version go1.17.1 darwin/arm64
-</code></pre>
     </div>
 </div>

--- a/themes/default/layouts/shortcodes/install-go.html
+++ b/themes/default/layouts/shortcodes/install-go.html
@@ -1,3 +1,21 @@
 <p class="mt-4">
     Install <strong><a href="https://golang.org/doc/install" target="_blank">Go</a></strong>. <br/>
 </p>
+
+<div class="note note-info" role="alert">
+    <div class="note-heading">
+        <i class="fas fa-info-circle mr-1"></i>
+        <span>Note</span>
+    </div>
+    <div class="note-body">
+        <p>
+            Pulumi requires Go 1.16 or later. If you're using Linux, your distribution may not
+            provide an up to date version of the Go compiler. To check what version of Go you have
+            installed, <code>go version</code> will tell you:
+        </p>
+<pre><code>
+$ go version
+go version go1.17.1 darwin/arm64
+</code></pre>
+    </div>
+</div>


### PR DESCRIPTION
New users who are on older versions of Go may encounter an error with `embed` being required by newer versions of Pulumi. 

Ran into this while I was getting started with the tool -- Debian is shipping 1.15 and Ubuntu LTS ships with 1.13. This won't matter for too long -- Debian will be shipping 1.17 in `testing` soon and the next Ubuntu LTS will likely ship with an up to date version. 

