### PR TITLE
How-To Guide: Fix Update Check Instruction

### DIFF
--- a/themes/default/content/registry/packages/aws/how-to-guides/s3-website.md
+++ b/themes/default/content/registry/packages/aws/how-to-guides/s3-website.md
@@ -98,7 +98,7 @@ To preview your Pulumi program, run [`pulumi up`]({{< relref "/docs/reference/cl
 
 #### **Pulumi Service**
 
-To see the full details of the deployment and the resources that are now part of the stack, open the update link in a browser. The **Resources** tab in the Pulumi Service has a link to the AWS console for the provisioned EC2 instance.
+To see the full details of the deployment and the resources that are now part of the stack, open the update link in a browser. You can see the bucket that was creAted in the **Resources** tab.
 
 #### **Pulumi CLI**
 


### PR DESCRIPTION
The AWS Classic How-To Guide "Host a Static Website on Amazon S3" says that "The Resources tab in the Pulumi Service has a link to the AWS console for the provisioned EC2 instance.", but there are no EC2 instances created in the guide. This change replaces "EC2 instance" with "S3 Bucket."
https://www.pulumi.com/registry/packages/aws/how-to-guides/s3-website/