### PR TITLE
Update install-java.html

### DIFF
--- a/themes/default/layouts/shortcodes/install-java.html
+++ b/themes/default/layouts/shortcodes/install-java.html
@@ -1,6 +1,6 @@
 <p class="mt-4">
     Install <a href="https://www.oracle.com/java/technologies/downloads" target="_blank">Java 11 or later</a> and
-    <a href="https://maven.apache.org/install.html">Apache Maven 3.5 or later</a>.
+    <a href="https://maven.apache.org/install.html">Apache Maven 3.6.1 or later</a>.
 </p>
 
 <div class="note note-info" role="alert">


### PR DESCRIPTION
discovered that the `--no-transfer-progress` flag creates a dependency on `maven-3.6.1` or greater when working on
- https://github.com/pulumi/pulumi-java/issues/529

as the redhat UBI image has a latest version of `maven-3.5.4`