### PR TITLE
Fix import reference to aws to be eks in eks example

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/aws/eks.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/eks.md
@@ -66,7 +66,7 @@ To create a new EKS cluster, allocate an instance of an `eks.Cluster` class in y
 {{% choosable language javascript %}}
 
 ```javascript
-const aws = require("@pulumi/eks");
+const eks = require("@pulumi/eks");
 
 // Create an EKS cluster with the default configuration.
 const cluster = new eks.Cluster("my-cluster");


### PR DESCRIPTION
sample code imports pulumi eks package as aws. I think it should be imported as eks instead. 
as later in the code eks.cluster is used