### PR TITLE
transform docs nav item into a menu

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -70,8 +70,28 @@
                     <li>
                         <a href="{{ relref . "/pricing" }}">Pricing</a>
                     </li>
-                    <li>
-                        <a href="{{ relref . "/docs" }}">Docs</a>
+                    <li class="header-nav-item-drop-down">
+                        <span class="dropdown-title">Docs</span>
+                        <span class="dropdown-menu-caret"></span>
+                        <div class="header-nav-drop-down-menu">
+                            <ul>
+                                <li>
+                                    <a href="{{ relref . "/docs" }}">
+                                        Docs
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{{ relref . "/registry" }}">
+                                        Registry
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{{ relref . "/docs/reference/pulumi-sdk" }}">
+                                        SDK Reference
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
                     </li>
                     <li class="header-nav-item-drop-down">
                         <span class="dropdown-title">Learn</span>
@@ -129,7 +149,10 @@
 
                         <li class="mobile-menu-item"><a href="{{ relref . "/pricing" }}">Pricing</a></li>
 
-                        <li class="mobile-menu-item"><a href="{{ relref . "/docs" }}">Docs</a></li>
+                        <li class="mobile-menu-item whitespace-nowrap"><a href="{{ relref . "/docs" }}">Docs</a></li>
+                        <li class="mobile-menu-subitem"><a href="{{ relref . "/docs" }}">Docs</a></li>
+                        <li class="mobile-menu-subitem"><a href="{{ relref . "/registry" }}">Registry</a></li>
+                        <li class="mobile-menu-subitem"><a href="{{ relref . "/docs/reference/pulumi-sdk" }}">SDK Reference</a></li>
 
                         <li class="mobile-menu-item"><a href="#">Learn</a></li>
                         <li class="mobile-menu-subitem"><a href="{{ relref . "/blog" }}">Blog</a></li>


### PR DESCRIPTION
## overview
this is transforming the docs nav item into a menu that contains docs, registry, and sdk reference. this is to help folks get easier access to these things and is intended as a small fix before we can do more extensive work to the docs navigation and potentially marketing top navigation.

there are a few general ux concerns about this change that ill mention
- label of docs repeated
- registry in the nav, but once you go to registry this nav is not represented there
- both docs and sdk reference go to docs, just a specific section in docs which may be confusing

im good with ignoring all of these concerns, to try out and see if this helps folks get easier access to things before we can make larger changes.

this work was motivated by feedback shared in community slack.

_note: registry will go to the weird registries page until this gets to docs_

### after screenshots
#### mobile
<img width="263" alt="mobile" src="https://user-images.githubusercontent.com/5489125/142668775-9ebd9ad1-16c6-40e2-9d36-acd7359a877a.png">

#### desktop
<img width="257" alt="desktop" src="https://user-images.githubusercontent.com/5489125/142668750-40d51bd1-e4a6-4f3a-ab78-277173ef46fd.png">

