### PR TITLE
Specify explicit menu identifiers for resource-options items

### DIFF
--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -3,6 +3,7 @@ title: "AdditionalSecretOutputs"
 meta_desc: The additionalSecretOutputs resource option specifies a list of named output properties that should be treated as secrets.
 menu:
   intro:
+    identifier: additionalSecretOutputs
     parent: options
     weight: 1
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/aliases.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/aliases.md
@@ -1,8 +1,9 @@
 ---
 title: "Aliases"
-meta_desc: The alises resource option an be used to refactor resources.
+meta_desc: The aliases resource option can be used to refactor resources.
 menu:
   intro:
+    identifier: aliases
     parent: options
     weight: 2
 aliases:
@@ -113,4 +114,4 @@ var db = new Database("new-name-for-db", new DatabaseArgs(),
 
 {{< /chooser >}}
 
-Aliases are implicitly inherited from a [parent]({{< relref "parent" >}}) so that if a parent is moved (new name, new type, etc.) all children will also be aliased appropriately. This includes both updating the parent type in the qualified type in the child's URN, as well as updating the child name prefix if the name starts with the parent name. If there are aliases for both the parent and the child, all combinations of parent and child aliases are computed, allowing any combination of these previous parent and child identities to be treated as the same as the new identity. This process is inherited through any number of levels of parent/child relationships.  
+Aliases are implicitly inherited from a [parent]({{< relref "parent" >}}) so that if a parent is moved (new name, new type, etc.) all children will also be aliased appropriately. This includes both updating the parent type in the qualified type in the child's URN, as well as updating the child name prefix if the name starts with the parent name. If there are aliases for both the parent and the child, all combinations of parent and child aliases are computed, allowing any combination of these previous parent and child identities to be treated as the same as the new identity. This process is inherited through any number of levels of parent/child relationships.

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -1,8 +1,9 @@
 ---
 title: "CustomTimeouts"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The customTimeouts resource option specifies the default retry/timeout behavior for resource provisioning.
 menu:
   intro:
+    identifier: customTimeouts
     parent: options
     weight: 3
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/deletebeforereplace.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/deletebeforereplace.md
@@ -1,8 +1,9 @@
 ---
 title: "DeleteBeforeReplace"
-meta_desc: Setting the deleteBeforeReplace option to true means that Pulumi will delete the existing resource before creating its replacement. 
+meta_desc: Setting the deleteBeforeReplace option to true means that Pulumi will delete the existing resource before creating its replacement.
 menu:
   intro:
+    identifier: deleteBeforeReplace
     parent: options
     weight: 4
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/dependson.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/dependson.md
@@ -1,8 +1,9 @@
 ---
 title: "DependsOn"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The dependsOn resource option specifies additional resource dependencies in addition to those in the dependency graph.
 menu:
   intro:
+    identifier: dependsOn
     parent: options
     weight: 5
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -1,8 +1,9 @@
 ---
 title: "IgnoreChanges"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The ignoreChanges resource option declares that changes to certain properties should be ignored during a diff.
 menu:
   intro:
+    identifier: ignoreChanges
     parent: options
     weight: 6
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/import.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/import.md
@@ -1,8 +1,9 @@
 ---
 title: "Import"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The import resource option brings an existing cloud resource into Pulumi.
 menu:
   intro:
+    identifier: import
     parent: options
     weight: 7
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/parent.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/parent.md
@@ -1,8 +1,9 @@
 ---
 title: "Parent"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The parent resource option establishes an explicit parent/child relationship between resources.
 menu:
   intro:
+    identifier: parent
     parent: options
     weight: 8
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/protect.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/protect.md
@@ -1,8 +1,9 @@
 ---
 title: "Protect"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The protect resource option prevents accidental deletion of a resource by marking it as protected.
 menu:
   intro:
+    identifier: protect
     parent: options
     weight: 9
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/provider.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/provider.md
@@ -1,8 +1,9 @@
 ---
 title: "Provider"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The provider resource option passes an explicitly configured provider to be used instead of the global or ambient provider.
 menu:
   intro:
+    identifier: provider
     parent: options
     weight: 10
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/providers.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/providers.md
@@ -1,8 +1,9 @@
 ---
 title: "Providers"
-meta_desc: An in depth look at Pulumi resources and their usage.
+meta_desc: The providers resource option specifies a set of explicitly configured providers to be used for a resource and all of its children.
 menu:
   intro:
+    identifier: providers
     parent: options
     weight: 11
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -3,6 +3,7 @@ title: "ReplaceOnChanges"
 meta_desc: The replaceOnChanges resource option indicates that changes to properties on a resource should force a replacement instead of an in-place update.
 menu:
   intro:
+    identifier: replaceOnChanges
     parent: options
     weight: 12
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/transformations.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/transformations.md
@@ -3,6 +3,7 @@ title: "Transformations"
 meta_desc: The transformations resource option provides a list of transformations to apply to a resource and all of its children.
 menu:
   intro:
+    identifier: transformations
     parent: options
     weight: 13
 ---

--- a/themes/default/content/docs/intro/concepts/resources/options/version.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/version.md
@@ -1,8 +1,9 @@
 ---
 title: "Version"
-meta_desc: The version resource option specifies a provider version to use when operating on a resource. 
+meta_desc: The version resource option specifies a provider version to use when operating on a resource.
 menu:
   intro:
+    identifier: version
     parent: options
     weight: 14
 ---


### PR DESCRIPTION
A follow-up to #997, this change makes the `Providers` menu item appear in the Resource Options menu by specifying explicit menu `identifier`s. (See [this comment](https://github.com/pulumi/pulumi-hugo/pull/997#pullrequestreview-862751882) for additional context.) Also adds page-specific meta descriptions for those that were re-using the description from the Resource Options overview page.