### PR TITLE
improving docs left-nav labels

### DIFF
--- a/themes/default/content/blog/introducing-crd2pulumi/index.md
+++ b/themes/default/content/blog/introducing-crd2pulumi/index.md
@@ -5,7 +5,7 @@ meta_desc: Generate Kubernetes CustomResource types in TypeScript, Python, C#, a
 menu:
   converters:
     identifier: crd2pulumi
-linktitle: crd2pulumi
+linktitle: Kubernetes CustomResources to Pulumi
 weight: 2
 meta_image: crd.png
 authors:

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Get Started
+title: Get Started with Pulumi
 meta_desc: Step-by-step guides for creating, deploying, and managing infrastructure with
            Pulumi on the cloud using your favorite language.
 no_on_this_page: true

--- a/themes/default/content/migrate/arm2pulumi.md
+++ b/themes/default/content/migrate/arm2pulumi.md
@@ -2,7 +2,7 @@
 title: Convert Your Azure ARM Template to a Modern Language
 url: /arm2pulumi
 layout: arm2pulumi
-linktitle: arm2pulumi
+linktitle: ARM to Pulumi
 menu:
   converters:
     identifier: arm2pulumi

--- a/themes/default/content/migrate/cf2pulumi.md
+++ b/themes/default/content/migrate/cf2pulumi.md
@@ -2,7 +2,7 @@
 title: Convert CloudFormation Templates to a Programming Language
 url: /cf2pulumi
 layout: cf2pulumi
-linktitle: cf2pulumi
+linktitle: CloudFormation to Pulumi
 menu:
   converters:
     identifier: cf2pulumi

--- a/themes/default/content/migrate/kube2pulumi.md
+++ b/themes/default/content/migrate/kube2pulumi.md
@@ -2,7 +2,7 @@
 title: Upgrade Your Kubernetes YAML to a Modern Language
 url: /kube2pulumi
 layout: kube2pulumi
-linktitle: kube2pulumi
+linktitle: Kubernetes YAML to Pulumi
 menu:
   converters:
     identifier: kube2pulumi

--- a/themes/default/content/migrate/tf2pulumi.md
+++ b/themes/default/content/migrate/tf2pulumi.md
@@ -2,7 +2,7 @@
 title: Convert Your Terraform to a Modern Language
 url: /tf2pulumi
 layout: tf2pulumi
-linktitle: tf2pulumi
+linktitle: Terraform to Pulumi
 menu:
   converters:
     identifier: tf2pulumi

--- a/themes/default/layouts/partials/docs/toc.html
+++ b/themes/default/layouts/partials/docs/toc.html
@@ -7,8 +7,8 @@
     {{ else if hasPrefix .RelPermalink "/docs/" }}
         {{/* Render a top-level menu for our major docs sections */}}
         {{ $toc_page := . }}
-        {{ $toc_sections := slice "Getting Started" "Intro" "User Guides" "Converters" "Reference" "Support" }}
-        {{ $toc_menus := dict "Getting Started" .Site.Menus.getstarted "Intro" .Site.Menus.intro "User Guides" .Site.Menus.userguides "Converters" .Site.Menus.converters "Reference" .Site.Menus.reference "Support" .Site.Menus.troubleshooting }}
+        {{ $toc_sections := slice "Get Started with Pulumi" "Intro" "User Guides" "Converters" "Reference" "Support" }}
+        {{ $toc_menus := dict "Get Started with Pulumi" .Site.Menus.getstarted "Intro" .Site.Menus.intro "User Guides" .Site.Menus.userguides "Converters" .Site.Menus.converters "Reference" .Site.Menus.reference "Support" .Site.Menus.troubleshooting }}
         {{ range $toc_sections }}
             {{ $toc_name := . }}
             {{ $toc_menu := (index $toc_menus $toc_name) }}


### PR DESCRIPTION
## overview

this is changing our converter labels to their full names which should better help folks find what they are looking for
this also updates the heading on the get started section to be more clear, ive aligned on get started instead of getting started but can switch to getting started if folks feel strongly

there was a previous convo around also updating the get started guide labels, but we decided against that for now

related [internal slack convo](https://pulumi.slack.com/archives/C85BS3LJZ/p1647957689762799)

## screenshots

### before
<img width="260" alt="Screen Shot 2022-03-24 at 3 16 54 PM" src="https://user-images.githubusercontent.com/5489125/160019314-a0146a59-4a7a-4241-92b7-689ba51ac048.png">

### after
<img width="320" alt="Screen Shot 2022-03-24 at 3 16 42 PM" src="https://user-images.githubusercontent.com/5489125/160019324-5490c1a1-aa0b-4f8b-8cd2-c575f1e97f38.png">
