### PR TITLE
Change .NET Core to .NET is our docs prose

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -107,7 +107,7 @@ reference:
     url: https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi
     weight: 3
 
-  - name: .NET Core
+  - name: .NET
     parent: Pulumi SDK
     url: /docs/reference/pkg/dotnet/Pulumi/Pulumi.html
     weight: 4

--- a/themes/default/content/docs/guides/pulumi-packages/how-to-author.md
+++ b/themes/default/content/docs/guides/pulumi-packages/how-to-author.md
@@ -14,7 +14,7 @@ This how-to guide will take you step-by-step through the tasks required to autho
 
 - You need to [install Pulumi]({{<relref "/docs/get-started/install">}}).
 - You should be familiar with the Pulumi [Resource and Component model]({{<relref "/docs/intro/concepts/resources">}}).
-- Pulumi Packages are multi-language: you can write your package once in either Go, Python, or TypeScript/JavaScript and then make it available to all Pulumi users, even if they use another language. To develop them, you need to have Git, Go, .NET Core, Python, and TypeScript installed on your system.
+- Pulumi Packages are multi-language: you can write your package once in either Go, Python, or TypeScript/JavaScript and then make it available to all Pulumi users, even if they use another language. To develop them, you need to have Git, Go, .NET, Python, and TypeScript installed on your system.
 - To follow the whole guide, you need a GitHub account. However, using GitHub is not a requirement; you may still find this guide useful even if you use another system to store your source code.
 
 ## Create a repository

--- a/themes/default/content/docs/intro/languages/_index.md
+++ b/themes/default/content/docs/intro/languages/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Languages
-meta_desc: An overview of how to use Node.js, Python, Go, .NET Core, Java, and YAML when writing cloud applications for AWS, Azure, Google Cloud, Kubernetes, etc.
+meta_desc: An overview of how to use Node.js, Python, Go, .NET, Java, and YAML when writing cloud applications for AWS, Azure, Google Cloud, Kubernetes, etc.
 menu:
   intro:
     identifier: languages
@@ -48,10 +48,10 @@ The following language runtimes are currently supported by Pulumi. Select one to
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8 pb-16 text-center" href="{{< relref "./dotnet" >}}">
             <p class="mx-auto text-xl font-semibold link">
-                .NET Core
+                .NET
                 <span class="text-xs font-light">(C#, F#, VB)</span>
             </p>
-            <img class="h-12 mx-auto inline" src="/logos/tech/dot-net.svg" alt=".NET Core">
+            <img class="h-12 mx-auto inline" src="/logos/tech/dot-net.svg" alt=".NET">
             <img class="h-12 mx-auto inline" src="/logos/tech/c-sharp.svg" alt="C#">
             <img class="h-12 mx-auto inline" src="/logos/tech/f-sharp.svg" alt="F#">
             <img class="h-12 mx-auto inline" src="/logos/tech/visual-basic.svg" alt="Visual Basic">

--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -1,5 +1,5 @@
 ---
-title: ".NET Core (C#, VB, F#)"
+title: ".NET (C#, VB, F#)"
 meta_desc: An overview of how to use .NET languages like C# and F# for infrastructure as code
            on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
@@ -12,9 +12,9 @@ aliases: ["/dotnet/"]
 
 <img src="/logos/tech/dotnet.png" align="right" width="150" style="padding:8px; margin-top: -64px">
 
-Pulumi supports infrastructure as code using any .NET Core language. You can use your favorite .NET tools &mdash; such as editors, package managers, build systems, and test frameworks &mdash; to create, deploy, and manage infrastructure on any cloud, including Azure, AWS, and Google Cloud.
+Pulumi supports infrastructure as code using any .NET language. You can use your favorite .NET tools &mdash; such as editors, package managers, build systems, and test frameworks &mdash; to create, deploy, and manage infrastructure on any cloud, including Azure, AWS, and Google Cloud.
 
-<a class="btn" href="https://dotnet.microsoft.com/download" target="_blank" title="Install .NET Core">Install .NET Core</a>
+<a class="btn" href="https://dotnet.microsoft.com/download" target="_blank" title="Install .NET">Install .NET</a>
 
 ## Getting Started
 
@@ -49,10 +49,10 @@ The Getting Started guides only demonstrate C#, but will also work for F# and Vi
 
 ## Prerequisites
 
-Before using Pulumi for .NET, you will need to install both Pulumi and .NET Core SDK 3.1 or later. If you follow the Getting Started guides above, they will walk you through doing this.
+Before using Pulumi for .NET, you will need to install both Pulumi and .NET Core SDK 3.1, .NET 5, or .NET 6 (recommended). If you follow the Getting Started guides above, they will walk you through doing this.
 
 1. [Install Pulumi]({{< relref "/docs/get-started/install" >}})
-1. [Install .NET Core SDK 3.1](https://dotnet.microsoft.com/download)
+1. [Install .NET SDK](https://dotnet.microsoft.com/download)
 
 ## Example
 
@@ -166,7 +166,7 @@ End Module
 
 ## C\#, F\#, and VB Templates
 
-As of version 1.5, Pulumi supports .NET Core 3.1. You can write Pulumi programs in your favorite .NET language to get additional verification and tooling benefits. The fastest way to get started is to use a template. The template will autogenerate a set of files and initialize a Pulumi project. The getting started guides shown above will help do this on your cloud of choice, but this section describes doing so independently.
+You can write Pulumi programs in your favorite .NET language to get additional verification and tooling benefits. The fastest way to get started is to use a template. The template will autogenerate a set of files and initialize a Pulumi project. The getting started guides shown above will help do this on your cloud of choice, but this section describes doing so independently.
 
 {{< chooser language "csharp,fsharp,visualbasic" >}}
 
@@ -229,11 +229,11 @@ This `visualbasic` template is cloud agnostic, and you will need to install NuGe
 
 {{< /chooser >}}
 
-## .NET Core Tools
+## .NET Tools
 
 Pulumi packages are distributed on [NuGet for download](https://www.nuget.org/packages?q=pulumi).
 
-Although you can use any editor, [Visual Studio Code](https://code.visualstudio.com/download), [Visual Studio](https://visualstudio.microsoft.com/downloads/), or [Rider](https://www.jetbrains.com/rider/) will deliver full tooling support for .NET Core out-of-the-box, including auto-completion, red error markers and build errors.
+Although you can use any editor, [Visual Studio Code](https://code.visualstudio.com/download), [Visual Studio](https://visualstudio.microsoft.com/downloads/), or [Rider](https://www.jetbrains.com/rider/) will deliver full tooling support for .NET out-of-the-box, including auto-completion, red error markers and build errors.
 
 ![VSCode](/images/docs/quickstart/vscode-dotnet.png)
 
@@ -243,7 +243,7 @@ The Pulumi programming model defines the core concepts you will use when creatin
 Pulumi. [Architecture & Concepts]({{< relref "/docs/intro/concepts" >}}) describes these concepts
 with examples available in Python. These concepts are made available to you in the Pulumi SDK.
 
-The Pulumi SDK is available to .NET Core developers as a Nuget package. To learn more,
+The Pulumi SDK is available to .NET developers as a Nuget package. To learn more,
 [refer to the Pulumi SDK Reference Guide](/docs/reference/pkg/dotnet/Pulumi/Pulumi.html).
 
 The Pulumi programming model includes a core concept of `Input` and `Output` values, which are used to track how outputs of one resource flow in as inputs to another resource.  This concept is important to understand when getting started with .NET and Pulumi, and the [Inputs and Outputs]({{< relref "/docs/intro/concepts/inputs-outputs" >}}) documentation is recommended to get a feel for how to work with this core part of Pulumi in common cases.
@@ -256,7 +256,7 @@ In addition to the CLI-driven workflows shown above, you can continuously deploy
 
 <img src="/logos/tech/azuredevops.png" align="right" width="100" style="padding:0 0 16px 32px">
 
-Pulumi can deploy infrastructure changes from your Azure DevOps Pipelines. This enables easy integration with your existing automation while using .NET Core for your infrastructure as code, leveraging the Pulumi task in the Visual Studio Marketplace.
+Pulumi can deploy infrastructure changes from your Azure DevOps Pipelines. This enables easy integration with your existing automation while using .NET for your infrastructure as code, leveraging the Pulumi task in the Visual Studio Marketplace.
 
 To learn more, [see the Pulumi Azure DevOps user guide]({{< relref "/docs/guides/continuous-delivery/azure-devops" >}}).
 

--- a/themes/default/content/docs/reference/pulumi-sdk.md
+++ b/themes/default/content/docs/reference/pulumi-sdk.md
@@ -50,10 +50,10 @@ Choose your language runtime to view the API documentation for the Pulumi SDK:
     <div class="pb-4 md:w-1/2">
         <a class="tile p-8 pb-16 text-center" href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.html">
             <p class="mx-auto text-xl font-semibold link">
-                .NET Core
+                .NET
                 <span class="text-xs font-light">(C#, F#, VB)</span>
             </p>
-            <img class="h-12 mx-auto inline" src="/logos/tech/dot-net.svg" alt=".NET Core">
+            <img class="h-12 mx-auto inline" src="/logos/tech/dot-net.svg" alt=".NET">
             <img class="h-12 mx-auto inline" src="/logos/tech/c-sharp.svg" alt="C#">
             <img class="h-12 mx-auto inline" src="/logos/tech/f-sharp.svg" alt="F#">
             <img class="h-12 mx-auto inline" src="/logos/tech/visual-basic.svg" alt="Visual Basic">

--- a/themes/default/content/partner/azure.md
+++ b/themes/default/content/partner/azure.md
@@ -244,7 +244,7 @@ detail_sections:
         - title: All Languages
           icon: code
           icon_color: yellow
-          description: The Pulumi Azure Native provider is available in all Pulumi languages, including JavaScript, TypeScript, Python, Go, .NET Core, Java, and YAML. All SDKs are open source on GitHub and available as npm, NuGet, PyPI, and Go modules.
+          description: The Pulumi Azure Native provider is available in all Pulumi languages, including JavaScript, TypeScript, Python, Go, .NET, Java, and YAML. All SDKs are open source on GitHub and available as npm, NuGet, PyPI, and Go modules.
 
 superpowers:
   - title: Multi Cloud

--- a/themes/default/layouts/partials/carousel.html
+++ b/themes/default/layouts/partials/carousel.html
@@ -93,7 +93,7 @@
                         />
                     </svg>
                 </span>
-                <span title=".NET Core">
+                <span title=".NET">
                     <svg class="h-8 mr-1 rounded" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
                         <defs>
                             <style>

--- a/themes/default/layouts/partials/supported-languages.html
+++ b/themes/default/layouts/partials/supported-languages.html
@@ -51,7 +51,7 @@
             />
         </svg>
     </span>
-    <span title=".NET Core">
+    <span title=".NET">
         <svg class="h-8 mr-1 rounded" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
             <defs>
                 <style>

--- a/themes/default/layouts/shortcodes/install-dotnet.html
+++ b/themes/default/layouts/shortcodes/install-dotnet.html
@@ -1,4 +1,4 @@
-<p class="mt-4">Install <a href="https://dotnet.microsoft.com/download" target="_blank" rel="noopener">.NET Core 3.1 SDK or later</a>.</p>
+<p class="mt-4">Install <a href="https://dotnet.microsoft.com/download" target="_blank" rel="noopener">.NET SDK</a>.</p>
 
 <div class="note note-info" role="alert">
     <div class="note-heading">


### PR DESCRIPTION
The technology is now called ".NET" and the latest version is ".NET 6", which is the only current LTS (long-term support) version. It's the default version that users will get if they follow our links to download pages. We are also about to change our templates and examples to .NET 6, which. also brings nice simplifications into programs.

I searched for all mentions of ".NET Core" and updated everything except blog posts, case studies, and old workshop guide.