### PR TITLE
Use pulumi-bot for auto-commits

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Check out branch
         uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
       - name: Fetch the latest pulumi/theme and pulumi/registry
         run: |


### PR DESCRIPTION
We've had branch protections disabled for a bit, in order to allow for certain `push` workflows to commit back to `master`, and up to now, those workflows have been running as whoever clicked the merge button. This change has them run as `pulumi-bot` instead, which should allow us to restore those branch protections to the usual set (approvals required for non-admins, etc.).