### PR TITLE
remove hyphen in pricing intro

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -8,7 +8,7 @@
             Fully managed cloud engineering platform
         </h2>
         <p class="max-w-3xl mx-auto mt-6">
-            The <a class="underline" href="{{ relref . "/product/pulumi-service" }}">Pulumi Service</a> is a fully-managed service for the
+            The <a class="underline" href="{{ relref . "/product/pulumi-service" }}">Pulumi Service</a> is a fully managed service for the
             open source CLI and SDK. It provides secure state & secrets management,
             collaboration features, CI/CD integrations, compliance enforcement, identity and access controls, and more.
         </p>


### PR DESCRIPTION
this came up in a review, we don't have the hyphen in the heading so its a bit weird to have it in the paragraph

@kimberleyamackenzie figured id just push this out now instead of waiting on the other release, but letting you know in case it messes anything up for you