### PR TITLE
Add Getting Started w/ AWS IAC workshop

### DIFF
--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-7-19-22/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-7-19-22/index.md
@@ -1,0 +1,80 @@
+---
+# Name of the webinar.
+title: "Getting Started with Infrastructure as Code on AWS"
+meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "https://www.bigmarker.com/pulumi/Getting-Started-with-Infrastructure-as-Code-on-AWS-09a76d558a62e8b0b4ef52d0"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Getting started with Infrastructure as Code on AWS"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Webinar pages support multiple session via the 'multiple' property.
+# multiple:
+#   - datetime: 2020-02-05T10:00:00-07:00
+#     hubspot_form_id: ""
+#     gotowebinar_key: ""
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Getting started with Infrastructure as Code on AWS"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: ""
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2022-07-19T10:07:00.000-07:00
+    # Duration of the webinar.
+    duration: "60 minutes"
+    # Datetime of the webinar.
+    datetime: "7/19/2022 10:00am - 11:00am PT"
+    # Description of the webinar.
+    description: ""
+
+    # The webinar presenters
+    presenters:
+        - name: ""
+          role: ""
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn: 
+        - ""
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: ""
+---

--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-7-19-22/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-7-19-22/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the webinar.
 title: "Getting Started with Infrastructure as Code on AWS"
-meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure."
+meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using the Pulumi Cloud Engineering platform."
 
 # A featured webinar will display first in the list.
 featured: false

--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-9-8-22/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-9-8-22/index.md
@@ -1,0 +1,80 @@
+---
+# Name of the webinar.
+title: "Getting Started with Infrastructure as Code on AWS"
+meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure."
+
+# A featured webinar will display first in the list.
+featured: false
+
+# If the video is pre-recorded or live.
+pre_recorded: false
+
+# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+pulumi_tv: false
+
+# The preview image will be shown on the list page.
+preview_image: ""
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: true
+block_external_search_index: true
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: "https://www.bigmarker.com/pulumi/Getting-Started-with-Infrastructure-as-Code-on-AWS-cf1d7efc1ee2072277ee1de6"
+
+# The content of the hero section.
+hero:
+    # The title text in the hero. This also serves as the pages H1.
+    title: "Getting started with Infrastructure as Code on AWS"
+    # The image the appears on the right hand side of the hero.
+    image: "/icons/containers.svg"
+
+# Webinar pages support multiple session via the 'multiple' property.
+# multiple:
+#   - datetime: 2020-02-05T10:00:00-07:00
+#     hubspot_form_id: ""
+#     gotowebinar_key: ""
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: "Getting started with Infrastructure as Code on AWS"
+    # URL for embedding a URL for ungated webinars.
+    youtube_url: ""
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2022-09-08T10:09:00.00-07:00
+    # Duration of the webinar.
+    duration: "60 minutes"
+    # Datetime of the webinar.
+    datetime: "9/8/2022 10:00am - 11:00am PT"
+    # Description of the webinar.
+    description: ""
+
+    # The webinar presenters
+    presenters:
+        - name: ""
+          role: ""
+
+    # A bullet point list containing what the user will learn during the webinar.
+    learn: 
+        - ""
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: ""
+---

--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-9-8-22/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-on-aws-9-8-22/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the webinar.
 title: "Getting Started with Infrastructure as Code on AWS"
-meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure."
+meta_desc: "In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using the Pulumi Cloud Engineering platform."
 
 # A featured webinar will display first in the list.
 featured: false


### PR DESCRIPTION
Issue: https://github.com/pulumi/marketing/issues/359, https://github.com/pulumi/marketing/issues/360

Adding workshops for the Getting Started with AWS on  7/19/22 and 9/8/22. The text for the description on the resources page is way too long and ends up overflowing the workshop card. I notice it was 2 paragraphs, I shortened it to only include the first one and it is still too long. Let me know what changes can be made here. Could we shorten "infrastructure as code" to just b abbreviated as "IaC"? That may do the trick.
![Screenshot from 2022-06-16 18-26-45](https://user-images.githubusercontent.com/16751381/174204035-c047b8be-f445-4bdf-b730-a0e9cc6f18f4.png)
