### PR TITLE
Add docs nav toggle for small screens; fix overlapping buttons on small screens

### DIFF
--- a/themes/default/layouts/docs/list.html
+++ b/themes/default/layouts/docs/list.html
@@ -3,7 +3,7 @@
         <div class="lg:flex">
 
             <div class="lg:hidden mb-6">
-                <button class="docs-sidebar-toggle items-center px-3 py-2 border rounded text-purple border-purple">
+                <button class="docs-sidebar-toggle items-center px-3 py-2 border rounded">
                     Toggle Docs Navigation
                 </button>
             </div>

--- a/themes/default/layouts/docs/list.html
+++ b/themes/default/layouts/docs/list.html
@@ -2,6 +2,23 @@
     <div class="container mx-auto px-4 py-8 mt-2">
         <div class="lg:flex">
 
+            <div class="lg:hidden mb-6">
+                <button class="docs-sidebar-toggle items-center px-3 py-2 border rounded text-purple border-purple">
+                    Toggle Docs Navigation
+                </button>
+            </div>
+
+            <div class="docs-sidebar-content hidden lg:block lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
+                <div class="sticky-sidebar">
+                    <div class="lg:mt-1 mb-6">
+                        {{ partial "docs/search.html" . }}
+                    </div>
+                    <div>
+                        {{ partial "docs/toc.html" . }}
+                    </div>
+                </div>
+            </div>
+
             <div class="lg:w-6/12 lg:px-4">
                 {{ partial "docs/breadcrumb.html" . }}
 
@@ -28,7 +45,7 @@
                 </div>
             </div>
 
-            <div class="lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
+            <!-- <div class="hidden lg:block lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
                 <div class="sticky-sidebar">
                     <div class="lg:mt-1 mb-6">
                         {{ partial "docs/search.html" . }}
@@ -37,7 +54,7 @@
                         {{ partial "docs/toc.html" . }}
                     </div>
                 </div>
-            </div>
+            </div> -->
         </div>
     </div>
 {{ end }}

--- a/themes/default/layouts/docs/list.html
+++ b/themes/default/layouts/docs/list.html
@@ -44,17 +44,6 @@
                     {{ partial "right-nav-ad.html" }}
                 </div>
             </div>
-
-            <!-- <div class="hidden lg:block lg:w-3/12 pr-8 mb-2 pt-8 lg:order-first lg:border-none lg:pt-0 lg:mt-0">
-                <div class="sticky-sidebar">
-                    <div class="lg:mt-1 mb-6">
-                        {{ partial "docs/search.html" . }}
-                    </div>
-                    <div>
-                        {{ partial "docs/toc.html" . }}
-                    </div>
-                </div>
-            </div> -->
         </div>
     </div>
 {{ end }}

--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -232,8 +232,8 @@
                 <p>
                     - Mike Corsaro, Senior Software Engineer at Bitbucket
                 </p>
-                <div class="mt-12">
-                    <a class="btn-primary" href="{{ relref . "/case-studies/atlassian" }}">Read Atlassian Case Study</a>
+                <div class="mt-12 flex flex-col sm:flex-row justify-center flex-grow">
+                    <a class="btn-primary mb-6 sm:mr-2 sm:mb-0" href="{{ relref . "/case-studies/atlassian" }}">Read Atlassian Case Study</a>
                     <a class="btn-secondary" href="{{ relref . "/case-studies" }}">See more case studies</a>
                 </div>
             </div>


### PR DESCRIPTION
This PR tackles two items affecting small screens:

1) Adds a toggle button for the docs nav at small screens.  Previously the nav content dropped to the bottom of the page which wasn't super clear or easy to use - this PR pulls in the same solution we use for the blog by adding a toggle button that shows the nav at the top of the page when toggled open.   https://github.com/pulumi/pulumi-hugo/issues/315

Since I have worked in docs less, would love some eyes to make sure I got everywhere the nav is (I checked both docs home and individual pages) - not sure if I might be missing something. 

2) Adjusts buttons for the Atlassian case study on the home page so they move to a column at small screen sizes.  https://github.com/pulumi/pulumi-hugo/issues/1111

<img width="407" alt="Screen Shot 2022-03-02 at 4 39 20 PM" src="https://user-images.githubusercontent.com/25756367/156474169-7b42789e-628b-4b59-9ee8-7b089aecf422.png">

