### PR TITLE
fix get started button link on why pulumi 

### DIFF
--- a/themes/default/layouts/page/why-pulumi.html
+++ b/themes/default/layouts/page/why-pulumi.html
@@ -15,7 +15,7 @@
                 <div>
                     <div class="flex justify-start items-start mt-8">
                         <div class="flex flex-col lg:flex-row items-start">
-                            <a class="btn-primary mr-4" href="{{ relref . "/docs/get-started/aws" }}">Get Started</a>
+                            <a class="btn-primary mr-4" href="{{ relref . "/docs/get-started" }}">Get Started</a>
                             <a class="btn-secondary" href="{{ relref . "/pricing" }}">View Pricing</a>
                         </div>
                     </div>


### PR DESCRIPTION
this was going to the aws begin page, instead of the get started landing page; this fixes it
change to `/why-pulumi/`

[internal slack convo](https://pulumi.slack.com/archives/C7XHM1GNT/p1650640951116219)