### PR TITLE
Add swiftype meta tag for registry package overview pages

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -81,6 +81,11 @@
         <meta property="og:description" content="{{ .Summary }}">
     {{ end }}
 
+    <!-- For Registry package overview pages, add a swiftype meta tag to elevate the page in search results. -->
+    {{ if eq (.Params.layout) "overview" }}
+        <meta class="swiftype" name="package-overview-description" data-type="text" content="{{ .Params.meta_desc }}" />
+    {{ end }}
+
     {{ if .IsHome }}
         <title>{{ .Site.Title }}</title>
     {{ else if .Params.title_tag }}


### PR DESCRIPTION
Add a meta tag in the head for Registry overview pages that re-uses the meta description as the content for the purposes of search results.  This should still accomplish https://github.com/pulumi/registry/issues/558, and we can always add a new frontmatter property if we find there are additional search terms we want to direct to the overview that are missing.  

The change this PR makes is that now, on registry package overview pages (and no other pages), there should be a meta tag in the head of the doc that looks something like this example:

```<meta class="swiftype" name="package-overview-description" data-type="text" content="Learn how you can use Pulumi's AWS Classic Provider to reduce the complexity of provisioning and managing resources on AWS.">```

This should have 0 effects otherwise until we update the weight of that tag in the swiftype console.

Shoutout to @cnunciato for pushing me to find a much simpler approach than my original idea!