### PR TITLE
Add AWS Crosswalk IAM exmaples in all languages

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/aws/iam.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/iam.md
@@ -56,7 +56,9 @@ OR across all of those policies when evaluating them.
 For more extensive details about IAM policies and their contents, refer to the [AWS access policies documentation](
 https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html).
 
-### Using the PolicyDocument Interface
+{{% choosable language typescript %}}
+
+### Strongly Typed Policy Documents
 
 Pulumi Crosswalk for AWS defines [the `aws.iam.PolicyDocument` interface](
 {{< relref "/registry/packages/aws/api-docs/iam" >}}) to add strong type checking to your policy documents. By using
@@ -91,6 +93,10 @@ const role = new aws.iam.Role("instance-role", {
 const profile = new aws.iam.InstanceProfile("instance-profile", { role });
 ```
 
+{{% /choosable %}}
+
+{{% choosable language "typescript,javascript" %}}
+
 ### Using Pre-Defined IAM Managed Policies
 
 An AWS managed policy is a standalone policy that is created and administered by AWS. Standalone policy means that
@@ -111,7 +117,12 @@ const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("rpa", {
 For a full list of available managed policy ARNs, refer to the
 [API documentation]({{< relref "/registry/packages/aws/api-docs/iam" >}}).
 
+{{% /choosable %}}
+
 ## Creating IAM Users, Groups, and Roles
+
+The primary IAM object types are users, groups, and roles. This section demonstrates how they
+relate and how to create and configure them.
 
 ### IAM Users
 
@@ -120,6 +131,10 @@ application that uses it to interact with AWS. A user in AWS consists of a name 
 
 Use the [`User` resource]({{< relref "/registry/packages/aws/api-docs/iam/user" >}}) to create new
 IAM users. This example creates an IAM user and attaches a policy:
+
+{{< chooser language "typescript,python,go,csharp" / >}}
+
+{{% choosable language "javascript,typescript" %}}
 
 ```typescript
 import * as aws from "@pulumi/aws";
@@ -141,6 +156,134 @@ const userPolicy = new aws.iam.UserPolicy("webmasterPolicy", {
     },
 });
 ```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import json
+import pulumi_aws as aws
+
+user = aws.iam.User('webmaster',
+    path='/system/',
+    tags={ 'Name': 'webmaster' },
+)
+user_access_key = aws.iam.AccessKey('webmasterKey',
+    user=user.name,
+)
+user_policy = aws.iam.UserPolicy('webmasterPolicy',
+    user=user.id,
+    policy=json.dumps({
+        'Version': '2012-10-17',
+        'Statement': [{
+            'Action': [ 'ec2:Describe*' ],
+            'Effect': 'Allow',
+            'Resource': '*'
+        }],
+    }),
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		user, err := iam.NewUser(ctx, "webmaster", &iam.UserArgs{
+			Path: pulumi.String("/system/"),
+			Tags: pulumi.StringMap{
+				"Name": pulumi.String("webmaster"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		userAccessKey, err := iam.NewAccessKey(ctx, "webmasterKey", &iam.AccessKeyArgs{
+			User: user.Name,
+		})
+		if err != nil {
+			return err
+		}
+
+		userPolicy, err := iam.NewUserPolicy(ctx, "webmasterPolicy", &iam.UserPolicyArgs{
+			User: user.ID().ToStringOutput(),
+			Policy: pulumi.String(`{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Action": [ "ec2:Describe*" ],
+		"Effect": "Allow",
+		"Resource": "*"
+	}]
+}
+`),
+		})
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("userId", user.ID())
+		ctx.Export("userAccessKeyId", userAccessKey.ID())
+		ctx.Export("userPolicyId", userPolicy.ID())
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using Pulumi;
+using Iam = Pulumi.Aws.Iam;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var user = new Iam.User("webmaster", new Iam.UserArgs
+        {
+            Path = "/system",
+            Tags = new Dictionary<string, string>
+            {
+                { "Name", "webmaster" },
+            }.ToImmutableDictionary(),
+        });
+        var userAccessKey = new Iam.AccessKey("webmasterKey", new Iam.AccessKeyArgs
+        {
+            User = user.Name,
+        });
+        var userPolicy = new Iam.UserPolicy("webmasterPolicy", new Iam.UserPolicyArgs
+        {
+            User = user.Name,
+            Policy = @"{
+    ""Version"": ""2012-10-17"",
+    ""Statement"": [{
+        ""Action"": [ ""ec2:Describe*"" ],
+        ""Effect"": ""Allow"",
+        ""Resource"": ""*""
+    }]
+}
+",
+        });
+    }
+}
+```
+
+{{% /choosable %}}
 
 For more options available when configuring IAM users, see the [API documentation](
 {{< relref "/registry/packages/aws/api-docs/iam/user" >}}).
@@ -167,6 +310,10 @@ them from the old groups and add them to the appropriate new groups.
 Use the [`Group` resource]({{< relref "/registry/packages/aws/api-docs/iam/group" >}}) to manage
 IAM groups. For example, this code creates a new group for an organization's developers, specifies a policy for that
 group, and adds a couple users into it, thereby granting them permissions from the developer group all at once:
+
+{{< chooser language "typescript,python,go,csharp" / >}}
+
+{{% choosable language "javascript,typescript" %}}
 
 ```typescript
 import * as aws from "@pulumi/aws";
@@ -198,6 +345,161 @@ const devTeam = new aws.iam.GroupMembership("dev-team", {
 });
 ```
 
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import json
+import pulumi_aws as aws
+
+# Create our users.
+jane = aws.iam.User('jane', ...)
+mary = aws.iam.User('mary', ...)
+
+# Define a group and assign a policy for it.
+devs = aws.iam.Group('devs',
+    path='/users/',
+)
+my_developer_policy = aws.iam.GroupPolicy('my_developer_policy',
+    group=devs.id,
+    policy=json.dumps({
+        'Version': '2012-10-17',
+        'Statement': [{
+            'Action': [ 'ec2:Describe*' ],
+            'Effect': 'Allow',
+            'Resource': '*',
+        }],
+    }),
+)
+
+# Finally add the users as members to this group.
+dev_team = aws.iam.GroupMembership('dev-team',
+    group=devs.id,
+    users=[ jane.id, mary.id ],
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create our users.
+		jane, err := iam.NewUser(ctx, "jane", &iam.UserArgs{...})
+		if err != nil {
+			return err
+		}
+		mary, err := iam.NewUser(ctx, "mary", &iam.UserArgs{...})
+		if err != nil {
+			return err
+		}
+
+		// Define a group and assign a policy for it.
+		devs, err := iam.NewGroup(ctx, "devs", &iam.GroupArgs{
+			Path: pulumi.String("/users/"),
+		})
+		if err != nil {
+			return err
+		}
+		myDeveloperPolicy, err := iam.NewGroupPolicy(
+			ctx, "my_developer_policy", &iam.GroupPolicyArgs{
+				Group: devs.ID().ToStringOutput(),
+				Policy: pulumi.String(`{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Action": [ "ec2:Describe*" ],
+		"Effect": "Allow",
+		"Resource": "*"
+	}]
+}
+`),
+            },
+		)
+		if err != nil {
+			return err
+		}
+
+		// Finally add the users as members to this group.
+		devTeam, err := iam.NewGroupMembership(
+			ctx, "dev-team", &iam.GroupMembershipArgs{
+				Group: devs.ID().ToStringOutput(),
+				Users: pulumi.StringArray{
+					jane.ID().ToStringOutput(),
+					mary.ID().ToStringOutput(),
+				},
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		ctx.Export("devsGroupId", devs.ID())
+		ctx.Export("devsGroupPolicyId", myDeveloperPolicy.ID())
+		ctx.Export("devsGroupMembershipId", devTeam.ID())
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using Pulumi;
+using Iam = Pulumi.Aws.Iam;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        // Create our users.
+        var jane = new Iam.User("jane", new Iam.UserArgs{});
+        var mary = new Iam.User("mary", new Iam.UserArgs{});
+
+        // Define a group and assign a policy for it.
+        var devs = new Iam.Group("devs", new Iam.GroupArgs
+        {
+            Path = "/users/",
+        });
+        var myDeveloperPolicy = new Iam.GroupPolicy("my_developer_policy", new Iam.GroupPolicyArgs
+        {
+            Group = devs.Id,
+            Policy = @"{
+    ""Version"": ""2012-10-17"",
+    ""Statement"": [{
+        ""Action"": [ ""ec2:Describe*"" ],
+        ""Effect"": ""Allow"",
+        ""Resource"": ""*""
+    }]
+}
+",
+        });
+
+        // Finally add the users as members to this group.
+        var devTeam = new Iam.GroupMembership("dev-team", new Iam.GroupMembershipArgs
+        {
+            Group = devs.Id,
+            Users = { jane.Id, mary.Id },
+        });
+    }
+}
+```
+
+{{% /choosable %}}
+
 For more information, refer to the API documentation for [groups](
 {{< relref "/registry/packages/aws/api-docs/iam/group" >}}), [group membership](
 {{< relref "/registry/packages/aws/api-docs/iam/groupmembership" >}}), and [group policies](
@@ -217,6 +519,10 @@ you assume a role, it provides you with temporary security credentials for your 
 
 To manage IAM roles, use the [`Role` resource]({{< relref "/registry/packages/aws/api-docs/iam/role" >}}).
 The following example creates a new role with a custom policy document, and also attaches a managed policy afterwards:
+
+{{< chooser language "typescript,python,go,csharp" / >}}
+
+{{% choosable language "javascript,typescript" %}}
 
 ```typescript
 import * as aws from "@pulumi/aws";
@@ -240,15 +546,165 @@ const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("my-rpa", {
 });
 ```
 
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+import json
+import pulumi_aws as aws
+
+role = aws.iam.Role('my-role',
+    assume_role_policy=json.dumps({
+        'Version': '2012-10-17',
+        'Statement': [{
+            'Action': 'sts:AssumeRole',
+            'Principal': {
+                'Service': 'ec2.amazonaws.com'
+            },
+            'Effect': 'Allow',
+            'Sid': '',
+        }],
+    }),
+)
+role_policy_attachment = aws.iam.RolePolicyAttachment('my-rpa',
+    role=role.id,
+    policy_arn='arn:aws:iam::aws:policy/ReadOnlyAccess',
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		role, err := iam.NewRole(ctx, "my-role", &iam.RoleArgs{
+			AssumeRolePolicy: pulumi.String(`{
+	"Version": "2012-10-17",
+	"Statement": [{
+		"Action": [ "sts:AssumeRole" ],
+		"Principal": {
+			"Service": "ec2.amazonaws.com"
+		},
+		"Effect": "Allow",
+		"Sid": ""
+	}]
+}
+`),
+		    },
+		)
+		if err != nil {
+			return err
+		}
+
+		_, err = iam.NewRolePolicyAttachment(
+			ctx, "my-rpa", &iam.RolePolicyAttachmentArgs{
+				Role:      role.ID().ToStringOutput(),
+				PolicyArn: pulumi.String("arn:aws:iam::aws:policy/ReadOnlyAccess"),
+			},
+		)
+		return err
+	})
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+using Pulumi;
+using Iam = Pulumi.Aws.Iam;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var role = new Iam.Role("my-role", new Iam.RoleArgs
+        {
+            AssumeRolePolicy = @"{
+    ""Version"": ""2012-10-17"",
+    ""Statement"": [{
+        ""Action"": [ ""sts:AssumeRole"" ],
+        ""Principal"": {
+            ""Service"": ""ec2.amazonaws.com""
+        },
+        ""Effect"": ""Allow"",
+        ""Sid"": """"
+    }]
+}
+",
+        });
+        var rolePolicyAttachment = new Iam.RolePolicyAttachment("my-rpa",
+            new Iam.RolePolicyAttachmentArgs
+            {
+                Role = role.Id,
+                PolicyArn = "arn:aws:iam::aws:policy/ReadOnlyAccess",
+            }
+        );
+    }
+}
+```
+
+{{% /choosable %}}
+
 Roles are often useful for creating [instance profiles](
 https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html), which
 controls the IAM role assumed by compute running inside of your AWS account, whether that be in EC2, ECS, EKS, or
 Lambda, for example. To create one, use the [`InstanceProfile` resource](
 {{< relref "/registry/packages/aws/api-docs/iam/instanceprofile" >}}) and simply pass in your role:
 
+{{< chooser language "typescript,python,go,csharp" / >}}
+
+{{% choosable language "javascript,typescript" %}}
+
 ```typescript
 const profile = new aws.iam.InstanceProfile("instance-profile", { role });
 ```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+profile = aws.iam.InstanceProfile('instance-profile', role=role.id)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+profile, err := aws.iam.NewInstanceProfile(
+    ctx, "instance-profile", &aws.iam.InstanceProfileArgs{
+        Role: role.ID().ToStringOutput(),
+    },
+)
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var profile = new Iam.InstanceProfile("instance-profile", { Role = role.Id });
+```
+
+{{% /choosable %}}
 
 For specific information about configuring roles, refer to [the API documentation](
 {{< relref "/registry/packages/aws/api-docs/iam/role" >}}). For more general information about IAM Roles, refer to the

--- a/themes/default/content/docs/guides/crosswalk/aws/iam.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/iam.md
@@ -56,11 +56,9 @@ OR across all of those policies when evaluating them.
 For more extensive details about IAM policies and their contents, refer to the [AWS access policies documentation](
 https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html).
 
-{{% choosable language typescript %}}
+#### Strongly Typed Policy Documents (TypeScript-only)
 
-### Strongly Typed Policy Documents
-
-Pulumi Crosswalk for AWS defines [the `aws.iam.PolicyDocument` interface](
+Pulumi Crosswalk for AWS in TypeScript defines [the `aws.iam.PolicyDocument` interface](
 {{< relref "/registry/packages/aws/api-docs/iam" >}}) to add strong type checking to your policy documents. By using
 this type, we will know at compile time whether we've mistyped an attribute:
 
@@ -93,31 +91,75 @@ const role = new aws.iam.Role("instance-role", {
 const profile = new aws.iam.InstanceProfile("instance-profile", { role });
 ```
 
-{{% /choosable %}}
-
-{{% choosable language "typescript,javascript" %}}
-
-### Using Pre-Defined IAM Managed Policies
+### Pre-Defined IAM Managed Policies
 
 An AWS managed policy is a standalone policy that is created and administered by AWS. Standalone policy means that
 the policy has its own Amazon Resource Name (ARN) that includes the policy name. For example,
-`arn:aws:iam::aws:policy/IAMReadOnlyAccess` is an AWS managed policy. The `aws.iam.ManagedPolicies` module exports a collection of
-constants for all available managed policies so that you don't need to remember the ARNs.
+`arn:aws:iam::aws:policy/IAMReadOnlyAccess` is an AWS managed policy.
 
-For example, the above is available as `aws.iam.ManagedPolicies.IAMReadOnlyAccess`:
+In places that accept a policy ARN, such as the `RolePolicyAttachment` resource, you can pass the ARN as a string,
+but that requires that you either memorize or look up the ARN each time. Instead, you can use the strongly typed
+`ManagedPolicy` enum, which exports a collection of constants for all available managed policies.
+
+For example, instead of typing out the ARN by hand, we can just reference `ManagedPolicy`'s `IAMReadOnlyAccess`
+enum value:
+
+{{< chooser language "typescript,python,go,csharp" / >}}
+
+{{% choosable language "javascript,typescript" %}}
 
 ```typescript
 const role = ...;
 const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("rpa", {
     role: role,
-    policyArn: aws.iam.ManagedPolicies.IAMReadOnlyAccess,
+    policyArn: aws.iam.ManagedPolicy.IAMReadOnlyAccess,
 });
 ```
 
-For a full list of available managed policy ARNs, refer to the
-[API documentation]({{< relref "/registry/packages/aws/api-docs/iam" >}}).
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+role = ...
+role_policy_attachment = aws.iam.RolePolicyAttachment('rpa',
+    role=role,
+    policy_arn=aws.iam.ManagedPolicy.IAMReadOnlyAccess,
+)
+```
 
 {{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+role := ...
+rolePolicyAttachment, err := iam.NewRolePolicyAttachment("rpa", &iam.RolePolicyAttachmentArgs{}
+    Role: role,
+    PolicyArn: iam.ManagedPolicyIAMReadOnlyAccess,
+})
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var role = ...;
+var rolePolicyAttachment = new Iam.RolePolicyAttachment("rpa", new Iam.RolePolicyAttachmentArgs
+{
+    Role = role,
+    PolicyArn = Iam.ManagedPolicy.IAMReadOnlyAccess.ToString(),
+})
+```
+
+{{% /choosable %}}
+
+For a full list of available managed policy ARNs, refer to the
+[API documentation]({{< relref "/registry/packages/aws/api-docs/iam" >}}).
 
 ## Creating IAM Users, Groups, and Roles
 


### PR DESCRIPTION
Just what it says on the tin.

I manually tested all of the examples. Are we doing any automation for doc examples these days that I should be adding this to?