### PR TITLE
Hide right hand cta

### DIFF
--- a/themes/default/layouts/partials/right-nav-ad.html
+++ b/themes/default/layouts/partials/right-nav-ad.html
@@ -1,5 +1,7 @@
+<!--
 <div class="mt-8">
     <a href="/resources/#upcoming">
         <img src="/images/webinar/pulumi-workshop-ad.png" alt="Join an upcoming Pulumi workshop" />
     </a>
 </div>
+-->


### PR DESCRIPTION
This PR hides the right-hand CTA as we've gotten feedback it is too prominent still. The plan is to create a new image and then re-enable the CTA with the new image.