### PR TITLE
fix broken sans institute link

### DIFF
--- a/themes/default/content/enterprise/_index.md
+++ b/themes/default/content/enterprise/_index.md
@@ -28,7 +28,7 @@ case_studies:
             Atlassian Bitbucket reduced developers' time spent on maintenance by 50% with a self-service platform built with Pulumi.
 
         - company: sans
-          link: /case-studies/sans/
+          link: /case-studies/sans-institute/
           quote: |
             SANS increased deployment velocity by 3X after adopting cloud engineering and implementing infrastructure CI/CD.
 


### PR DESCRIPTION
fixes: https://github.com/pulumi/marketing/issues/343

fixes the broken link to the sans institute case study on the `/enterprise` page.