### PR TITLE
Add a BASEURL to get a link in the console when running locally

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -5,4 +5,4 @@ set -o errexit -o pipefail
 source ./scripts/common.sh
 
 # Just run Hugo.
-hugo serve --buildDrafts --buildFuture | grep -v -e 'WARN .* REF_NOT_FOUND'
+HUGO_BASEURL=http://localhost:1313 hugo serve --buildDrafts --buildFuture | grep -v -e 'WARN .* REF_NOT_FOUND'


### PR DESCRIPTION
Tiny little DX improvement to give you a clickable link when running `make serve` (h/t @mattstratton for the suggestion).

![image](https://user-images.githubusercontent.com/274700/162542748-9aaab618-d39a-41e3-a402-c28a988d312e.png)
