### PR TITLE
Migrate ECS AWSX guide to multi-lang

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/aws/ecs.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/ecs.md
@@ -177,38 +177,6 @@ the optional `memory` and `cpu` values we request for our containers.
 For many scenarios, this is exactly what we want: a simple way of just running containerized applications. While this
 approach is simple and hides a lot of complexity, it's often desirable to control more of what is going on.
 
-## Explicitly Creating ECS Clusters for EC2 or Fargate
-
-The `awsx.ecs.Cluster` class creates a new ECS cluster for Tasks and Services to run within. If you don't specify
-a cluster explicitly, then a default one will be created that is configured to use your region's default VPC.
-
-There are a few reasons to want to create a cluster explicitly: The first is to isolate the compute running in
-different clusters from one another. Another is to place your cluster in a VPC so that it is isolated at the
-networking level. If you want to schedule non-Fargate Tasks and Services, you will need to create a
-cluster explicitly, since you will need to define an Auto Scaling Group that controls the EC2 instances powering it.
-
-To use an explicit cluster, create an instance and pass it as the `cluster` property for the
-`awsx.ecs.FargateService` or `awsx.ecs.EC2Service` constructors:
-
-```typescript
-import * as awsx from "@pulumi/awsx";
-
-// Create an ECS cluster explicitly, and give it a name tag.
-const cluster = new awsx.ecs.Cluster("custom", {
-    tags: {
-        "Name": "my-custom-ecs-cluster",
-    },
-});
-
-// Deploy a Service into this new cluster.
-const nginx = new awsx.ecs.FargateService("nginx", {
-    cluster,
-    // ... as before ...
-});
-```
-
-In this example, we simply specified the tags for our cluster. We will see other possibilities in the following examples.
-
 ## Creating an ECS Cluster in a VPC
 
 To create an ECS cluster inside of a VPC, we will first create or use an existing VPC using any of the techniques

--- a/themes/default/content/docs/guides/crosswalk/aws/ecs.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/ecs.md
@@ -39,7 +39,8 @@ providing full control over the underlying EC2 machine resources that power your
 To run a Docker container in ECS using default network and cluster settings, use the `awsx.ecs.FargateService`
 class. Since we need to access this container over port 80 using a stable address, we will use a load balancer.
 
-{{< chooser language "typescript,python,go,csharp" / >}}
+<!-- {{< chooser language "typescript,python,go,csharp" / >}} -->
+{{< chooser language "typescript,python,csharp" / >}}
 
 {{% choosable language "javascript,typescript" %}}
 
@@ -49,11 +50,11 @@ import * as awsx from "@pulumi/awsx";
 
 const cluster = new aws.ecs.Cluster("default-cluster");
 
-// // Create a load balancer on port 80 and spin up two instances of Nginx.
 const lb = new awsx.lb.ApplicationLoadBalancer("nginx-lb");
 
 const service = new awsx.ecs.FargateService("my-service", {
     cluster: cluster.arn,
+    desiredCount: 2,
     taskDefinitionArgs: {
         container: {
             image: "nginx:latest",
@@ -70,7 +71,6 @@ const service = new awsx.ecs.FargateService("my-service", {
     },
 });
 
-// Export the load balancer's address so that it's easy to access.
 export const url = lb.loadBalancer.dnsName;
 ```
 
@@ -88,13 +88,14 @@ cluster = aws.ecs.Cluster("default-cluster")
 lb = awsx.lb.ApplicationLoadBalancer("nginx-lb")
 
 service = awsx.ecs.FargateService("my-service",
-    cluster=cluster.arn
+    cluster=cluster.arn,
+    desired_count=2,
     task_definition_args=awsx.ecs.FargateServiceTaskDefinitionArgs(
         container=awsx.ecs.TaskDefinitionContainerDefinitionArgs(
             image="nginx:latest",
             cpu=512,
-            memory= 128,
-            essential= true,
+            memory=128,
+            essential=True,
             port_mappings=[awsx.ecs.TaskDefinitionPortMappingArgs(
                 target_group=lb.default_target_group
             )],
@@ -105,13 +106,13 @@ service = awsx.ecs.FargateService("my-service",
 
 {{% /choosable %}}
 
-{{% choosable language go %}}
+<!-- {{% choosable language go %}}
 
 ```go
 // TODO
 ```
 
-{{% /choosable %}}
+{{% /choosable %}} -->
 
 {{% choosable language csharp %}}
 
@@ -120,41 +121,40 @@ var cluster = new Aws.Ecs.Cluster("default-cluster");
 
 var lb = new Awsx.Lb.ApplicationLoadBalancer("nginx-lb");
 
-var service = new Awsx.Ecs.FargateService("my-service", new FargateServiceArgs
+var service = new Awsx.Ecs.FargateService("my-service", new Awsx.Ecs.FargateServiceArgs
 {
     Cluster = cluster.Arn,
-    TaskDefinition = new Awsx.Ecs.FargateServiceTaskDefinitionArgs
+    DesiredCount = 2,
+    TaskDefinitionArgs = new Awsx.Ecs.Inputs.FargateServiceTaskDefinitionArgs
     {
-        Container = new Awsx.Ecs.TaskDefinitionContainerDefinitionArgs
+        Container = new Awsx.Ecs.Inputs.TaskDefinitionContainerDefinitionArgs
         {
             Image = "nginx:latest",
             Cpu = 512,
             Memory = 128,
             Essential = true,
-            PortMappings = {new awsx.ecs.TaskDefinitionPortMappingArgs
+            PortMappings = {new Awsx.Ecs.Inputs.TaskDefinitionPortMappingArgs
             {
-                TargetGroup = lb.default_target_group,
+                TargetGroup = lb.DefaultTargetGroup,
             }},
         }
     }
 });
 
-this.Url = lb.AwsLoadBalancer.DnsName;
+this.Url = lb.LoadBalancer.Apply(lb => lb.DnsName);
 ```
 
 {{% /choosable %}}
 
-After deploying this program, we can access our two  NGINX web servers behind our load balancer via curl:
+After deploying this program, `pulumi stack output url` can be used to access the Url output property. We can then access our  NGINX web server behind our load balancer via curl:
 
 ```bash
 curl http://$(pulumi stack output url)
 ```
 
-`$(pulumi stack output url)` evaluates to the load balancer's domain name.
+Giving the following output:
 
-### **Output**
-
-```
+```bash
 <!DOCTYPE html>
 <html>
 <body>

--- a/themes/default/content/docs/guides/crosswalk/aws/ecs.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/ecs.md
@@ -262,30 +262,6 @@ var service = new Awsx.Ecs.FargateService("my-service", new Awsx.Ecs.FargateServ
 
 When using a custom VPC, you will also need to specify your own security groups if you need to allow ingress or egress.
 
-## Creating an Auto Scaling Group for ECS Cluster Instances
-
-Using Fargate is easy, because we don't have to worry about the EC2 instances powering our cluster. In the case
-of wanting more control over the instances and their configuration, we can create an
-[Auto Scaling Group](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) explicitly, and
-the cluster will then use that to run all compute scheduled inside our cluster. This is required to use `EC2Service`.
-
-```typescript
-import * as awsx from "@pulumi/awsx";
-
-const cluster = new awsx.ecs.Cluster("custom");
-
-const asg = cluster.createAutoScalingGroup("custom", {
-    templateParameters: { minSize: 5 },
-    launchConfigurationArgs: { instanceType: "t2.medium" },
-});
-```
-
-Because we're manually managing our cluster's compute, we are also responsible for ensuring our cluster has enough
-capacity to meet our workload's demands. It is typically not desirable to use a fixed quantity of servers. Instead,
-refer to [Automatic Scaling with Amazon ECS](
-https://aws.amazon.com/blogs/compute/automatic-scaling-with-amazon-ecs/) for best practices on setting up auto-scaling
-for your ECS workloads. Remember, Fargate handles all of this for you behind the scenes, but with less control.
-
 ## Using an Existing ECS Cluster
 
 If you already have an ECS cluster that you'd like to use, and would like to define Tasks and Services to run there, you can supply the `cluster` argument to the constructor:

--- a/themes/default/content/docs/guides/crosswalk/aws/ecs.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/ecs.md
@@ -262,28 +262,6 @@ var service = new Awsx.Ecs.FargateService("my-service", new Awsx.Ecs.FargateServ
 
 When using a custom VPC, you will also need to specify your own security groups if you need to allow ingress or egress.
 
-## Using an Existing ECS Cluster
-
-If you already have an ECS cluster that you'd like to use, and would like to define Tasks and Services to run there, you can supply the `cluster` argument to the constructor:
-
-```typescript
-import * as aws from "@pulumi/aws";
-import * as awsx from "@pulumi/awsx";
-
-// Fetch an existing cluster.
-const cluster = new awsx.ecs.Cluster("custom", {
-    cluster: aws.ecs.Cluster.get("existing_cluster_id"),
-});
-
-// Deploy a Service into the existing cluster.
-const nginx = new awsx.ecs.FargateService("nginx", {
-    cluster,
-    // ... as before ...
-});
-```
-
-Notice that we are using a method from a different package, [`aws.ecs.Cluster.get`]({{< relref "/registry/packages/aws/api-docs/ecs/cluster#look-up" >}}), to look up our existing cluster by its ID and then creating an `awsx.ecs.Cluster` out of it. The former is the raw resource description, while the latter is the object type required to work with the Pulumi Crosswalk for AWS ECS APIs.
-
 ## ECS Tasks, Containers, and Services
 
 We saw example uses above but didn't describe the details of how ECS core concepts work, or are authored in your


### PR DESCRIPTION
Oustanding tasks:

- [ ] Add Go
- [ ] Remove props listings and just link to the registry (assuming this will exist)
- [x] Make the service-less tasks section clearer and probably shorter
- [ ] Docker ECR image integration rework
- [ ] _Maybe_ add a section on EC2?
- [ ] Remove or rework the fire-and-forget example ... this relies heavily on callback magic that's not multi-lang. Perhaps just add a note about it being classic-only?