### PR TITLE
add info on how to add urself to the website

### DIFF
--- a/pulumi-employees/add-yourself-to-the-website.md
+++ b/pulumi-employees/add-yourself-to-the-website.md
@@ -1,0 +1,8 @@
+# Add yourself to the website
+
+Clone the [Pulumi Hugo repo](https://github.com/pulumi/pulumi-hugo) locally, create a new branch (e.g. `yourfirstname/team`), and add the following files in a new commit:
+
+1. A TOML file to the [team data](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/data/team/team) directory
+1. A square sized picture to the [team images](https://github.com/pulumi/pulumi-hugo/tree/master/themes/default/static/images/team) directory.
+
+Then push your branch and open a pull request against master.


### PR DESCRIPTION
i know this is in onboarding docs in a few different places, but it seemed most relevant to have this content available in the repo where you add it. @cnunciato any thoughts on this?