### PR TITLE
Actually fail when the Markdown linter fails

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+set -o errexit -o pipefail
+
 node ./scripts/lint/lint-markdown.js
 yarn prettier --check .

--- a/themes/default/content/blog/multicloud-with-kubernetes-and-pulumi/index.md
+++ b/themes/default/content/blog/multicloud-with-kubernetes-and-pulumi/index.md
@@ -2,7 +2,6 @@
 title: "Multicloud with Kubernetes and Pulumi"
 date: 2022-06-09T11:40:47-07:00
 meta_desc: "Learn how to customize the multi-cloud developer experience with Kubernetes and Pulumi, using TypeScript"
-meta_desc: "Customizing the multi-cloud developer experience with Kubernetes and Pulumi"
 meta_image: showcase-image.png
 authors:
     - guinevere-saenger

--- a/themes/default/content/docs/guides/self-hosted/components/api.md
+++ b/themes/default/content/docs/guides/self-hosted/components/api.md
@@ -128,7 +128,7 @@ You only need to configure one of the support services.
 {{% notes type="info" %}}
 When you need to create a new version of a key, do not disable the previous version. All versions of the key must remain
 active. The API service never has access to the private key material of the key you create in Azure KeyVault. It only
-uses the public key for encryption. The API will request KeyVault to decrypt a cipher text.  
+uses the public key for encryption. The API will request KeyVault to decrypt a cipher text.
 {{% /notes %}}
 
 | Variable Name | Description |
@@ -238,7 +238,6 @@ The database migrations container is configurable to enable connections to the d
 | PULUMI_DATABASE_ENDPOINT      | The database server endpoint in the format `host:port`. This should be a MySQL 5.6 server. |
 | PULUMI_DATABASE_PING_ENDPOINT | The database server endpoint to ping for availability before login. |
 | RUN_MIGRATIONS_EXTERNALLY     | Request for migrations to be run against an external database. |
-
 
 ## Audit Logs
 


### PR DESCRIPTION
When the Prettier check was added to `lint.sh`, we forgot to add a line to tell the script to fail and exit on any error, which has allowed a few Markdown-related changes to sneak by that _should've_ failed, but didn't, because the Prettier check that runs _after_ `markdownlint` passed. (In other words, as of now, only a Prettier failure will cause `lint.sh` to exit nonzero, which means we're essentially no longer linting Markdown.)

This change adds a line to handle this as we do elsewhere and fixes up the Markdown things that've gotten through.