### PR TITLE
update footer link and link text; apis -> registry

### DIFF
--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -10,7 +10,7 @@
                 <li><a data-track="footer-get-started" href="{{ relref . "/docs/get-started" }}" class="link">Get Started</a></li>
                 <li><a data-track="footer-install" href="{{ relref . "/docs/get-started/install" }}" class="link">Install</a></li>
                 <li><a data-track="footer-documentation" href="{{ relref . "/docs/reference" }}" class="link">Documentation</a></li>
-                <li><a data-track="footer-apis" href="{{ relref . "/docs/reference/pkg" }}" class="link">APIs</a></li>
+                <li><a data-track="footer-apis" href="{{ relref . "/registry" }}" class="link">Registry</a></li>
             </ul>
 
             <ul>


### PR DESCRIPTION
## overview

we have an apis link in the footer that went to the docs API reg list page which we will prolly be removing at some point in the future; i updated the link to send you to registry and use that link text; if anyone feels strongly that it should be `Pulumi Registry` instead of just registry pls let me know, happy to update