### PR TITLE
Add newsletter cta to bottom of blog posts

### DIFF
--- a/themes/default/layouts/blog/single.html
+++ b/themes/default/layouts/blog/single.html
@@ -25,6 +25,18 @@
                         <section data-swiftype-index="true">
                             {{ .Content }}
                         </section>
+
+                        <section class="py-8">
+                            <div class="container mx-auto">
+                                <div class="text-center">
+                                    <h4 class="md:mr-8">Subscribe to the Pulumi Newsletter</h4>
+                                    <div class="inline-block">
+                                        <pulumi-hubspot-form form-id="027b4c6d-9b73-4ad8-b149-3c8b07fff608" class="newsletter newsletter-dark-border"></pulumi-hubspot-form>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>
+
                         <div>
                             {{ if .Params.tags }}
                                 <ul class="m-0 mt-8 p-0">


### PR DESCRIPTION
This PR adds a CTA to the bottom of the blog posts that asks people to subscribe to the newsletter.

Fixes: https://github.com/pulumi/pulumi-hugo/pull/1535

<img width="897" alt="subscribe-blog" src="https://user-images.githubusercontent.com/15146337/169445615-279c68be-3456-4f0f-8622-7df570201ebe.png">
