### PR TITLE
Run full website builds for PRs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,20 +40,8 @@ jobs:
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
           role-session-name: PullRequestPreviewSession
 
-      - name: Check out the docs repo
-        uses: actions/checkout@v2
-        with:
-          repository: pulumi/docs
-          path: docs
-
       - name: Run a full docs build
-        run: HUGO_MODULE_REPLACEMENTS="github.com/pulumi/pulumi-hugo/themes/default -> $(pwd)/../themes/default" make ensure ensure_tools build
-        working-directory: docs
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make ci-build-full-site
 
       - name: Build and deploy preview
         run: make ci-pull-request

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,6 +7,8 @@ jobs:
   preview:
     # Only run this job for events that originate on this repository.
     if: github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      GOPATH: ${{ github.workspace }}/go
     name: Build and deploy preview
     runs-on: ubuntu-18.04
     steps:
@@ -37,6 +39,21 @@ jobs:
           aws-region: us-west-2
           role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
           role-session-name: PullRequestPreviewSession
+
+      - name: Check out the docs repo
+        uses: actions/checkout@v2
+        with:
+          repository: pulumi/docs
+          path: docs
+
+      - name: Run a full docs build
+        run: HUGO_MODULE_REPLACEMENTS="github.com/pulumi/pulumi-hugo/themes/default -> $(pwd)/../themes/default" make ensure ensure_tools build
+        working-directory: docs
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and deploy preview
         run: make ci-pull-request

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ public
 .DS_Store
 yarn-error.log
 .hugo_build.lock
+docs

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ lint:
 build:
 	./scripts/build.sh
 
+.PHONY: ci-build-full-site
+ci-build-full-site:
+	./scripts/ci/build-full-site.sh
+
 .PHONY: serve
 serve:
 	./scripts/serve.sh

--- a/scripts/ci/build-full-site.sh
+++ b/scripts/ci/build-full-site.sh
@@ -10,7 +10,8 @@ rm -rf temp-docs && mkdir temp-docs
 # Use this pulumi-hugo branch's themes/default content to run a full build of the website.
 pushd temp-docs
     git clone https://github.com/pulumi/docs.git .
-    HUGO_MODULE_REPLACEMENTS="github.com/pulumi/pulumi-hugo/themes/default -> $(pwd)/../themes/default" make ensure ensure_tools build
+    HUGO_MODULE_REPLACEMENTS="github.com/pulumi/pulumi-hugo/themes/default -> $(pwd)/../themes/default" \
+        make ensure ensure_tools build
 popd
 
 rm -rf temp-docs

--- a/scripts/ci/build-full-site.sh
+++ b/scripts/ci/build-full-site.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+source ./scripts/ci/common.sh
+
+# Check out the docs repo @ master.
+rm -rf temp-docs && mkdir temp-docs
+
+# Use this pulumi-hugo branch's themes/default content to run a full build of the website.
+pushd temp-docs
+    git clone https://github.com/pulumi/docs.git .
+    HUGO_MODULE_REPLACEMENTS="github.com/pulumi/pulumi-hugo/themes/default -> $(pwd)/../themes/default" make ensure ensure_tools build
+popd
+
+rm -rf temp-docs


### PR DESCRIPTION
This change adds a step to check out the docs repo and run a full website build for every PR commit. It should help us identify `{{< relref >}}` issues that would otherwise fail when pulled into pulumi/docs PRs later.

Note that this **adds** about 15 minutes to PR build times, and _does not_ push the full website in PR previews, as that'd take much longer. (Preview links will still consist of the same content they do today.) If we find that 15 minutes is too long (and I suspect we might), we could fairly easily convert this work to be done in response to a GitHub slash command later. 