### PR TITLE
Add zoominfo websights snippet

### DIFF
--- a/themes/default/layouts/_default/baseof.html
+++ b/themes/default/layouts/_default/baseof.html
@@ -14,5 +14,9 @@
         </main>
 
         {{ partial "footer.html" . }}
+        <noscript>
+        <img src="https://ws.zoominfo.com/pixel/61f9917376ed81001a80e653"
+        width="1" height="1" style="display: none;" />
+        </noscript>
     </body>
 </html>

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -143,13 +143,26 @@
 
     <script async defer src="https://buttons.github.io/buttons.js"></script>
     {{- if eq hugo.Environment "production" }}
-    <!--Segment tracking-->
-    <script>
-    !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-    analytics.load("UK90Ofwacetj5VCPJ7cUgkbNcKLSHO3u");
-    analytics.page();
-    }}();
-    </script>
+        <!--Segment tracking-->
+        <script>
+        !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("UK90Ofwacetj5VCPJ7cUgkbNcKLSHO3u");
+        analytics.page();
+        }}();
+        </script>
+
+        <!-- Zoominfo Websights -->
+        <script>
+        (function() {
+        var zi = document.createElement('script');
+        zi.type = 'text/javascript';
+        zi.async = true;
+        zi.referrerPolicy = 'unsafe-url';
+        zi.src = 'https://ws.zoominfo.com/pixel/61f9917376ed81001a80e653';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(zi, s);
+        })();
+        </script>
     {{- end }}
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->


### PR DESCRIPTION
Just as the title states this PR adds the Zoominfo Websights snippet.

Fixes: https://github.com/pulumi/marketing/issues/112

Zoominfo Installation guide: https://university.zoominfo.com/learn/article/implementation-guide-zoominfo-websights