### PR TITLE
Minor visual adjustments to the DA single template

### DIFF
--- a/themes/default/layouts/community/developer-advocates/single.html
+++ b/themes/default/layouts/community/developer-advocates/single.html
@@ -7,13 +7,16 @@
     <section class="max-w-5xl container mx-auto my-8 px-4 text-lg">
         <div class="my-8 flex flex-col md:flex-row">
             <div class="md:w-1/3">
-                <img class="rounded-full mb-4 shadow-md mx-auto" src="/images/team/{{ $personData.id }}.jpg" alt="{{ $personData.name }}" >
+                <img class="rounded-full mb-4 shadow-md mx-auto w-64 md:w-auto" src="/images/team/{{ $personData.id }}.jpg" alt="{{ $personData.name }}" >
             </div>
             <div class="text-center md:text-left md:w-2/3 md:pl-8">
                 <h2 class="mb-1">{{ $personData.name }}</h2>
                 <div class="text-sm text-gray-700 mb-1">
                     <span class="">{{ $personData.title }}</span>
-                    <span>&bull; <a class="text-blue-500 underline" href="{{ relref . "/community/developer-advocates" }}">See all developer advocates</a></span>
+                    <span>
+                        <span class="hidden md:inline">&bull; </span>
+                        <a class="block md:inline text-blue-500 underline" href="{{ relref . "/community/developer-advocates" }}">See all developer advocates</a>
+                    </span>
                 </div>
                 {{ partial "widgets/social-icons.html" (dict "social" $personData.social)}}
                 <div class="my-8 text-left">


### PR DESCRIPTION
Mainly for mobile, to reduce the profile image size and prevent wrapping of the "see all" link. 