### PR TITLE
Allowlist env vars for hugo 0.92

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -40,6 +40,12 @@ module:
         - source: archetypes
           target: archetypes
 
+security:
+  funcs:
+    getenv:
+      - ASSET_BUNDLE_ID
+      - REPO_THEME_PATH
+      - PULUMI_CONVERT_URL
 
 disableKinds:
   - category


### PR DESCRIPTION
Hugo v0.91.0 added a new key to the config, "security", defining allowlists for env vars and other things. This change allows 0.91 and 0.92 to build and serve the Pulumi site.

TODO:
- [ ] #972 