### PR TITLE
Update marketplace link and case study buttons on /enterprise

### DIFF
--- a/themes/default/content/enterprise/_index.md
+++ b/themes/default/content/enterprise/_index.md
@@ -97,7 +97,7 @@ support:
 partners:
     title: Cloud Partners
     description: |
-        Pulumi works with the leading cloud providers including AWS, Google Cloud, and Microsoft Azure to ensure best-in-class support of the Pulumi Cloud Engineering Platform across each cloud. Pulumi provides Native Providers which enables same-day support of all new products and features in each cloud. Pulumi is also available for purchase through [AWS Marketplace](https://aws.amazon.com/marketplace) with support for additional cloud provider marketplaces coming soon.
+        Pulumi works with the leading cloud providers including AWS, Google Cloud, and Microsoft Azure to ensure best-in-class support of the Pulumi Cloud Engineering Platform across each cloud. Pulumi provides Native Providers which enables same-day support of all new products and features in each cloud. Pulumi is also available for purchase through [AWS Marketplace](https://aws.amazon.com/marketplace/pp/prodview-dwn22batkhsyg) with support for additional cloud provider marketplaces coming soon.
 
 get_started:
     title: Get Started

--- a/themes/default/layouts/page/enterprise.html
+++ b/themes/default/layouts/page/enterprise.html
@@ -49,7 +49,7 @@
                                         </div>
                                     </div>
 
-                                    <div class="card-cta-btn mt-8 text-center">
+                                    <div class="my-4 text-center">
                                         <a href="{{ $item.link }}" class="btn-secondary">Read Case Study</a>
                                     </div>
                                 </div>

--- a/themes/default/layouts/partials/banner.html
+++ b/themes/default/layouts/partials/banner.html
@@ -1,6 +1,6 @@
-{{ $summary := "Recently announced: The Pulumi Registry, your window to the cloud." }}
-{{ $url := relref . "/registry" }}
-{{ $label := "Browse the Registry"}}
+{{ $summary := "Introducing Pulumi Business Critical Edition for Enterprise Modernization." }}
+{{ $url := relref . "/blog/business-critical-launch" }}
+{{ $label := "Read more"}}
 
 <div class="top-nav-banner-cta-container">
     <div class="top-nav-banner-cta">

--- a/themes/default/layouts/partials/banner.html
+++ b/themes/default/layouts/partials/banner.html
@@ -1,4 +1,4 @@
-{{ $summary := "Introducing Pulumi Business Critical Edition for Enterprise Modernization." }}
+{{ $summary := "Recently announced: Pulumi Business Critical Edition for Enterprise Modernization." }}
 {{ $url := relref . "/blog/business-critical-launch" }}
 {{ $label := "Read more"}}
 


### PR DESCRIPTION
Just as the title states this PR updates the marketplace link and the case study buttons so they don't extend past the box as per the feedback in Slack.