### PR TITLE
Update description of startTime for audit logs API

### DIFF
--- a/themes/default/content/docs/reference/service-rest-api/_index.md
+++ b/themes/default/content/docs/reference/service-rest-api/_index.md
@@ -2016,7 +2016,7 @@ GET /api/orgs/{organization}/auditlogs
 | Parameter | Type | In | Description |
 | --------- | ---------- | ---------- | ---------- |
 | `organization` | string | path | organization name |
-| `startTime` | unix timestamp | query | return results that occur after this timestamp |
+| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e. are older) than this timestamp |
 | `userFilter` | string | query | **Optional.** username (e.g. `user1`) to filter results by |
 | `continuationToken` | string | query | **Optional.** the continuation token to use for retrieving the next set of results if results were truncated |
 
@@ -2099,7 +2099,7 @@ GET /api/orgs/{organization}/auditlogs/export
 | Parameter | Type | In | Description |
 | --------- | ---------- | ---------- | ---------- |
 | `organization` | string | path | organization name |
-| `startTime` | unix timestamp | query | return results that occur after this timestamp |
+| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e. are older) than this timestamp |
 | `userFilter` | string | query | **Optional.** username (e.g. `user1`) to filter results by |
 | `format` | string | query | **Optional.** the response format to return - possible values are `cef` or `csv` (default) |
 

--- a/themes/default/content/docs/reference/service-rest-api/_index.md
+++ b/themes/default/content/docs/reference/service-rest-api/_index.md
@@ -2016,7 +2016,7 @@ GET /api/orgs/{organization}/auditlogs
 | Parameter | Type | In | Description |
 | --------- | ---------- | ---------- | ---------- |
 | `organization` | string | path | organization name |
-| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e. are older) than this timestamp |
+| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e., are older) than this timestamp |
 | `userFilter` | string | query | **Optional.** username (e.g. `user1`) to filter results by |
 | `continuationToken` | string | query | **Optional.** the continuation token to use for retrieving the next set of results if results were truncated |
 
@@ -2099,7 +2099,7 @@ GET /api/orgs/{organization}/auditlogs/export
 | Parameter | Type | In | Description |
 | --------- | ---------- | ---------- | ---------- |
 | `organization` | string | path | organization name |
-| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e. are older) than this timestamp |
+| `startTime` | unix timestamp | query | return audit log entries that occurred before (i.e., are older) than this timestamp |
 | `userFilter` | string | query | **Optional.** username (e.g. `user1`) to filter results by |
 | `format` | string | query | **Optional.** the response format to return - possible values are `cef` or `csv` (default) |
 


### PR DESCRIPTION
Make it clear that audit logs that are OLDER than startTime are returned.