### PR TITLE
Redirect /crosswalk

### DIFF
--- a/themes/default/content/crosswalk/_index.md
+++ b/themes/default/content/crosswalk/_index.md
@@ -1,5 +1,7 @@
 ---
 title: Pulumi Crosswalk
 meta_desc: Pulumi Crosswalk is a collection of libraries that use well-architected best practices to make common infrastructure-as-code tasks easier and more secure.
-private: true
+layout: aws
+redirect_to: /crosswalk/aws
+redirect_temporarily: true
 ---

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -10,7 +10,14 @@
     <meta name="google-site-verification" content="N-ezSTIu4P3bSc4TqidV4wWCkMzFiMN269ZgDYArGkk" />
 
     {{ if .Params.redirect_to }}
-        <meta http-equiv="refresh" content="0; url={{ .Params.redirect_to }}" />
+        {{ $delay := 0 }}
+
+        {{/* https://developers.google.com/search/docs/advanced/crawling/301-redirects#metarefresh */}}
+        {{ if .Params.redirect_temporarily }}
+            {{ $delay = 1 }}
+        {{ end }}
+
+        <meta http-equiv="refresh" content="{{ $delay }}; url={{ .Params.redirect_to }}" />
     {{ end }}
 
     {{ if eq .Params.block_external_search_index true }}


### PR DESCRIPTION
We don't currently have any content on this page, and it's been search-engine indexed, so we should probably send those who find it to our current Crosswalk for AWS docs.

This change does two things:
* Asks Google not to index /crosswalk
* Redirects to https://www.pulumi.com/docs/guides/crosswalk/aws/

If we do plan to fill this page out with content, though, we might want to redirect temporarily rather than permanently.