### PR TITLE
Fix AWS KMS secret provider docs for setting profile

### DIFF
--- a/themes/default/content/docs/intro/concepts/secrets.md
+++ b/themes/default/content/docs/intro/concepts/secrets.md
@@ -486,7 +486,7 @@ If you have previously configured the AWS CLI, the same credentials will be used
 As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_PROFILE` environment variable, add `awssdk=v2` and `profile=` followed by the profile name to the query string.
 
 1. By ID: `awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=dev`.
-2. By alias: `awskms://alias/ExampleAlias?region=us-east-1&awssdk=v2&profile=qa`.
+1. By alias: `awskms://alias/ExampleAlias?region=us-east-1&awssdk=v2&profile=qa`.
 1. By ARN: `awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=prod`.
 {{% /notes %}}
 

--- a/themes/default/content/docs/intro/concepts/secrets.md
+++ b/themes/default/content/docs/intro/concepts/secrets.md
@@ -483,11 +483,11 @@ $ pulumi stack init my-stack \
 If you have previously configured the AWS CLI, the same credentials will be used. These can also be overridden using the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. For more options, refer to the [AWS Go SDK documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/).
 
 {{% notes "info" %}}
-As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_PROFILE` environment variable, you can append the profile as a querystring to the above KMS identifiers:
+As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_PROFILE` environment variable, it can be specified by adding `awssdk=v2` and `profile=` followed by the profile name to the query string.
 
-1. By ID: `awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1&profile=dev`.
-1. By alias: `awskms://alias/ExampleAlias?region=us-east-1&profile=qa`.
-1. By ARN: `awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1&profile=prod`.
+1. By ID: `awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=dev`.
+2. By alias: `awskms://alias/ExampleAlias?region=us-east-1&awssdk=v2&profile=qa`.
+3. By ARN: `awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=prod`.
 {{% /notes %}}
 
 #### Azure Key Vault

--- a/themes/default/content/docs/intro/concepts/secrets.md
+++ b/themes/default/content/docs/intro/concepts/secrets.md
@@ -487,7 +487,7 @@ As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_P
 
 1. By ID: `awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=dev`.
 2. By alias: `awskms://alias/ExampleAlias?region=us-east-1&awssdk=v2&profile=qa`.
-3. By ARN: `awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=prod`.
+1. By ARN: `awskms:///arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34bc-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=prod`.
 {{% /notes %}}
 
 #### Azure Key Vault

--- a/themes/default/content/docs/intro/concepts/secrets.md
+++ b/themes/default/content/docs/intro/concepts/secrets.md
@@ -483,7 +483,7 @@ $ pulumi stack init my-stack \
 If you have previously configured the AWS CLI, the same credentials will be used. These can also be overridden using the standard `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables. For more options, refer to the [AWS Go SDK documentation](https://docs.aws.amazon.com/sdk-for-go/api/aws/session/).
 
 {{% notes "info" %}}
-As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_PROFILE` environment variable, it can be specified by adding `awssdk=v2` and `profile=` followed by the profile name to the query string.
+As of Pulumi CLI v3.33.1, instead of specifying the AWS Profile using the `AWS_PROFILE` environment variable, add `awssdk=v2` and `profile=` followed by the profile name to the query string.
 
 1. By ID: `awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1&awssdk=v2&profile=dev`.
 2. By alias: `awskms://alias/ExampleAlias?region=us-east-1&awssdk=v2&profile=qa`.


### PR DESCRIPTION
The "awssdk=v2" property is required according to the original PR and confirmed by a user in an issue:
- https://github.com/pulumi/pulumi/pull/9590
- https://github.com/pulumi/pulumi/issues/9846


Fixes pulumi/pulumi#9846.