### PR TITLE
Add landing page for reinvent qr code

### DIFF
--- a/themes/default/content/aws-reinvent-2021/_index.md
+++ b/themes/default/content/aws-reinvent-2021/_index.md
@@ -1,0 +1,63 @@
+---
+title: "AWS re:Invent 2021"
+meta_desc: "Join the Pulumi team in the exhibit hall where we will be showcasing the latest Pulumi features and answering any and all questions about the cloud."
+
+events:
+  title: The benefits of using Pulumi
+  items:
+    - title: AWS Dev Days Getting started Pululmi on AWS
+      url: /resources/aws-dev-day-getting-started-with-aws/
+      date: 2021-12-14T09:00:00-07:00
+      icon: code-window
+      icon_color: salmon
+      description: |
+        In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure.
+
+    - title: AWS - Howdy Partner
+      url: /resources/aws-howdy-partner-twitch/
+      date: 2021-12-08T14:00:00-07:00
+      icon: download-from-cloud
+      icon_color: violet
+      description: |
+        Join Pulumi and the AWS team for a fun live coding session showing off the new AWS Native Provider.
+
+newsroom:
+  - title: Announcing the Pulumi AWS Native Provider
+    url: /blog/announcing-aws-native/
+    icon: nodes
+    icon_color: purple
+    description: "Pulumi Native Providers like AWS Native are a new type of Pulumi Package that give you a complete and consistent interface for the modern cloud."
+
+  - title: Eureka! How Pulumi Brought Sanity to Our DevOps Team
+    url: https://www.anitian.com/eureka-how-pulumi-brought-sanity-to-our-devops-team/
+    icon: guage
+    icon_color: salmon
+    description: "Learn how Anitian used Pulumi help accelerate their cloud usage an achieve their strategic business goals."
+
+  - title: AWS Lambda Functions Powered by AWS Graviton2 Processors
+    url: /blog/aws-lambda-functions-powered-by-graviton2/
+    icon: download-from-cloud
+    icon_color: yellow
+    description: "Let’s use Pulumi to deploy a new AWS Lambda Function using a Graviton2 architecture."
+
+
+hiring:
+    title: We're Hiring
+    description: |
+        Pulumi is reinventing how people build modern cloud applications, with a unique platform that combines deep systems and infrastructure innovation with elegant programming models and developer tools.
+
+        Our team is a diverse and talented group of individuals, with backgrounds in distributed cloud systems, programming languages, developer tools, and operating systems, from companies from all corners of the industry. Our culture is one of technical excellence, passion for teamwork, and customer obsession.
+
+        While we have a fabulous office in downtown Seattle, Pulumi cares about the health, safety and happiness of our employees, and we've been a fully remote company since March, 2020. We've learned and grown as a company this year, and — unless otherwise specified — all of our open positions are remote. We will continue to collaborate and grow from different locations, and are committed to making sure our team is successful from their home offices.
+
+get_started:
+    title: Get started with AWS
+    cta_text: Get Started
+    description: |
+        Pulumi is a cloud engineering platform that brings infrastructure, application
+        development, and compliance teams together through a unified software engineering
+        process to deliver and manage modern cloud applications on AWS.
+
+type: page
+layout: aws-reinvent-2021
+---

--- a/themes/default/content/aws-reinvent-2021/_index.md
+++ b/themes/default/content/aws-reinvent-2021/_index.md
@@ -3,11 +3,11 @@ title: "AWS re:Invent 2021"
 meta_desc: "Join the Pulumi team in the exhibit hall where we will be showcasing the latest Pulumi features and answering any and all questions about the cloud."
 
 events:
-  title: The benefits of using Pulumi
+  title: Events
   items:
-    - title: AWS Dev Days Getting started Pululmi on AWS
+    - title: AWS Dev Days Getting Started Pulumi on AWS
       url: /resources/aws-dev-day-getting-started-with-aws/
-      date: 2021-12-14T09:00:00-07:00
+      date: 2021-12-14T09:00:00-08:00
       icon: code-window
       icon_color: salmon
       description: |
@@ -15,30 +15,32 @@ events:
 
     - title: AWS - Howdy Partner
       url: /resources/aws-howdy-partner-twitch/
-      date: 2021-12-08T14:00:00-07:00
+      date: 2021-12-08T14:00:00-08:00
       icon: download-from-cloud
       icon_color: violet
       description: |
         Join Pulumi and the AWS team for a fun live coding session showing off the new AWS Native Provider.
 
 newsroom:
-  - title: Announcing the Pulumi AWS Native Provider
-    url: /blog/announcing-aws-native/
-    icon: nodes
-    icon_color: purple
-    description: "Pulumi Native Providers like AWS Native are a new type of Pulumi Package that give you a complete and consistent interface for the modern cloud."
+  title: Newsroom
+  items:
+    - title: Announcing the Pulumi AWS Native Provider
+      url: /blog/announcing-aws-native/
+      icon: nodes
+      icon_color: purple
+      description: "Pulumi Native Providers like AWS Native are a new type of Pulumi Package that give you a complete and consistent interface for the modern cloud."
 
-  - title: Eureka! How Pulumi Brought Sanity to Our DevOps Team
-    url: https://www.anitian.com/eureka-how-pulumi-brought-sanity-to-our-devops-team/
-    icon: guage
-    icon_color: salmon
-    description: "Learn how Anitian used Pulumi help accelerate their cloud usage an achieve their strategic business goals."
+    - title: Eureka! How Pulumi Brought Sanity to Our DevOps Team
+      url: https://www.anitian.com/eureka-how-pulumi-brought-sanity-to-our-devops-team/
+      icon: guage
+      icon_color: salmon
+      description: "Learn how Anitian used Pulumi help accelerate their cloud usage an achieve their strategic business goals."
 
-  - title: AWS Lambda Functions Powered by AWS Graviton2 Processors
-    url: /blog/aws-lambda-functions-powered-by-graviton2/
-    icon: download-from-cloud
-    icon_color: yellow
-    description: "Let’s use Pulumi to deploy a new AWS Lambda Function using a Graviton2 architecture."
+    - title: AWS Lambda Functions Powered by AWS Graviton2 Processors
+      url: /blog/aws-lambda-functions-powered-by-graviton2/
+      icon: download-from-cloud
+      icon_color: yellow
+      description: "Let’s use Pulumi to deploy a new AWS Lambda Function using a Graviton2 architecture."
 
 
 hiring:

--- a/themes/default/content/resources/aws-dev-day-getting-started-with-aws/index.md
+++ b/themes/default/content/resources/aws-dev-day-getting-started-with-aws/index.md
@@ -1,0 +1,86 @@
+---
+# Name of the webinar.
+title: "Getting Started with Infrastructure as Code on AWS"
+meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code on AWS through a series of exercises using Pulumi’s Cloud Engineering platform."
+
+aws_dev_day: true
+
+aliases:
+  - /resources/gettint-started-with-aws
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "getting-started-with-aws"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Getting Started with Infrastructure as Code on AWS"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Webinar pages support multiple session via the 'multiple' property.
+multiple:
+    - datetime: 2021-12-14T09:00:00-07:00
+      hubspot_form_id: d984a26d-32ed-4789-90a6-435a650180e1
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Getting Started with Infrastructure as Code on AWS"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: "https://www.youtube.com/embed/haTaQubGTEo"
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2020-10-21T09:00:00-07:00
+    # Duration of the webinar.
+    duration: "1 hour"
+    # Datetime of the webinar.
+    datetime: ""
+    # Description of the webinar.
+    description: |
+        In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure.
+
+        This workshop is designed to help users completely new to Pulumi to become familiar with the core concepts to be effective with the Pulumi Infrastructure as Code platform. We will guide you through the Pulumi platform with diagrams and a series of hands on exercises to help you understand the building blocks available in Pulumi.
+
+
+    # The webinar presenters
+    presenters:
+        - name: "Laura Santamaria"
+          role: "Developer Advocate, Pulumi"
+        - name: Marina Novikova
+          role: Partner Solutions Architect, AWS
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn:
+        - The basics of the Pulumi Programming Model.
+        - How to provision, update, and destroy AWS resources.
+---

--- a/themes/default/content/resources/aws-dev-day-getting-started-with-aws/index.md
+++ b/themes/default/content/resources/aws-dev-day-getting-started-with-aws/index.md
@@ -50,7 +50,7 @@ hero:
 
 # Webinar pages support multiple session via the 'multiple' property.
 multiple:
-    - datetime: 2021-12-14T09:00:00-07:00
+    - datetime: 2021-12-14T09:00:00-08:00
       hubspot_form_id: d984a26d-32ed-4789-90a6-435a650180e1
 
 # Content for the left hand side section of the page.
@@ -60,7 +60,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: "https://www.youtube.com/embed/haTaQubGTEo"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2020-10-21T09:00:00-07:00
+    sortable_date: 2020-10-21T09:00:00-08:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.

--- a/themes/default/content/resources/aws-howdy-partner-twitch/index.md
+++ b/themes/default/content/resources/aws-howdy-partner-twitch/index.md
@@ -52,7 +52,7 @@ main:
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-12-08T14:00:00-07:00
+    sortable_date: 2021-12-08T14:00:00-08:00
     # Duration of the webinar.
     duration: "1 hour"
     # Datetime of the webinar.

--- a/themes/default/layouts/page/aws-reinvent-2021.html
+++ b/themes/default/layouts/page/aws-reinvent-2021.html
@@ -1,0 +1,73 @@
+{{ define "hero" }}
+    {{ partial "hero.html" (dict "title" .Title) }}
+{{ end }}
+
+{{ define "main" }}
+    <section id="overview" class="max-w-5xl mx-auto">
+        <h2>Events</h2>
+        <div class="flex flex-col lg:flex-row justify-center items-stretch my-8">
+            {{ range $item := .Params.events.items }}
+                <div class="w-full lg:w-1/2 p-2">
+                    <div class="card p-6 text-center bg-white h-full relative">
+                        <div>
+                            {{ partial "color-icon.html" (dict "icon" $item.icon "icon_color" $item.icon_color) }}
+                        </div>
+                        <h5>{{ $item.title }}</h5>
+                        <p><pulumi-datetime class="inline-block" date="{{ .date }}"></pulumi-datetime></p>
+                        <p>{{ $item.description | markdownify }}</p>
+                        <div class="card-cta-btn text-center">
+                            <a href="{{ $item.url }}" class="btn-secondary">Register Now</a>
+                        </div>
+                    </div>
+                </div>
+            {{ end }}
+        </div>
+    </section>
+
+    <section id="details" class="max-w-5xl mx-auto">
+        <h2>Newsroom</h2>
+        <div class="flex lg:flex-wrap lg:flex-row justify-center items-stretch my-8">
+            {{ range $item := .Params.newsroom }}
+                <div class="w-full lg:w-1/2 p-6 h-full">
+                    <div class="card p-6 mx-4 text-center bg-white h-full relative">
+                        <div>
+                            {{ partial "color-icon.html" (dict "icon" $item.icon "icon_color" $item.icon_color) }}
+                        </div>
+                        <h5>{{ $item.title }}</h5>
+                        <p>{{ $item.description | markdownify }}</p>
+                        <div class="card-cta-btn text-center">
+                            <a href="{{ $item.url }}" class="btn-secondary">Learn More</a>
+                        </div>
+                    </div>
+                </div>
+            {{ end }}
+        </div>
+    </section>
+
+    <section id="cta" class="max-w-5xl mx-auto">
+        <h2>{{ .Params.hiring.title }}</h2>
+        <p>{{ .Params.hiring.description | markdownify }}
+        <ul class="list-none p-0 border-t-2 border-b-2" data-faq-type="faq-pricing">
+            <li class="accordion-item text-2xl py-3">
+                {{ partial "accordian-header" (dict "text" "Open Positions" "large_header" true) }}
+
+                <div class="accordion-item-body-no-animation text-base">
+                    <pulumi-greenhouse-jobs-list></pulumi-greenhouse-jobs-list>
+                </div>
+            </li>
+        </ul>
+    </section>
+
+    <section id="get-started" class="max-w-5xl px-6 lg:px-0 mx-auto my-16">
+        <div class="w-full bg-violet-600 card p-6 lg:p-16 lg:pt-24 text-center">
+            <div class="max-w-xl mx-auto">
+                <h2 class="text-white hidden lg:block px-0 lg:px-8">{{ .Params.get_started.title }}</h2>
+                <h4 class="text-white mt-0 lg:hidden">{{ .Params.get_started.title }}</h4>
+                <p class="text-white">{{ .Params.get_started.description }}</p>
+                <div class="mt-16">
+                    <a class="btn-secondary" href="{{ relref . "/docs/get-started/aws" }}">{{ .Params.get_started.cta_text }}</a>
+                </div>
+            </div>
+        </div>
+    </section>
+{{ end }}

--- a/themes/default/layouts/page/aws-reinvent-2021.html
+++ b/themes/default/layouts/page/aws-reinvent-2021.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <section id="overview" class="max-w-5xl mx-auto p-3">
-        <h2>Events</h2>
+        <h2>{{ .Params.events.title }}</h2>
         <div class="flex flex-col lg:flex-row justify-center items-stretch my-8">
             {{ range $item := .Params.events.items }}
                 <div class="w-full lg:w-1/2 p-2 my-6">
@@ -25,9 +25,9 @@
     </section>
 
     <section id="details" class="max-w-5xl mx-auto p-3">
-        <h2>Newsroom</h2>
+        <h2>{{ .Params.newsroom.title }}</h2>
         <div class="flex flex-wrap lg:flex-row justify-center items-stretch my-8">
-            {{ range $item := .Params.newsroom }}
+            {{ range $item := .Params.newsroom.items }}
                 <div class="w-full lg:w-1/2 p-6 h-full">
                     <div class="card p-6 mx-4 text-center bg-white h-full relative">
                         <div>

--- a/themes/default/layouts/page/aws-reinvent-2021.html
+++ b/themes/default/layouts/page/aws-reinvent-2021.html
@@ -26,7 +26,7 @@
 
     <section id="details" class="max-w-5xl mx-auto">
         <h2>Newsroom</h2>
-        <div class="flex lg:flex-wrap lg:flex-row justify-center items-stretch my-8">
+        <div class="flex flex-wrap lg:flex-row justify-center items-stretch my-8">
             {{ range $item := .Params.newsroom }}
                 <div class="w-full lg:w-1/2 p-6 h-full">
                     <div class="card p-6 mx-4 text-center bg-white h-full relative">

--- a/themes/default/layouts/page/aws-reinvent-2021.html
+++ b/themes/default/layouts/page/aws-reinvent-2021.html
@@ -3,11 +3,11 @@
 {{ end }}
 
 {{ define "main" }}
-    <section id="overview" class="max-w-5xl mx-auto">
+    <section id="overview" class="max-w-5xl mx-auto p-3">
         <h2>Events</h2>
         <div class="flex flex-col lg:flex-row justify-center items-stretch my-8">
             {{ range $item := .Params.events.items }}
-                <div class="w-full lg:w-1/2 p-2">
+                <div class="w-full lg:w-1/2 p-2 my-6">
                     <div class="card p-6 text-center bg-white h-full relative">
                         <div>
                             {{ partial "color-icon.html" (dict "icon" $item.icon "icon_color" $item.icon_color) }}
@@ -24,7 +24,7 @@
         </div>
     </section>
 
-    <section id="details" class="max-w-5xl mx-auto">
+    <section id="details" class="max-w-5xl mx-auto p-3">
         <h2>Newsroom</h2>
         <div class="flex flex-wrap lg:flex-row justify-center items-stretch my-8">
             {{ range $item := .Params.newsroom }}
@@ -44,7 +44,7 @@
         </div>
     </section>
 
-    <section id="cta" class="max-w-5xl mx-auto">
+    <section id="cta" class="max-w-5xl mx-auto p-3">
         <h2>{{ .Params.hiring.title }}</h2>
         <p>{{ .Params.hiring.description | markdownify }}
         <ul class="list-none p-0 border-t-2 border-b-2" data-faq-type="faq-pricing">


### PR DESCRIPTION
Adding a landing page with the events, newsroom, hiring, and get started CTAs. This page will be linked to QR code at re:Invent in 2021.