### PR TITLE
Add trailing slash to the Javadocs link

### DIFF
--- a/themes/default/content/docs/reference/pulumi-sdk.md
+++ b/themes/default/content/docs/reference/pulumi-sdk.md
@@ -60,7 +60,7 @@ Choose your language runtime to view the API documentation for the Pulumi SDK:
         </a>
     </div>
     <div class="pb-4 md:pr-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="/docs/reference/pkg/java">
+        <a class="tile p-8 pb-16 text-center" href="/docs/reference/pkg/java/">
             <p class="mx-auto text-xl font-semibold link">
                 Java
             </p>


### PR DESCRIPTION
Follow-up from https://github.com/pulumi/pulumi-hugo/pull/1466#issuecomment-1118587132. The trailing slash is necessary in order for the redirect rule in https://github.com/pulumi/docs/pull/7476 to be applied properly: