### PR TITLE
Upgrade Hugo, Node, Go versions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,17 +13,17 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.82.0'
+          hugo-version: '0.92.0'
           extended: true
 
       - name: Check out branch

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,17 +11,17 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
 
       - name: Install Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.82.0'
+          hugo-version: '0.92.0'
           extended: true
 
       - name: Check out branch

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/README.md
+++ b/README.md
@@ -12,21 +12,10 @@ First, be sure to read our [contributing guide](CONTRIBUTING.md) and review our 
 
 We build the Pulumi website statically with Hugo, manage our Node.js dependencies with Yarn, and write most of our documentation in Markdown. Below is a list of the tools you'll need to run the website locally:
 
-* [Go](https://golang.org/)
-* [Hugo](https://gohugo.io)
-* [Node.js](https://nodejs.org/en/)
-* [Yarn](https://classic.yarnpkg.com/en/)
-
-### CSS and JavaScript Tools
-
-We also use a handful of tools for compiling and managing our CSS and JavaScript assets, including:
-
-* [Sass](https://sass-lang.com/)
-* [TailwindCSS](https://tailwindcss.com/)
-* [Stencil.js](https://stenciljs.com/)
-* [TypeScript](https://www.typescriptlang.org/)
-
-You don't need to install these tools individually or globally; the scripts below will handle everything for you. But if you'd like to contribute any CSS or JavaScript, you'll probably want to understand how to work with each of these tools as well.
+* [Go](https://golang.org/) (>= 1.15)
+* [Hugo](https://gohugo.io) (>= 0.81)
+* [Node.js](https://nodejs.org/en/) (>= 1.14)
+* [Yarn](https://classic.yarnpkg.com/en/) (1.x)
 
 ## Installing prerequisites
 
@@ -45,16 +34,6 @@ make serve
 ```
 
 You can browse the development server at http://localhost:1313, and any changes you make to content or layouts should be reloaded automatically.
-
-## Running Hugo with CSS and JavaScript support
-
-If you plan on making changes to CSS or JavaScript files, you'll probably want to use this command instead:
-
-```
-make serve-all
-```
-
-The `serve-all` target runs Hugo, node-sass, and the Stencil development server concurrently, allowing you to make changes to Sass files, Stencil components, or TypeScript/JavaScript source files, and have those changes compiled and reloaded automatically as well.
 
 ## Linting and testing
 
@@ -95,7 +74,8 @@ You'll find all of these files in `themes/default`.
 
 ### What's not in this repo
 
-* Generated documentation for the Pulumi CLI and SDK. You'll find this at https://github.com/pulumi/docs).
+* CSS and JavaScript. You'll find these at https://github.com/pulumi/theme.
+* Generated documentation for the Pulumi CLI and SDK. You'll find this at https://github.com/pulumi/docs.
 * Generated tutorials. You'll find these at https://github.com/pulumi/examples).
 * Templates used for generating resource documentation. You'll find these at https://github.com/pulumi/pulumi.
 

--- a/scripts/ensure.sh
+++ b/scripts/ensure.sh
@@ -4,12 +4,8 @@ set -o errexit -o pipefail
 
 source ./scripts/common.sh
 
-REQUIRED_GO="1.16"
-REQUIRED_HUGO="0.82"
-REQUIRED_NODE="$(cat .nvmrc)"
-
-# Check for the required versions of Go, Hugo, Node, and Yarn.
-if [[ -z "$(which go)" || -z "$(go version | grep ${REQUIRED_GO})"  ]]; then
+# Check for Go, Hugo, Node, and Yarn.
+if [[ -z "$(which go)" ]]; then
     echo "This project uses Go version ${REQUIRED_GO}."
     echo "See the README for the complete list of prerequisities and "
     echo "https://golang.org/doc/install for help installing Go."
@@ -23,7 +19,7 @@ if [[ -z "$(which hugo)" ]]; then
     exit 1
 fi
 
-if [[ -z "$(which node)" || -z "$(node --version | grep ${REQUIRED_NODE})"  ]]; then
+if [[ -z "$(which node)" ]]; then
     echo "This project uses Node.js ${REQUIRED_NODE}."
     echo "See the README for the complete list of prerequisities and "
     echo "https://nodejs.org/en/download for help installing Node.js."


### PR DESCRIPTION
This PR upgrades all workflows to use the latest versions of Hugo, Go, and Node, removes the version checks from the `ensure` script, and updates the README to include minimum versions.

I'll propagate these changes to the Registry and Docs repos next, but I wanted to get these in first to keep folks running `make serve` locally from being unable to work on content simply because their local tool versions didn't line up perfectly with what we run in CI (and some tools, like Hugo, make it fairly painful to move between versions).