### PR TITLE
Unlist Cloud Engineering Summit

### DIFF
--- a/themes/default/content/resources/cloud-engineering-summit/index.md
+++ b/themes/default/content/resources/cloud-engineering-summit/index.md
@@ -16,7 +16,7 @@ pulumi_tv: false
 preview_image: "/images/webinar/cloud-engineering-summit.png"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.


### PR DESCRIPTION
Noticed the CES link now 404s (from https://www.pulumi.com/resources/#featured), so hopefully this is the right way to remove it from that page. (If there's some other way to do this, though, let me know!)