### PR TITLE
remove links from get started landing pages

### DIFF
--- a/themes/default/content/docs/get-started/kubernetes/_index.md
+++ b/themes/default/content/docs/get-started/kubernetes/_index.md
@@ -19,8 +19,7 @@ required.
 Pulumi supports programming against Kubernetes---Minikube, on-premises and
 cloud-hosted custom Kubernetes clusters, and the managed services from Google
 (GKE), Azure (AKS), and Amazon (EKS). The Pulumi Kubernetes provider
-packages and [CLI]({{< relref "/docs/reference/cli" >}})
-help you accomplish all these within minutes.
+packages and CLI help you accomplish all these within minutes.
 
 For a quick example of how Pulumi deploys infrastructure on Kubernetes, this tutorial takes you through the following steps to easily deploy an [NGINX](https://www.nginx.com/) web server:
 

--- a/themes/default/layouts/shortcodes/cloud-intro.html
+++ b/themes/default/layouts/shortcodes/cloud-intro.html
@@ -3,9 +3,8 @@
 <div>
     <p>
         Pulumi's infrastructure-as-code SDK helps you create, deploy, and manage {{ .Get 0 }} containers,
-        serverless functions, and infrastructure using <a href="{{ relref . "/docs/intro/languages" }}">familiar programming languages</a>. The Pulumi {{ .Get 0 }} provider packages
-        and <a href="{{ relref . "/docs/reference/cli" }}">CLI</a>
-        help you accomplish all these within minutes.
+        serverless functions, and infrastructure using TypeScript, Python, Go, or C#. The Pulumi {{ .Get 0 }} provider packages
+        and CLI help you accomplish all these within minutes.
     </p>
     <p>
         For a quick example of how Pulumi deploys infrastructure on {{ .Get 0 }}, this tutorial takes you through the following steps to easily deploy a static website:

--- a/themes/default/layouts/shortcodes/cloud-intro.html
+++ b/themes/default/layouts/shortcodes/cloud-intro.html
@@ -3,7 +3,7 @@
 <div>
     <p>
         Pulumi's infrastructure-as-code SDK helps you create, deploy, and manage {{ .Get 0 }} containers,
-        serverless functions, and infrastructure using TypeScript, Python, Go, or C#. The Pulumi {{ .Get 0 }} provider packages
+        serverless functions, and infrastructure using programming languages like TypeScript, Python, Go, or C#. The Pulumi {{ .Get 0 }} provider packages
         and CLI help you accomplish all these within minutes.
     </p>
     <p>


### PR DESCRIPTION
a thing ive learned from @SaraDPH recently is that we should be thoughtful about linking people away from the content at the beginning. i was also talking with Luke about these pages today, and he mentioned that these links arent taking folks to a super useful place. so this is proposing removing them.

im open to hearing alternative thoughts and concerns!