### PR TITLE
Update stack readme example

### DIFF
--- a/themes/default/content/blog/stack-readme/index.md
+++ b/themes/default/content/blog/stack-readme/index.md
@@ -86,7 +86,7 @@ In order to add a README to your Pulumi Stack, you will need to do the following
 
 Export a [Stack output](https://www.pulumi.com/learn/building-with-pulumi/stack-outputs) named `readme` that contains your templated Stack README markdown, commonly by reading a file, i.e. `Pulumi.README.md`.
 
-{{< chooser language "typescript,python,go,csharp,java" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language typescript %}}
 
@@ -182,6 +182,25 @@ public class App {
         });
     }
 }
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+name: stack-readme-yaml
+runtime: yaml
+description: A minimal Pulumi YAML program demonstrating stack readme feature
+variables:
+  readme:
+    Fn::ReadFile: ./Pulumi.README.md
+outputs:
+  strVar: foo
+  arrVar:
+    - fizz
+    - buzz
+  readme: ${readme}
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/blog/stack-readme/index.md
+++ b/themes/default/content/blog/stack-readme/index.md
@@ -95,7 +95,7 @@ import { readFileSync } from "fs";
 export const strVar = "foo";
 export const arrVar = ["fizz", "buzz"];
 // add readme to stack outputs. must be named "readme".
-export const readme = readFileSync("./Pulumi.README.md");
+export const readme = readFileSync("./Pulumi.README.md").toString();
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
Two changes in this PR:
1. Stringifies file in typescript example
2. Adds YAML example.

YAML Screenshot:
![Screenshot 2022-06-17 at 14 50 40](https://user-images.githubusercontent.com/17183569/174406109-9dff494f-1556-4fd6-ac0c-73cf9e42a7b0.png)


