### PR TITLE
remove answerable from feedback msg

### DIFF
--- a/themes/default/layouts/partials/docs/feedback.html
+++ b/themes/default/layouts/partials/docs/feedback.html
@@ -23,8 +23,8 @@
             Thank you for your feedback!
         </p>
         <p>
-            If you have a specific, answerable question about how
-            to use Pulumi, ask it in our <a href="https://slack.pulumi.com/">Community Slack</a>.
+            If you have a question about how
+            to use Pulumi, reach out in <a href="https://slack.pulumi.com/">Community Slack</a>.
         </p>
         <p>
             Open an issue on GitHub to


### PR DESCRIPTION
noticed this today, _answerable_ reads as kinda rude, and im not sure how a user is supposed to know ahead of time if their question is _answerable_, so rephrased.