### PR TITLE
fix(lint): patch a lint error in an older commit

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/components/api.md
+++ b/themes/default/content/docs/guides/self-hosted/components/api.md
@@ -169,6 +169,7 @@ Azure Storage account key using the `AZURE_STORAGE_KEY` env var.
 | AZURE_STORAGE_DOMAIN | (Optional) The custom domain for your storage domain, if any. If this is not provided, the default Azure public domain "blob.core.windows.net" will be used. |
 
 ### GitLab OAuth
+
 Only required if using GitLab as the backing identity provider for your organization.
 
 | Variable Name | Description |


### PR DESCRIPTION
Looks like there was a linting error in an older commit. It's throwing errors on previews in newer PRs.