### PR TITLE
Filter author and tag taxonomy templates to blog posts only

### DIFF
--- a/themes/default/content/learn/building-with-pulumi/_index.md
+++ b/themes/default/content/learn/building-with-pulumi/_index.md
@@ -12,8 +12,6 @@ youll_learn:
     - Sharing values from one Pulumi program or project to another
     - Working with secrets inside of Pulumi
     - Testing your Pulumi programs
-tags:
-    - learn
 providers:
     - aws
 block_external_search_index: false

--- a/themes/default/content/learn/building-with-pulumi/secrets/index.md
+++ b/themes/default/content/learn/building-with-pulumi/secrets/index.md
@@ -11,7 +11,6 @@ meta_image: meta.png
 authors:
     - matt-stratton
 tags:
-    - learn
     - secrets
 block_external_search_index: false
 ---

--- a/themes/default/content/learn/building-with-pulumi/stack-outputs/index.md
+++ b/themes/default/content/learn/building-with-pulumi/stack-outputs/index.md
@@ -10,8 +10,6 @@ estimated_time: 10
 meta_image: meta.png
 authors:
     - matt-stratton
-tags:
-    - learn
 block_external_search_index: false
 ---
 
@@ -89,7 +87,7 @@ View Live: https://app.pulumi.com/***/my-first-app/dev/updates/3
 
 
     pulumi:pulumi:Stack my-first-app-dev running
-    pulumi:pulumi:Stack my-first-app-dev  
+    pulumi:pulumi:Stack my-first-app-dev
 
 Outputs:
   + url: "http://localhost:3001"

--- a/themes/default/content/learn/building-with-pulumi/stack-references/index.md
+++ b/themes/default/content/learn/building-with-pulumi/stack-references/index.md
@@ -11,7 +11,6 @@ meta_image: meta.png
 authors:
     - matt-stratton
 tags:
-    - learn
     - stacks
     - outputs
 block_external_search_index: false

--- a/themes/default/content/learn/building-with-pulumi/testing/index.md
+++ b/themes/default/content/learn/building-with-pulumi/testing/index.md
@@ -12,7 +12,6 @@ authors:
     - matt-stratton
     - laura-santamaria
 tags:
-    - learn
     - testing
 block_external_search_index: false
 ---

--- a/themes/default/content/learn/building-with-pulumi/understanding-stacks/index.md
+++ b/themes/default/content/learn/building-with-pulumi/understanding-stacks/index.md
@@ -12,7 +12,6 @@ authors:
     - matt-stratton
 tags:
     - stacks
-    - learn
 block_external_search_index: false
 ---
 

--- a/themes/default/layouts/taxonomy/author.html
+++ b/themes/default/layouts/taxonomy/author.html
@@ -8,7 +8,8 @@
 
             <div class="lg:w-7/12">
                 {{ $authorData := index $.Site.Data.team.team .Data.Term }}
-                {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
+                {{ $blogPosts := where .Data.Pages "Section" "blog" }}
+                {{ $paginator := .Paginate $blogPosts.ByDate.Reverse }}
 
                 <header>
                     <div class="flex items-top">

--- a/themes/default/layouts/taxonomy/tag.html
+++ b/themes/default/layouts/taxonomy/tag.html
@@ -8,7 +8,8 @@
 
             <div class="lg:w-7/12">
                 {{ $authorData := index $.Site.Data.team.team .Data.Term }}
-                {{ $paginator := .Paginate .Data.Pages.ByDate.Reverse }}
+                {{ $blogPosts := where .Data.Pages "Section" "blog" }}
+                {{ $paginator := .Paginate $blogPosts.ByDate.Reverse }}
 
                 <header>
                     <h1 class="no-anchor">


### PR DESCRIPTION
Our author and tag listings are unintentionally showing Learn content (which also happens to have `author` and `tag` metadata), so this change add a filter to those pages to have them show only content from the blog. 

This is a less-than-ideal fix in that it _should_ be possible (one would think) to have Hugo generate section-specific `tag` and `author` taxonomy pages, but a quick look through the docs and some fiddling this morning didn't make that super clear to me. So we'll probably want to revisit this once we start thinking about supporting taxonomy pages outside of just the blog.

