### PR TITLE
Fix archetype scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ ci-scheduled:
 
 .PHONY: new-blog-post
 new-blog-post:
-	hugo new --kind blog-post \
-		"themes/default/content/blog/$(shell bash -c 'read -p "Slug (e.g., 'my-new-post'): " slug; echo $$slug')"
+	hugo new --kind blog-post --contentDir themes/default/content \
+	"blog/$(shell bash -c 'read -p "Slug (e.g., 'my-new-post'): " slug; echo $$slug')"
 
 .PHONY: new-learn-module
 new-learn-module:

--- a/scripts/content/new-learn-module.sh
+++ b/scripts/content/new-learn-module.sh
@@ -5,13 +5,13 @@ set -o errexit -o pipefail
 module=""
 topic=""
 
-content_root="themes/default/content/"
+content_dir="themes/default/content"
 
 prompt_for_module_name() {
     read -p "Module name (e.g., pulumi-101-aws): " module
 
     if [ ! -z "$module" ]; then
-        hugo new --kind learn/module "${content_root}learn/${module}"
+        hugo new --kind learn/module --contentDir "${content_dir}" "learn/${module}"
         return
     fi
 
@@ -23,7 +23,7 @@ prompt_for_topic_name() {
     read -p "Topic name (e.g., basics): " topic
 
     if [ ! -z "$topic" ]; then
-        hugo new --kind learn/topic "${content_root}learn/${module}/${topic}"
+        hugo new --kind learn/topic --contentDir "${content_dir}" "learn/${module}/${topic}"
         return
     fi
 

--- a/scripts/content/new-learn-topic.sh
+++ b/scripts/content/new-learn-topic.sh
@@ -4,12 +4,12 @@ set -o errexit -o pipefail
 
 module=""
 topic=""
-content_root="themes/default/content/"
+content_dir="themes/default/content"
 
 prompt_for_module_name() {
     read -p "Module name (e.g., pulumi-101-aws): " module
 
-    if [[ ! -z "$module" && -d "${content_root}learn/${module}" ]]; then
+    if [[ ! -z "$module" && -d "${content_dir}/learn/${module}" ]]; then
         return
     fi
 
@@ -22,7 +22,7 @@ prompt_for_topic_name() {
     read -p "Topic name (e.g., basics): " topic
 
     if [ ! -z "$topic" ]; then
-        hugo new --kind learn/topic "${content_root}learn/${module}/${topic}"
+        hugo new --kind learn/topic --contentDir "${content_dir}" "learn/${module}/${topic}"
         return
     fi
 


### PR DESCRIPTION
Happened to notice the `make new-blog-post`, `make new-learn-module`, and `make new-learn-topic` helpers stopped working with the most recent version of Hugo, which switched things up a bit. This PR should fix 'em up.

Before: 

```
$ make new-blog-post 

Slug (e.g., my-new-post): how-i-spent-my-summer-vacation 
hugo new --kind blog-post "blog/how-i-spent-my-summer-vacation"
Error: could not determine content directory for "blog/how-i-spent-my-summer-vacation/index.md"
```

After: 

```
$ make new-blog-post 
Slug (e.g., my-new-post): how-i-spent-my-summer-vacation
hugo new --kind blog-post --contentDir themes/default/content \
        "blog/how-i-spent-my-summer-vacation"
Content dir "/Users/christian/go/src/github.com/pulumi/pulumi-hugo/themes/default/content/blog/how-i-spent-my-summer-vacation" created
```