### PR TITLE
Add path prefixes for Learn content helpers

### DIFF
--- a/scripts/content/new-learn-module.sh
+++ b/scripts/content/new-learn-module.sh
@@ -5,11 +5,13 @@ set -o errexit -o pipefail
 module=""
 topic=""
 
+content_root="themes/default/content/"
+
 prompt_for_module_name() {
     read -p "Module name (e.g., pulumi-101-aws): " module
 
     if [ ! -z "$module" ]; then
-        hugo new --kind learn/module "learn/${module}"
+        hugo new --kind learn/module "${content_root}learn/${module}"
         return
     fi
 
@@ -21,7 +23,7 @@ prompt_for_topic_name() {
     read -p "Topic name (e.g., basics): " topic
 
     if [ ! -z "$topic" ]; then
-        hugo new --kind learn/topic "learn/${module}/${topic}"
+        hugo new --kind learn/topic "${content_root}learn/${module}/${topic}"
         return
     fi
 

--- a/scripts/content/new-learn-topic.sh
+++ b/scripts/content/new-learn-topic.sh
@@ -4,11 +4,12 @@ set -o errexit -o pipefail
 
 module=""
 topic=""
+content_root="themes/default/content/"
 
 prompt_for_module_name() {
     read -p "Module name (e.g., pulumi-101-aws): " module
 
-    if [[ ! -z "$module" && -d "themes/default/content/learn/${module}" ]]; then
+    if [[ ! -z "$module" && -d "${content_root}learn/${module}" ]]; then
         return
     fi
 
@@ -21,7 +22,7 @@ prompt_for_topic_name() {
     read -p "Topic name (e.g., basics): " topic
 
     if [ ! -z "$topic" ]; then
-        hugo new --kind learn/topic "learn/${module}/${topic}"
+        hugo new --kind learn/topic "${content_root}learn/${module}/${topic}"
         return
     fi
 


### PR DESCRIPTION
We've made a few changes recently to this repo's configuration that seem to have affected the Learn archetypes. This change adds explicit path prefixes in order to unbreak them.