### PR TITLE
Add a warning about enabling merged results pipeline in GitLab

### DIFF
--- a/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -24,7 +24,7 @@ To enable the integration with your GitLab project, you will need to ensure you 
   * After you add the organization, ensure that it uses GitLab [as its identity provider]({{< relref "/docs/intro/pulumi-service/organizations#changing-identity-providers" >}}).
 
 {{% notes type="warning" %}}
-This feature is currently not compatible with pipelines for [merged results pipelines](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html).
+This feature is currently not compatible with GitLab's [pipelines for merged results](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html).
 See the [GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086) for details as to why.
 {{% /notes %}}
 

--- a/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -25,7 +25,7 @@ To enable the integration with your GitLab project, you will need to ensure you 
 
 {{% notes type="warning" %}}
 If you have [Merged Results Pipeline](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html) enabled for your project you must disable
-it. For more information, see the [issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086) on GitLab.
+it. For more information, see the [GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086).
 {{% /notes %}}
 
 ## Configuring the GitLab Webhook

--- a/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -23,6 +23,11 @@ To enable the integration with your GitLab project, you will need to ensure you 
   in Pulumi.
   * After you add the organization, ensure that it uses GitLab [as its identity provider]({{< relref "/docs/intro/pulumi-service/organizations#changing-identity-providers" >}}).
 
+{{% notes type="warning" %}}
+If you have [Merged Results Pipeline](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html) enabled for your project you must disable
+it. For more information, see https://gitlab.com/gitlab-org/gitlab/-/issues/350086.
+{{% /notes %}}
+
 ## Configuring the GitLab Webhook
 
 * Create a [Pulumi access token](https://app.pulumi.com/account/tokens) using the account that you would like the merge request notes to be posted as. Save this token as we will use this momentarily in a following step.

--- a/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -25,7 +25,7 @@ To enable the integration with your GitLab project, you will need to ensure you 
 
 {{% notes type="warning" %}}
 If you have [Merged Results Pipeline](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html) enabled for your project you must disable
-it. For more information, see https://gitlab.com/gitlab-org/gitlab/-/issues/350086.
+it. For more information, see the [issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086) on GitLab.
 {{% /notes %}}
 
 ## Configuring the GitLab Webhook

--- a/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/guides/continuous-delivery/gitlab-app.md
@@ -24,8 +24,8 @@ To enable the integration with your GitLab project, you will need to ensure you 
   * After you add the organization, ensure that it uses GitLab [as its identity provider]({{< relref "/docs/intro/pulumi-service/organizations#changing-identity-providers" >}}).
 
 {{% notes type="warning" %}}
-If you have [Merged Results Pipeline](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html) enabled for your project you must disable
-it. For more information, see the [GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086).
+This feature is currently not compatible with pipelines for [merged results pipelines](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html).
+See the [GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086) for details as to why.
 {{% /notes %}}
 
 ## Configuring the GitLab Webhook


### PR DESCRIPTION
GitLab projects that have enabled the [Merged Results Pipeline](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html) feature will not be able to use the Pulumi GitLab integration for MR comments. I have added a note in the guide to setup that integration warning users about the use of that feature.