### PR TITLE
Update SSO configuration instructions for Okta

### DIFF
--- a/themes/default/content/docs/guides/saml/okta.md
+++ b/themes/default/content/docs/guides/saml/okta.md
@@ -93,7 +93,7 @@ organization. Select the **Settings** tab, and then select **Access Management**
 
 In the **Membership Requirements** section, select the **Change requirements** button.
 
-Select the **SAML SSO** for the IDP and then **Next**.
+Select **SAML SSO** for the IDP and then **Next**.
 
 Paste the IDP metadata descriptor into the bottom card
 titled **SAML SSO Settings**. Then select **Save** at the bottom of the card.

--- a/themes/default/content/docs/guides/saml/okta.md
+++ b/themes/default/content/docs/guides/saml/okta.md
@@ -89,7 +89,11 @@ a user's identity.
 ![SAML Application Metadata](/images/docs/reference/service/saml-okta/okta-xml-descriptor.png)
 
 With the block of XML text in your clipboard, open the Pulumi Service and navigate to your SAML
-organization. Select the **Settings** tab, and then select **SAML SSO**.
+organization. Select the **Settings** tab, and then select **Access Management**.
+
+In the **Membership Requirements** section, select the **Change requirements** button.
+
+Select the **SAML SSO** for the IDP and click **Next**.
 
 Paste the IDP metadata descriptor into the bottom card
 titled **SAML SSO Settings**. Then select **Save** at the bottom of the card.

--- a/themes/default/content/docs/guides/saml/okta.md
+++ b/themes/default/content/docs/guides/saml/okta.md
@@ -93,7 +93,7 @@ organization. Select the **Settings** tab, and then select **Access Management**
 
 In the **Membership Requirements** section, select the **Change requirements** button.
 
-Select the **SAML SSO** for the IDP and click **Next**.
+Select the **SAML SSO** for the IDP and then **Next**.
 
 Paste the IDP metadata descriptor into the bottom card
 titled **SAML SSO Settings**. Then select **Save** at the bottom of the card.


### PR DESCRIPTION
It seems that the Organization Settings tab has changed and "Access Management" now contains the "Membership Requirements" which controls the SAML SSO configuration. Additionally, there are several IDPs and we need to select the correct one.