### PR TITLE
add redirect for the old self hosted console page

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/components/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/components/_index.md
@@ -1,11 +1,13 @@
 ---
 title: Pulumi Service Components
+meta_desc: The Pulumi service container images page links and docker hub links.
 menu:
     userguides:
         parent: self_hosted
         identifier: self_hosted_components
         weight: 70
-meta_desc: The Pulumi service container images page links and docker hub links.
+aliases:
+  - /docs/guides/self-hosted/console/
 ---
 
 {{% notes type="info" %}}


### PR DESCRIPTION
originally reported in [internal slack](https://pulumi.slack.com/archives/C85BS3LJZ/p1647816830868659)