### PR TITLE
Fix awards link

### DIFF
--- a/themes/default/data/awards.toml
+++ b/themes/default/data/awards.toml
@@ -2,7 +2,7 @@
 title = "Best Innovation in Coding Tools, 2022"
 featured = true
 img = "/logos/press/awards/devies-2022.png"
-url = "https://www.developerweek.com/awards/2021-devies-winners/"
+url = "https://www.developerweek.com/awards/"
 
 [[awards]]
 title = "Top Open Source Tech Startups 2021"


### PR DESCRIPTION
I mistakenly linked to the 2021 awards. 🤦 