### PR TITLE
Fix up link in release blog post

### DIFF
--- a/themes/default/content/blog/pulumi-release-notes-m64/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m64/index.md
@@ -207,7 +207,7 @@ We shipped new versions of the Azure Native provider (1.43.0 through 1.45.0) tha
 
 ## Pulumi CLI and core technologies
 
-In this milestone, we shipped Pulumi versions [3.16.0](https://github.com/pulumi/pulumi/releases/tag/v3.16.0) through [3.17.0](https://github.com/pulumi/pulumi/releases/tag/v3.17.0). The full list of changes in each version is available in the [changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md); read on to learn about some of the biggest changes.
+In this milestone, we shipped Pulumi version [3.17.0](https://github.com/pulumi/pulumi/releases/tag/v3.17.0). The full list of changes in this version is available in the [changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md); read on to learn about some of the biggest changes.
 
 ### Functions now support outputs
 

--- a/themes/default/content/blog/pulumi-release-notes-m64/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m64/index.md
@@ -207,7 +207,7 @@ We shipped new versions of the Azure Native provider (1.43.0 through 1.45.0) tha
 
 ## Pulumi CLI and core technologies
 
-In this milestone, we shipped Pulumi versions [3.16.1](https://github.com/pulumi/pulumi/releases/tag/v3.16.1) through [3.17.0](https://github.com/pulumi/pulumi/releases/tag/v3.17.0). The full list of changes in each version is available in the [changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md); read on to learn about some of the biggest changes.
+In this milestone, we shipped Pulumi versions [3.16.0](https://github.com/pulumi/pulumi/releases/tag/v3.16.0) through [3.17.0](https://github.com/pulumi/pulumi/releases/tag/v3.17.0). The full list of changes in each version is available in the [changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md); read on to learn about some of the biggest changes.
 
 ### Functions now support outputs
 


### PR DESCRIPTION
Addresses: https://pulumi.slack.com/archives/C03G209S6H4/p1654269687768099

Fixes the 3.16.1 release link in this [blog post](https://www.pulumi.com/blog/pulumi-release-notes-m64/)

The link was linking to a release that either got deleted or never existed. There is no 3.16.1 of `pulumi/pulumi`. I did however find a 3.16.0. So I linked to that since at least the minor version is the same. It also looks like the dates align between 3.16.0 and 3.17.0 (i.e. 13 day time span which closely matches the 2 week milestone cadence we were using at that time). So I'm guessing this may have been what was intended based on the context of the sentence in the blog post.