### PR TITLE
Update dynamic-providers.md

### DIFF
--- a/themes/default/content/docs/intro/concepts/resources/dynamic-providers.md
+++ b/themes/default/content/docs/intro/concepts/resources/dynamic-providers.md
@@ -719,5 +719,3 @@ export("label_url", label.url)
 
 - [Add a Custom Domain to an Azure CDN endpoint](https://github.com/pulumi/examples/tree/master/classic-azure-ts-dynamicresource)
     Similar to the previous example, this is another example of a shortcoming of the regular Azure resource provider available in Pulumi. However, due to the availability of a REST API, we can easily add a custom domain to an Azure CDN resource using a dynamic provider.
-- [Dynamic Providers as Provisioners](https://github.com/pulumi/examples/tree/master/aws-ts-ec2-provisioners)
-    Provisioning a VM after it is created is a common problem. Developers have the option to run user-supplied scripts while creating the VM itself. For example, the AWS EC2 resource has a userData parameter, that allows you to specify an inline script, which EC2 will run at instance startup. However, this example of dynamic providers as provisioners allows you to copy/execute scripts on the target instance without replacing the instance itself.


### PR DESCRIPTION
The example now uses `pulumi.command` instead