### PR TITLE
Put the console image inside the console note

### DIFF
--- a/themes/default/layouts/shortcodes/console-note.html
+++ b/themes/default/layouts/shortcodes/console-note.html
@@ -12,7 +12,7 @@
             and configuration.
         </p>
         <a href="/images/getting-started/console-update.png", target="_blank">
-            <img src="/images/getting-started/console-update.png">
+            <img src="/images/getting-started/console-update.png" alt="A stack update with console output, as shown in the Pulumi Service">
         </a>
     </div>
 </div>

--- a/themes/default/layouts/shortcodes/console-note.html
+++ b/themes/default/layouts/shortcodes/console-note.html
@@ -1,8 +1,3 @@
-
-<a href="/images/getting-started/console-update.png", target="_blank">
-    <img src="/images/getting-started/console-update.png">
-</a>
-
 <div class="note note-info" role="alert">
     <div class="note-heading">
         <i class="fas fa-info-circle mr-1"></i>
@@ -16,5 +11,8 @@
             where you can view the output and explore detailed information about your stack such as its activity, resources,
             and configuration.
         </p>
+        <a href="/images/getting-started/console-update.png", target="_blank">
+            <img src="/images/getting-started/console-update.png">
+        </a>
     </div>
 </div>


### PR DESCRIPTION
Since this image corresponds with the content that's inside the note, it's odd that it's both outside the note and shown before it. Putting it inside the note, and after the content it refers to, makes more sense. (Otherwise, it's unclear until you read the note why this image is even here.)

## Before

![image](https://user-images.githubusercontent.com/274700/164069097-8ba1a78c-3e02-468a-97b0-8a274e1040f1.png)

## After

![image](https://user-images.githubusercontent.com/274700/164068326-06ae7bc3-afe4-4cc5-a111-e5d1c66d3963.png)
