### PR TITLE
Add video to what is iac page

### DIFF
--- a/themes/default/content/what-is/what-is-infrastructure-as-code.md
+++ b/themes/default/content/what-is/what-is-infrastructure-as-code.md
@@ -28,6 +28,38 @@ customer_logos:
       - webflow
       - supabase
       - ro
+
+video:
+  title: "A Quick Bite of Cloud Engineering: Infrastructure as Code"
+  description: |
+    What is infra as code (IaC)? Get a quick overview with Laura, one of Pulumi's developer advocates, in this episode of Quick Bites of Cloud Engineering.
+  youtube_url: "https://www.youtube.com/embed/WhWf48kcEXU"
+  transcript: |
+    Welcome to your first quick bite of cloud engineering. I am Laura, and today we're gonna talk about infrastructure as code. So, what exactly is infrastructure as code? Infra as code, or IAC, is the idea that infrastructure configuration should be treated just as you would treat your code.
+
+    So, that means putting it into source control, updating it with commits, doing code reviews, automating it as much as you possibly can, versioning it, testing it. IAC helps us automate the provisioning of infrastructure, which reduces mistakes. And, allows us to have multiple, near identical environments, without configuration drift. We can declare our configuration, and avoid hard coding secrets in, which in turn, helps to secure our systems.
+
+    Why, exactly, does all of this really matter? Well, we can trigger builds of ephemeral or short-term environments, for things like development work, unit testing and integration testing, smoke testing, load testing, any kind of testing you really can think about. Security reviews, these environments can look and act exactly like production. Because, they're set up and built exactly the same way. All driven by code. Sure, you could use a cloud dashboard to set up everything, and somehow point and click your way through, to actually deploying your application.
+
+    But, what happens if you click the wrong button and delete something? Or, your entire system goes down overnight? Or, maybe you just need to move to a new cloud provider? You can't remember what you set up, or the order you set it up in cause everything is named differently? We're developers and engineers. Instead of doing that point and click system, we write these instructions into code, to manage that infrastructure, leaving us with a source controlled, repeatable process that we can take anywhere, and scale on any system.
+
+    Now, when we think about doing all of this, in real life, there's a few approaches you can do. You certainly can script up something with bash, and a cloud CLI, but that doesn't really track state, meaning where everything is. Or, the transitions between two states. Or, give us any other familiar tools.
+
+    IAC, on the other hand, works by declaring a goal state. What you want your infrastructure to look like, when it is stable, deployed, and running as normal. To do that, we let an oracle, or the IAC engine, decide how best to carry out deployments. Both for brand new environments, or environments that are currently existing, that we want to actually scale up. These kinds of solutions are much better than your typical manual, or scripting changes.
+
+    The first infra as code solutions use templating languages, like YAML and JSON. And nearly all cloud providers offer this type of solution. They can be very useful, because they're native to the ecosystem. But you do end up with vendor lock in, which can be expensive, if you want to change. And, obviously, you can't run systems across multiple clouds with that single tool, because it's locked into that specific vendor. There's also solutions like Terraform, which use a specific templating language, that can span cloud providers, to declare that goal state that you actually want.
+
+    That means you can work with, again, those systems across multiple ones, making it easy to switch from one cloud to another. However, while these systems do actually have an idea of state, you still have to manage the state file, which is where everything's stored, all by yourself. And, you have to learn specialized languages and tools to be able to actually use something like it.
+
+    Now, modern infra is complex. And, there's a lot of teams working in any platform, at any given time. We can't afford to continue to widen the gap between app teams and infra teams, and devs, and ops, and infrastructure, and security. So, there's new players in the field. And, this is where I might get a little bit biased. These new infra as code systems, known as, cloud engineering systems, like Pulumi, let you accomplish the same robust goal, of a good IAC system, but with everything we know and love about our favorite programming languages.
+
+    We can use expressive capabilities, like four loops, abstraction and encapsulation, with classes and functions, and share and reuse common patterns, using packages. We can use our favorite tools, like linters, editors, debuggers, and test ring works. By doing so, we bring apps and infra closer together, and help devs and infrastructure experts collaborate more closely, all with a system that manages state for you, rather than having to manage it yourself.
+
+    Of course, you can also go the DIY route, and build off the open source projects that are behind systems, like Terraform and Pulumi. Why would you want to do that? Well, you own it. You know how it works. You know where everything lives. You know why it works, and you know how to secure it. Or, you know how you secured it. However, there's the downside of you own it. You have to be there when it breaks, and you need to spend the time and money to continue to maintain it, and manage that entire system.
+
+    It's really up to you. Overall, infra as code has been a great tool to work with the complexity of modern cloud based systems. We have a repeatable, scalable process to get the infrastructure we need, when we need it, and ship the features that we need, quickly. So, we can focus on getting out good code. This has been your quick bite of cloud engineering for this week.
+
+    I'll be back in two weeks on Wednesday, to do another quick bite, for another topic on cloud engineering. So, subscribe if you want to get notified for the next episode. If you want to hear anything specific, leave me a note down in the comments, and we'll see if we can get that answered for ya. Anyway, that's it for Quick Bites. Take care. Bye.
 ---
 
 Infrastructure as code (IaC) means using code to define and manage infrastructure. **Infrastructure as code is about bringing software engineering principles and approaches into the cloud infrastructure space.**

--- a/themes/default/layouts/what-is/single.html
+++ b/themes/default/layouts/what-is/single.html
@@ -20,6 +20,29 @@
         <div class="container mx-auto">
             <div class="lg:flex lg:justify-end">
                 <div class="lg:max-w-5xl">
+                    {{ with .Params.video }}
+                        <div class="card p-6 my-12">
+                            <h4>{{ .title}}</h4>
+                            <div>
+                                <div class="" style="position: relative; padding-bottom: 48.25%; height: 0; overflow: hidden;">
+                                    <iframe src="{{ .youtube_url }}" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" allowfullscreen=""></iframe>
+                                </div>
+                                <p>
+                                    {{ .description }}
+                                </p>
+                            </div>
+                            <div>
+                                <div class="accordion-item text-2xl py-3 border-b-2 border-t-2">
+                                    {{ partial "accordian-header" (dict "text" "Transcript" "large_header" false) }}
+
+                                    <div class="accordion-item-body-no-animation text-base">
+                                        <p>{{ .transcript | markdownify }}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {{ end }}
+
                     <div class="bg-white px-3">
                         {{ .Content }}
                     </div>


### PR DESCRIPTION
This PR adds support for videos on the "What is" pages.

Fixes: https://github.com/pulumi/pulumi-hugo/issues/834