### PR TITLE
Fix go mod and go sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20211008162151-6e65a2068c3b // indirect
 	github.com/pulumi/registry/themes/default v0.0.0-20220426172125-157916f7a0af // indirect
-	github.com/pulumi/theme v0.0.0-20220518161422-128f8ed456f0 // indirect
+	github.com/pulumi/theme v0.0.0-20220518171329-2d98251bc72f // indirect
 )
 
 replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/pulumi/theme v0.0.0-20220516191554-2c4567537010 h1:6kZMV79MRm8nV8Cb3x
 github.com/pulumi/theme v0.0.0-20220516191554-2c4567537010/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
 github.com/pulumi/theme v0.0.0-20220518161422-128f8ed456f0 h1:3ivjlijSUa6nEOqlqPOxo33+8zoTyJz6g3vA7/H/nhg=
 github.com/pulumi/theme v0.0.0-20220518161422-128f8ed456f0/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=
+github.com/pulumi/theme v0.0.0-20220518171329-2d98251bc72f h1:g/lCBKLeWvuHf1PKYinrOYP+/0dFBGoxzrZb3SHbClY=
+github.com/pulumi/theme v0.0.0-20220518171329-2d98251bc72f/go.mod h1:Ksr+ztEgwxDLYFRalb0SYu4WcGROgnF35iILealOMno=


### PR DESCRIPTION
Hugo merge build is currently failing on some go mod/sum errors: https://github.com/pulumi/pulumi-hugo/runs/6493942813?check_suite_focus=true.  Last time we saw this, a manual update to use the `release` branch of theme fixed things up, so that's what this PR does.