### PR TITLE
Remove block_external_search setting from Learn content

### DIFF
--- a/themes/default/archetypes/learn/module/_index.md
+++ b/themes/default/archetypes/learn/module/_index.md
@@ -37,9 +37,6 @@ tags:
 # At least one provider is required.
 providers:
     - aws
-
-# Exclude from search-engine indexing for now.
-block_external_search_index: true
 ---
 
 This is the content that will appear at the top of the module index page. It should

--- a/themes/default/archetypes/learn/topic/index.md
+++ b/themes/default/archetypes/learn/topic/index.md
@@ -51,9 +51,6 @@ tags:
 links:
     - text: Some Website
       url: http://something.com
-
-# Exclude from search-engine indexing for now.
-block_external_search_index: true
 ---
 
 This is the actual body of the topic, authored in Markdown.

--- a/themes/default/content/learn/_index.md
+++ b/themes/default/content/learn/_index.md
@@ -24,18 +24,15 @@ tutorials:
 
 overview: |
     <h1>Welcome to Learn Pulumi!</h1>
-    
+
     These learning pathways will help you learn all of the concepts of Pulumi,
     along with best practices and architectural patterns, through real-life
     examples.
-    
+
     In each tutorial, you'll complete a series of steps while exploring Pulumi
     to complete a project or build a system. Start with Pulumi Fundamentals to
     get comfortable with the vocabulary, and then head to another pathway to
     explore further.
-
-# Exclude from search-engine indexing for now.
-block_external_search_index: false
 ---
 
 Ipsum lorem

--- a/themes/default/content/learn/abstraction-encapsulation/_index.md
+++ b/themes/default/content/learn/abstraction-encapsulation/_index.md
@@ -18,7 +18,6 @@ tags:
     - components
 providers:
     - aws
-block_external_search_index: false
 ---
 
 ## Time

--- a/themes/default/content/learn/abstraction-encapsulation/abstraction/index.md
+++ b/themes/default/content/learn/abstraction-encapsulation/abstraction/index.md
@@ -14,7 +14,6 @@ authors:
     - laura-santamaria
 tags:
     - learn
-block_external_search_index: false
 ---
 
 Just like any application code, Pulumi infrastructure code can be abstracted, enabling us to work with high-level, generic representations of the things we need to build. If we use an object-oriented language such as JavaScript, Python, or TypeScript, we can create and instantiate classes. For languages like Go, we can build up interfaces. In all cases, we're thinking in terms of taking code that we've written and making it reusable in some form. Let's first explore abstraction.

--- a/themes/default/content/learn/abstraction-encapsulation/component-resources/index.md
+++ b/themes/default/content/learn/abstraction-encapsulation/component-resources/index.md
@@ -5,10 +5,10 @@ date: 2021-11-17
 draft: false
 description: |
     Try creating a component resource, or a logical grouping of code that Pulumi
-    recognizes as a resource. 
+    recognizes as a resource.
 meta_desc: |
     Try creating a component resource, or a logical grouping of code that Pulumi
-    recognizes as a resource. 
+    recognizes as a resource.
 index: 3
 estimated_time: 10
 meta_image: meta.png
@@ -19,7 +19,6 @@ tags:
 links:
     - text: Component Resources
       url: https://www.pulumi.com/docs/intro/concepts/resources/#components
-block_external_search_index: false
 ---
 
 Now that we have a better understanding of why abstraction and encapsulation are valuable concepts for Pulumi programs, let's explore what happens when we start working in larger teams at scale.

--- a/themes/default/content/learn/abstraction-encapsulation/encapsulation/index.md
+++ b/themes/default/content/learn/abstraction-encapsulation/encapsulation/index.md
@@ -14,7 +14,6 @@ authors:
     - laura-santamaria
 tags:
     - learn
-block_external_search_index: false
 ---
 
 Encapsulation is one part of what makes a programming language so powerful. Without encapsulation, programs would still be sets of commands. Encapsulation is generally considered as part of an object-oriented paradigm, but it's present in other software development paradigms like functional programming (e.g., lexical closures). But what does this have to do with infrastructure? Well, by using encapsulation we break logic down into reusable components. In doing so, we ensure better maintainability, readability, and reusability&mdash;all critical to good infrastructure as code both in theory and in practice.

--- a/themes/default/content/learn/building-with-pulumi/_index.md
+++ b/themes/default/content/learn/building-with-pulumi/_index.md
@@ -14,7 +14,6 @@ youll_learn:
     - Testing your Pulumi programs
 providers:
     - aws
-block_external_search_index: false
 ---
 
 This tutorial digs a little deeper into what it means to create multiple Pulumi

--- a/themes/default/content/learn/building-with-pulumi/secrets/index.md
+++ b/themes/default/content/learn/building-with-pulumi/secrets/index.md
@@ -12,7 +12,6 @@ authors:
     - matt-stratton
 tags:
     - secrets
-block_external_search_index: false
 ---
 
 All resource input and output values are recorded as _state_ and are stored

--- a/themes/default/content/learn/building-with-pulumi/stack-outputs/index.md
+++ b/themes/default/content/learn/building-with-pulumi/stack-outputs/index.md
@@ -10,7 +10,6 @@ estimated_time: 10
 meta_image: meta.png
 authors:
     - matt-stratton
-block_external_search_index: false
 ---
 
 We've created some resources. Now, let's see how we can use outputs outside of

--- a/themes/default/content/learn/building-with-pulumi/stack-references/index.md
+++ b/themes/default/content/learn/building-with-pulumi/stack-references/index.md
@@ -13,7 +13,6 @@ authors:
 tags:
     - stacks
     - outputs
-block_external_search_index: false
 ---
 
 We've created some resources. Now, let's see how we can use outputs outside of

--- a/themes/default/content/learn/building-with-pulumi/testing/index.md
+++ b/themes/default/content/learn/building-with-pulumi/testing/index.md
@@ -13,7 +13,6 @@ authors:
     - laura-santamaria
 tags:
     - testing
-block_external_search_index: false
 ---
 
 Pulumi programs are authored in a general-purpose language like TypeScript,

--- a/themes/default/content/learn/building-with-pulumi/understanding-stacks/index.md
+++ b/themes/default/content/learn/building-with-pulumi/understanding-stacks/index.md
@@ -12,7 +12,6 @@ authors:
     - matt-stratton
 tags:
     - stacks
-block_external_search_index: false
 ---
 
 Every Pulumi program is deployed to a stack. A stack is an isolated,

--- a/themes/default/content/learn/pulumi-fundamentals/_index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/_index.md
@@ -6,7 +6,7 @@ draft: false
 description: |
     Learn how to use Pulumi to build, configure, and deploy a real-life, modern
     application.
-meta_desc: | 
+meta_desc: |
     Learn how to use Pulumi to build, configure, and deploy a real-life, modern
     application.
 index: 0
@@ -18,7 +18,6 @@ tags:
     - fundamentals
 providers:
     - docker
-block_external_search_index: false
 ---
 
 For this tutorial, we're going to learn more about cloud computing by exploring

--- a/themes/default/content/learn/pulumi-fundamentals/configure-and-provision/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/configure-and-provision/index.md
@@ -20,7 +20,6 @@ tags:
 links:
     - text: Code Repo
       url: https://github.com/pulumi/tutorial-pulumi-fundamentals
-block_external_search_index: false
 ---
 
 Now that we've created our images, we can provision our application with a

--- a/themes/default/content/learn/pulumi-fundamentals/create-a-pulumi-project/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/create-a-pulumi-project/index.md
@@ -15,7 +15,6 @@ tags:
     - fundamentals
     - projects
     - docker
-block_external_search_index: false
 ---
 
 Infrastructure in Pulumi is organized into _projects_. In the Pulumi ecosystem,

--- a/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
@@ -17,7 +17,6 @@ tags:
 links:
     - text: Code Repo
       url: https://github.com/pulumi/tutorial-pulumi-fundamentals
-block_external_search_index: false
 ---
 
 In this part, we'll create our first Pulumi _resource_. Resources in Pulumi are


### PR DESCRIPTION
Early on, I included the `block_external_search_index` setting in our module and topic archetypes thinking we might want to publish and iterate on content (behind a "coming soon" home page or something) without risk of exposing that content it to crawlers. Now that we've launched, though, and we have PR previews, etc., we no longer need it.