### PR TITLE
Copy helper unit test method for C# in tutorial

### DIFF
--- a/themes/default/content/docs/guides/testing/unit.md
+++ b/themes/default/content/docs/guides/testing/unit.md
@@ -501,6 +501,17 @@ public async Task InstanceHasNameTag()
     tags.Should().NotBeNull("Tags are not defined");
     tags.Should().ContainKey("Name");
 }
+
+public static Task<T> GetValueAsync<T>(this Output<T> output)
+{
+    var tcs = new TaskCompletionSource<T>();
+    output.Apply(v =>
+    {
+        tcs.SetResult(v);
+        return v;
+    });
+    return tcs.Task;
+}
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Copied the C# helper method from the c# unit test directory: https://github.com/pulumi/examples/blob/74db62a03d013c2854d2cf933c074ea0a3bbf69d/testing-unit-cs/Testing.cs

This should fix #1566