### PR TITLE
Update /docs/reference/pkg links to go directly to API docs

### DIFF
--- a/themes/default/layouts/shortcodes/resource-providers.html
+++ b/themes/default/layouts/shortcodes/resource-providers.html
@@ -7,7 +7,7 @@ of the API Reference section so that we can use the additional metadata that goe
     {{ $pkgs := split (.Get 0) "," }}
     {{ $useLogo := default true (.Get 1) }}
     {{ range $pkg := $pkgs }}
-        {{ $href := printf "/registry/packages/%s" $pkg }}
+        {{ $href := printf "/registry/packages/%s/api-docs" $pkg }}
         {{ with $site.GetPage $href }}
             {{ $page := .Site.GetPage $href }}
             <div class="md:w-1/2 lg:w-1/3 xl:w-1/4 p-2">


### PR DESCRIPTION
Hypothesis: we can infer the user's intent ("I want API docs") from where these links are located, so we should take them directly to the part of Registry that matches their intent (API docs).