### PR TITLE
Add Deploy with Pulumi widgets

### DIFF
--- a/themes/default/content/blog/testing-pulumi-programs-with-jest/index.md
+++ b/themes/default/content/blog/testing-pulumi-programs-with-jest/index.md
@@ -12,6 +12,10 @@ tags:
     - aws
     - lambda
     - serverless
+deploy_with_pulumi:
+    repo: pulumi/examples
+    branch: master
+    path: testing-unit-ts-mocks-jest
 ---
 
 When I was a kid growing up in Southern California, there was a phone number you could call to find out what time it was. It was a local number, 853-1212 (easy to remember as the arrangement of the numbers on the keypad made a capital T), and I used it all the time, to set my watch, adjust the alarm clock, fix the display on the VCR. I don't recall the last time I used it, probably sometime in the mid '90s, but I do remember clearly the sound of [the voice at the other end of the line](https://telephoneworld.org/telephone-sounds/modern-north-american-telephone-sounds/time-temperature-weather-forecast-recordings/).

--- a/themes/default/layouts/blog/single.html
+++ b/themes/default/layouts/blog/single.html
@@ -40,6 +40,11 @@
                             {{ end }}
                         </div>
 
+                        {{ if .Params.deploy_with_pulumi }}
+                            {{ partial "deploy-with-pulumi" (dict "repo" .Params.deploy_button.repo "branch" .Params.deploy_button.branch "path" .Params.deploy_button.path) }}
+                        {{ end }}
+
+
                         <section class="py-8">
                             <div class="container mx-auto">
                                 <div class="text-center">

--- a/themes/default/layouts/partials/deploy-with-pulumi.html
+++ b/themes/default/layouts/partials/deploy-with-pulumi.html
@@ -1,0 +1,5 @@
+<div class="my-4">
+    <a href="https://app.pulumi.com/new?template=https://github.com/{{ .repo }}/tree/{{ .branch }}/{{ .path }}">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy with Pulumi" />
+    </a>
+</div>

--- a/themes/default/layouts/shortcodes/deploy-with-pulumi.html
+++ b/themes/default/layouts/shortcodes/deploy-with-pulumi.html
@@ -1,0 +1,10 @@
+{{ $repo := .Get "repo" }}
+{{ $branch := .Get "branch" }}
+{{ $path := .Get "path" }}
+
+
+<div class="my-4">
+    <a href="https://app.pulumi.com/new?template=https://github.com/{{ $repo }}/tree/{{ $branch }}/{{ $path }}">
+        <img src="https://get.pulumi.com/new/button.svg" alt="Deploy with Pulumi" />
+    </a>
+</div>


### PR DESCRIPTION
This change adds a `deploy-with-pulumi` shortcode and partial to make it easier to drop these buttons into content and template files, and adds the partial to the blog template so it can be driven by (optional) frontmatter. Usage:

In blog posts:

```
---
...

deploy_with_pulumi:
    repo: pulumi/examples
    branch: master
    path: testing-unit-ts-mocks-jest
---
```

In other Markdown files:

```
{{< deploy-with-pulumi repo="pulumi/examples" branch="master" path="my-example" >}}
```

In templates:

```
{{ partial "deploy-with-pulumi" (dict "repo" "pulumi/examples" "branch" "master" "path" "my-example") }}
``` 

(Still marked as a WIP while we think through the various ways of positioning the button in blog posts.)