### PR TITLE
Fix the PulumiUP date

### DIFF
--- a/themes/default/content/resources/pulumi-up/index.md
+++ b/themes/default/content/resources/pulumi-up/index.md
@@ -2,8 +2,7 @@
 # Name of the webinar.
 title: "PulumiUP"
 meta_desc: |
-    PulumiUP introduces you to the emerging practice of Cloud Engineering. Hear from the Pulumi team
-    and assorted industry experts.
+    PulumiUP is a virtual conference with industry-recognized leaders, demos, and panel discussions about the future of IaC, Cloud Engineering & DevOps and Cloud.
 
 redirect_to: /pulumi-up
 
@@ -43,5 +42,5 @@ url_slug: "pulumi-up"
 # Content for the left hand side section of the page.
 main:
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2021-04-20T09:00:00-07:00
+    sortable_date: 2022-05-04T09:00:00-07:00
 ---

--- a/themes/default/layouts/partials/content-tile.html
+++ b/themes/default/layouts/partials/content-tile.html
@@ -12,8 +12,8 @@
         {{ $target = "" }}
     {{ end }}
 
-    <article class="card bg-white mb-10 flex flex-col mx-2 md:mx-0 content-tile">
-        <a href="{{ $href }}" rel="{{ $relref }}" target="{{ $target }}" class="w-full h-full hover:underline">
+    <article class="card bg-white mb-10 flex flex-col mx-2 md:mx-0 content-tile group">
+        <a href="{{ $href }}" rel="{{ $relref }}" target="{{ $target }}" class="w-full h-full group-hover">
             <span class="block w-full h-full p-4 flex flex-col">
                 <span class="block pb-2 mb-4">
                     <div class="bg-violet-100 rounded-full inline-block p-4 w-16 h-16 flex items-center justify-center">
@@ -21,7 +21,7 @@
                     </div>
                 </span>
                 <span class="block">
-                    <h6 class="">
+                    <h6 class="group-hover:underline">
                         {{ .data.Params.title }}
                         {{ if .external }}<i class="text-sm ml-2 fas fa-external-link-alt"></i>{{ end }}
                     </h6>


### PR DESCRIPTION
Updates the date and summary copy of the Pulumi Up event resource. Also makes a slight tweak to the hover behavior to underline only the title (instead all of the text on the card).

Fixes https://github.com/pulumi/marketing/issues/122.