### PR TITLE
Disable username updates in OKTA SCIM set up

### DIFF
--- a/themes/default/content/docs/guides/scim/okta.md
+++ b/themes/default/content/docs/guides/scim/okta.md
@@ -100,6 +100,14 @@ Now that the SCIM connector knows how to connect to Pulumi, you need to adjust t
 5. Click **Save Mappings**.
 6. Click **Apply Updates**.
 
+## Adjusting the Okta to Pulumi Username Mappings
+
+It is important that usernames are not changed after a user is associated with a Pulumi application. To disable Okta from pushing username updates to Pulumi, perform the following steps:
+
+1. Under **Sign On** in the **Settings** module, click **Edit**.
+2. Under **Credentials Details**, change **Update application username on** from **Create and update** to **Create only**.
+3. Click **Save**.
+
 ## Setting up Group Provisioning {#groupprovisioning}
 
 The Pulumi Service supports the provisioning of teams within your organization using SCIM. This is done by mapping the groups you have created using SCIM to create teams within your organization in the Pulumi Service. Setting this up allows you to manage your teams' memberships solely in Okta.

--- a/themes/default/content/docs/guides/scim/okta.md
+++ b/themes/default/content/docs/guides/scim/okta.md
@@ -102,7 +102,7 @@ Now that the SCIM connector knows how to connect to Pulumi, you need to adjust t
 
 ## Adjusting the Okta to Pulumi Username Mappings
 
-It is important that usernames are not changed after a user is associated with a Pulumi application. To disable Okta from pushing username updates to Pulumi, perform the following steps:
+Pulumi usernames are immutable and should not be changed after a user is associated with a Pulumi application. To disable Okta from pushing username updates to Pulumi, perform the following steps:
 
 1. Under **Sign On** in the **Settings** module, select **Edit**.
 2. Under **Credentials Details**, change **Update application username on** from **Create and update** to **Create only**.

--- a/themes/default/content/docs/guides/scim/okta.md
+++ b/themes/default/content/docs/guides/scim/okta.md
@@ -104,9 +104,9 @@ Now that the SCIM connector knows how to connect to Pulumi, you need to adjust t
 
 It is important that usernames are not changed after a user is associated with a Pulumi application. To disable Okta from pushing username updates to Pulumi, perform the following steps:
 
-1. Under **Sign On** in the **Settings** module, click **Edit**.
+1. Under **Sign On** in the **Settings** module, select **Edit**.
 2. Under **Credentials Details**, change **Update application username on** from **Create and update** to **Create only**.
-3. Click **Save**.
+3. Select **Save**.
 
 ## Setting up Group Provisioning {#groupprovisioning}
 


### PR DESCRIPTION
## Description

Update Okta SCIM public docs to direct user to disable username push updates from Okta.

## Related Issues

https://github.com/pulumi/pulumi-service/issues/8237