### PR TITLE
Unlink the blog post title on the blog post page

### DIFF
--- a/themes/default/layouts/blog/single.html
+++ b/themes/default/layouts/blog/single.html
@@ -9,9 +9,9 @@
                 <article class="mb-8 pb-8 border-b border-gray-200">
 
                     {{ if and (.Params.h1) (not .Params.notitle) }}
-                        <h1 class="no-anchor"><a data-track="blog-title" href="{{ .Permalink }}">{{ .Params.h1 }}</a></h1>
+                        <h1 class="no-anchor">{{ .Params.h1 }}</h1>
                     {{ else if and (ne .Title "") (not .Params.notitle) }}
-                        <h1 class="no-anchor"><a data-track="blog-title" href="{{ .Permalink }}">{{ .Title }}</a></h1>
+                        <h1 class="no-anchor">{{ .Title }}</h1>
                     {{ end }}
 
                     <p>Posted on <time>{{ .Date.Format "Monday, Jan 2, 2006" }}</time>


### PR DESCRIPTION
These needn't be linked, so this change just unlinks them.