### PR TITLE
shorten content on learn card

### DIFF
--- a/themes/default/content/learn/abstraction-encapsulation/_index.md
+++ b/themes/default/content/learn/abstraction-encapsulation/_index.md
@@ -3,9 +3,9 @@ title: "Abstraction and Encapsulation"
 layout: module
 date: 2021-11-17
 description: |
-    Explore abstraction and encapsulation with Pulumi programs using component resources.
+    Explore abstraction and encapsulation with Pulumi and component resources.
 meta_desc: |
-    Explore abstraction and encapsulation with Pulumi programs using component resources.
+    Explore abstraction and encapsulation with Pulumi and component resources.
 index: 6
 meta_image: meta.png
 level: intermediate


### PR DESCRIPTION
## overview
one of the 3 learn cards has a longer description than the rest; we should try to keep these to no more than 3 lines. @nimbinatus happy to adjust the content in a different way if ya don't think my edit will work.

### screenshots

#### before
<img width="1026" alt="Screen Shot 2022-02-23 at 10 27 14 AM" src="https://user-images.githubusercontent.com/5489125/155383724-ae48f2d9-5331-412a-9d10-3d68d9465eca.png">

#### after
<img width="1056" alt="Screen Shot 2022-02-23 at 10 27 08 AM" src="https://user-images.githubusercontent.com/5489125/155383708-a07783c5-447d-40ee-bcdb-3a356fedd19d.png">

