### PR TITLE
Fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20220421161604-afeb673c253d // indirect
-	github.com/pulumi/theme v0.0.0-20220420205818-619ff0a78fb7 // indirect
+	github.com/pulumi/theme v0.0.0-20220425181032-45d2ab2e5df0 // indirect
 )
 
 replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/pulumi/registry/themes/default v0.0.0-20220423094712-7a673fe04040 h1:a9RoTBtVlo6mFMc+RiNN8hKXNq1ZTWTlEe8Awas6TqU=
-github.com/pulumi/registry/themes/default v0.0.0-20220423094712-7a673fe04040/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=
-github.com/pulumi/theme v0.0.0-20220418160522-11aaf6d778b1 h1:707Q/pLqAHqk3Vzxk5CZQvHi2Qpm8mw64ZF7LGxNw70=
-github.com/pulumi/theme v0.0.0-20220418160522-11aaf6d778b1/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
-github.com/pulumi/theme v0.0.0-20220420205818-619ff0a78fb7 h1:UhHKt5nF9z3SQxSMt74MveYFWxwPp2Rqzy/13wZXeqc=
-github.com/pulumi/theme v0.0.0-20220420205818-619ff0a78fb7/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/registry/themes/default v0.0.0-20220421161604-afeb673c253d h1:IjnPXA6BrF5lNA+kRNpAHFgWOOgt/wv3jE410XRcDew=
+github.com/pulumi/registry/themes/default v0.0.0-20220421161604-afeb673c253d/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=
+github.com/pulumi/theme v0.0.0-20220425181032-45d2ab2e5df0 h1:p8VxXzzpJwdTIE682JOV0K5gwPuKKWyVb+1YdguAu0M=
+github.com/pulumi/theme v0.0.0-20220425181032-45d2ab2e5df0/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=


### PR DESCRIPTION
The most recent master build failed on this, related to the version of theme in the go mod - https://github.com/pulumi/pulumi-hugo/runs/6162876217?check_suite_focus=true.  I'm not sure why this happened, but in this PR I manually removed theme from the go.mod and then ran `hugo mod get github.com/pulumi/theme@release`, so hopefully this should get master back to a good state.