### PR TITLE
Remove errant ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ public
 .DS_Store
 yarn-error.log
 .hugo_build.lock
-docs


### PR DESCRIPTION
This was a mistake; in #1106, I added a script to build the full site and write it to a local directory, and that directory was initially called `docs`, later changed to `temp-docs`. I ended up doing the post-build cleanup work in the script, though, but forgot to go back and remove the entry from `.gitignore`. 