### PR TITLE
Change Page.Dir references to Page.File.Dir

### DIFF
--- a/themes/default/layouts/shortcodes/get-started-stepper.html
+++ b/themes/default/layouts/shortcodes/get-started-stepper.html
@@ -7,7 +7,7 @@
 
 {{/* Get the pages in the current directory. */}}
 {{ $unsortedPages := slice $currentPage }}
-{{ if eq $currentPage.Dir $currentPage.Parent.Dir }}
+{{ if eq $currentPage.File.Dir $currentPage.Parent.File.Dir }}
     {{ $unsortedPages = $unsortedPages | append $currentPage.Parent }}
 {{ end }}
 {{ range $index, $page := .Page.CurrentSection.Pages }}


### PR DESCRIPTION
We've been seeing warning-level error this in the logs for a bit:

```
ERROR 2022/03/15 15:04:17 Page.Dir is deprecated and will be removed in Hugo 0.93.0. Use .File.Dir
```

Now that the current version of Hugo is `0.94` (which definitely does break on this), we should fix this up, as users who run locally will hit start hitting it once they install or upgrade to latest. (h/t @meagancojocar) 