### PR TITLE
Fix string interpolation syntax in C# example for Output.All

### DIFF
--- a/themes/default/content/docs/intro/concepts/inputs-outputs.md
+++ b/themes/default/content/docs/intro/concepts/inputs-outputs.md
@@ -156,7 +156,7 @@ var connectionString = Output.All(sqlServer.name, database.name)
 
 // For more flexibility, 'Output.Tuple' is used so that each unwrapped value will preserve their distinct type.
 var connectionString2 = Output.Tuple(sqlServer.name, database.name)
-    .Apply(t => $"Server=tcp:${t.Item1}.database.windows.net;initial catalog=${t.Item2}...");
+    .Apply(t => $"Server=tcp:{t.Item1}.database.windows.net;initial catalog={t.Item2}...");
 
 // Or using a more natural Tuple syntax and a statement lambda expression.
 var connectionString2 = Output.Tuple(sqlServer.name, database.name).Apply(t =>

--- a/themes/default/content/docs/intro/concepts/inputs-outputs.md
+++ b/themes/default/content/docs/intro/concepts/inputs-outputs.md
@@ -162,7 +162,7 @@ var connectionString2 = Output.Tuple(sqlServer.name, database.name)
 var connectionString2 = Output.Tuple(sqlServer.name, database.name).Apply(t =>
 {
     var (serverName, databaseName) = t;
-    return $"Server=tcp:{serverName}.database.windows.net;initial catalog=${databaseName}...";
+    return $"Server=tcp:{serverName}.database.windows.net;initial catalog={databaseName}...";
 });
 ```
 

--- a/themes/default/content/docs/intro/concepts/inputs-outputs.md
+++ b/themes/default/content/docs/intro/concepts/inputs-outputs.md
@@ -152,17 +152,17 @@ connectionString := pulumi.All(sqlServer.Name, database.Name).ApplyT(
 ```csharp
 // When all the input values have the same type, Output.All can be used and produces an ImmutableArray.
 var connectionString = Output.All(sqlServer.name, database.name)
-    .Apply(t => `Server=tcp:${t[0]}.database.windows.net;initial catalog=${t[1]}...`);
+    .Apply(t => $"Server=tcp:{t[0]}.database.windows.net;initial catalog={t[1]}...");
 
 // For more flexibility, 'Output.Tuple' is used so that each unwrapped value will preserve their distinct type.
 var connectionString2 = Output.Tuple(sqlServer.name, database.name)
-    .Apply(t => `Server=tcp:${t.Item1}.database.windows.net;initial catalog=${t.Item2}...`);
+    .Apply(t => $"Server=tcp:${t.Item1}.database.windows.net;initial catalog=${t.Item2}...");
 
 // Or using a more natural Tuple syntax and a statement lambda expression.
 var connectionString2 = Output.Tuple(sqlServer.name, database.name).Apply(t =>
 {
     var (serverName, databaseName) = t;
-    return `Server=tcp:${serverName}.database.windows.net;initial catalog=${databaseName}...`;
+    return $"Server=tcp:{serverName}.database.windows.net;initial catalog=${databaseName}...";
 });
 ```
 


### PR DESCRIPTION
The string interpolation syntax for the C# example was using back-tick string interpolation syntax instead of `$"{}"` interpolation syntax.