### PR TITLE
Update site banner for PulumiUP

### DIFF
--- a/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
+++ b/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
@@ -48,7 +48,7 @@ main:
     # Webinar title.
     title: "From Zero to Production in Kubernetes"
     # URL for embedding a URL for ungated webinars.
-    youtube_url: "https://www.youtube.com/embed/L-8uzn6AdHM"
+    #youtube_url: "https://www.youtube.com/embed/L-8uzn6AdHM"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2022-05-10T09:00:00-07:00
     # Duration of the webinar.

--- a/themes/default/layouts/partials/banner.html
+++ b/themes/default/layouts/partials/banner.html
@@ -1,6 +1,6 @@
-{{ $summary := "Recently announced: Pulumi Business Critical Edition for Enterprise Modernization." }}
-{{ $url := relref . "/blog/business-critical-launch" }}
-{{ $label := "Read more"}}
+{{ $summary := "Join us virtually on May 4th as we introduce the last innovations in Cloud Engineering." }}
+{{ $url := relref . "/pulumi-up" }}
+{{ $label := "Register for PulumiUP"}}
 
 <div class="top-nav-banner-cta-container">
     <div class="top-nav-banner-cta">

--- a/themes/default/layouts/partials/banner.html
+++ b/themes/default/layouts/partials/banner.html
@@ -1,4 +1,4 @@
-{{ $summary := "Join us virtually on May 4th as we introduce the last innovations in Cloud Engineering." }}
+{{ $summary := "Join us virtually on May 4th as we introduce the latest innovations in Cloud Engineering." }}
 {{ $url := relref . "/pulumi-up" }}
 {{ $label := "Register for PulumiUP"}}
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/marketing/issues/227

This PR updates the site banner for PulumiUP and removes a watch now button for a partner workshop.