### PR TITLE
Add track properties for pricing dialog

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -367,7 +367,7 @@
                             <span class="pb-6 md:pb-0">Most popular way to use Pulumi</span>
                             <p class="py-0 md:py-6 text-center hidden md:block">The fastest and easiest way to try Pulumi <br />using our scalable, highly available, and secure SaaS.</p>
                             <div class="z-0">
-                                <a id="startServiceTrial" class="btn-primary" href="https://app.pulumi.com/site/trial" >Start 14-Day Trial</a>
+                                <a id="startServiceTrial" data-track="trial-dialog-service" class="btn-primary" href="https://app.pulumi.com/site/trial" >Start 14-Day Trial</a>
                             </div>
                         </div>
                         <div class="mt-16 md:mt-0 flex flex-col items-center md:w-96">
@@ -378,7 +378,7 @@
                             <span class="pb-6 md:pb-0">For enterprises with data control requirements</span>
                             <p class="py-0 md:py-6 text-center hidden md:block">Run the Pulumi Service in your on-premises or cloud environment and manage it yourself.</p>
                             <div class="z-0">
-                                <a id="startSelfHostedTrial" class="btn-secondary" href="{{ relref . " /product/self-hosted#self-hosted-trial" }}">Request Trial of Self-Hosted</a>
+                                <a id="startSelfHostedTrial" data-track="trial-dialog-self-hosted" class="btn-secondary" href="{{ relref . " /product/self-hosted#self-hosted-trial" }}">Request Trial of Self-Hosted</a>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Add properties to the two links inside the pricing page "get started" dialog so that we can have insight into usage of this dialog to navigate to the different pages.