### PR TITLE
Add support for custom canonical tag

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -112,8 +112,8 @@
         https://en.wikipedia.org/wiki/Canonical_link_element
     -->
 
-    {{ if .Params.canonical_link }}
-        <link rel="canonical" href="{{ .Params.canonical_link }}" >
+    {{ if .Params.canonical_url }}
+        <link rel="canonical" href="{{ .Params.canonical_url }}" >
     {{ else }}
         <link rel="canonical" href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}" >
     {{ end }}

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -111,7 +111,12 @@
         https://support.google.com/webmasters/answer/139066?hl=en
         https://en.wikipedia.org/wiki/Canonical_link_element
     -->
-    <link rel="canonical" href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}" >
+
+    {{ if .Params.canonical_link }}
+        <link rel="canonical" href="{{ .Params.canonical_link }}" >
+    {{ else }}
+        <link rel="canonical" href="{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}" >
+    {{ end }}
 
     <!-- RSS link for the blog. -->
     <link rel="alternate" type="application/rss+xml" href="{{ "/blog/rss.xml" | absURL }}" title="Pulumi Blog" />


### PR DESCRIPTION
Fixes #901 

This adds support for a canonical tag for when we cross-post from someone else's blog (only for use for community blogs, etc)

Please do not merge this without approval from @zchase 

Signed-off-by: Matt Stratton <matt.stratton@gmail.com>