### PR TITLE
move self-hosted repos note up

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/_index.md
@@ -45,15 +45,15 @@ Here are some examples of deployment topologies:
 
 ## Components
 
+{{% notes type="info" %}}
+The component repositories are private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
+{{% /notes %}}
+
 | Component | Repository |
 | --------- | ---------- |
 | [API]({{< relref "api" >}}) | [https://hub.docker.com/r/pulumi/service/](https://hub.docker.com/r/pulumi/service/) |
 | [Console]({{< relref "console" >}}) |	[https://hub.docker.com/r/pulumi/console/](https://hub.docker.com/r/pulumi/console/) |
 | Migrations | [https://hub.docker.com/r/pulumi/migrations/](https://hub.docker.com/r/pulumi/migrations/) |
-
-{{% notes type="info" %}}
-The above container image repositories are private. [Contact us]({{< relref "/contact.md" >}}) if you would like to evaluate the Self-Hosted Enterprise Edition.
-{{% /notes %}}
 
 ## Quickstart
 


### PR DESCRIPTION
the note that says why the links don't work is below the actual links which make it difficult for folks to be aware that the links wont work. this moves it up, above the table, with the hope that folks might read it before trying to use the links.