### PR TITLE
align language get started sections

### DIFF
--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -22,22 +22,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=csharp" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=csharp" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=csharp" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=csharp" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -22,22 +22,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=csharp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}?language=csharp">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=csharp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}?language=csharp">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=csharp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}?language=csharp">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=csharp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}?language=csharp">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -43,8 +43,9 @@ The fastest way to get up and running is to choose from one of the following Get
     </div>
 </div>
 
-> The Getting Started guides currently only demonstrate C#. For F# and Visual Basic,
-> they will work just fine &mdash; the guides simply aren't ready for them yet.
+{{% notes "info" %}}
+The Getting Started guides only demonstrate C#, but will also work for F# and Visual Basic.
+{{% /notes %}}
 
 ## Prerequisites
 

--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -18,16 +18,27 @@ Pulumi supports writing your infrastructure as code using the Go language. Go 1.
 
 The fastest way to get up and running is to choose from one of the following Getting Started guides:
 
-<div class="tiles my-4">
-    <a class="tile flex-1 p-4" href="{{< relref "/docs/get-started/aws" >}}">
-        <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-    </a>
-    <a class="tile md:mx-4 flex-1 p-4" href="{{< relref "/docs/get-started/azure" >}}">
-        <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-    </a>
-    <a class="tile flex-1 p-4" href="{{< relref "/docs/get-started/gcp" >}}">
-        <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-    </a>
+<div class="tiles mt-4">
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+        </a>
+    </div>
+    <div class="flex-1 pb-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+        </a>
+    </div>
 </div>
 
 ## Templates

--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -20,22 +20,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=go" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=go" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=go" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=go" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -20,22 +20,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=go" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}?language=go">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=go" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}?language=go">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=go" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}?language=go">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=go" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}?language=go">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -22,14 +22,30 @@ test frameworks.
 
 ## Getting Started
 
-The fastest way to get started in JavaScript is using a template. From an empty directory in which you'd like to create a new project:
+The fastest way to get up and running is to choose from one of the following Getting Started guides:
 
-```bash
-$ mkdir myproject && cd myproject
-$ pulumi new javascript
-```
-
-This will create a `Pulumi.yaml` [project file]({{< relref "../concepts/project" >}}), a `package.json` file for dependencies, and an `index.js` file, containing your program. The name of the directory is used as the project name in `Pulumi.yaml`.
+<div class="tiles mt-4">
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+        </a>
+    </div>
+    <div class="flex-1 pb-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+        </a>
+    </div>
+</div>
 
 ## Pulumi Programming Model
 

--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -26,22 +26,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=nodejs" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}?language=nodejs">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=nodejs" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}?language=nodejs">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=nodejs" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}?language=nodejs">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=nodejs" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}?language=nodejs">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -26,22 +26,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=nodejs" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=nodejs" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=nodejs" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=nodejs" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -22,22 +22,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=python" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}?language=python">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=python" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}?language=python">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=python" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}?language=python">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=python" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}?language=python">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>

--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -18,22 +18,30 @@ Pulumi supports programs written in Python 3. Python version 3.6 or later is req
 
 ## Getting Started
 
-The fastest way to get started with Pulumi Python is by using a template.  From an empty directory in which you'd like to create a new project:
+The fastest way to get up and running is to choose from one of the following Getting Started guides:
 
-```bash
-$ mkdir myproject && cd myproject
-$ pulumi new python
-```
-
-This creates a `Pulumi.yaml` file, containing minimal metadata about your project (including a name and description, which you may wish to change), a `requirements.txt` file, where you will specify your dependencies (see [Using Pulumi PyPI Packages](#pypi-packages) below), and a `__main__.py` file, containing your program.
-
-{{% notes %}}
-Although the template uses a very simple package structure, by placing `__main__.py` in the root directory, Pulumi fully supports [properly modularized Python programs](http://docs.python-guide.org/en/latest/writing/structure/) and `setup.py` files.  This is important if you ever decide to turn your Pulumi program into a library.
-{{% /notes %}}
-
-{{% notes %}}
-Pulumi looks for a `python3` executable to use on `PATH`. If not found, it looks for a `python` executable. It expects the executable it finds to refer to Python 3.6 or above. This can be overridden by explicitly setting the `PULUMI_PYTHON_CMD` environment variable to the name of the Python executable to use.
-{{% /notes %}}
+<div class="tiles mt-4">
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
+        </a>
+    </div>
+    <div class="flex-1 pb-4 md:mr-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
+        </a>
+    </div>
+    <div class="flex-1 pb-4">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
+        </a>
+    </div>
+</div>
 
 ## Pulumi Programming Model
 

--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -22,22 +22,22 @@ The fastest way to get up and running is to choose from one of the following Get
 
 <div class="tiles mt-4">
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/aws" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/aws/?language=python" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/azure" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/azure/?language=python" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
         </a>
     </div>
     <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/gcp/?language=python" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
         </a>
     </div>
     <div class="flex-1 pb-4">
-        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes" >}}">
+        <a class="tile p-4" href="{{< relref "/docs/get-started/kubernetes/?language=python" >}}">
             <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
         </a>
     </div>


### PR DESCRIPTION
## overview
i noticed that the get started sections on the language pages were all different. this aligns them all to direct folks to the get started guides, to match what .net is currently doing

### screenshot
<img width="777" alt="alignment" src="https://user-images.githubusercontent.com/5489125/142446124-8222e3ec-2ed5-4d38-a12d-429fa12f729a.png">

