### PR TITLE
Add PULUMI_TEST_MODE to guides/testing/unit

### DIFF
--- a/themes/default/content/docs/guides/testing/unit.md
+++ b/themes/default/content/docs/guides/testing/unit.md
@@ -683,7 +683,7 @@ That's it&mdash;now let's run the tests.
 The command line to run your Mocha tests would therefore be:
 
 ```bash
-$ mocha -r ts-node/register ec2tests.ts
+$ PULUMI_TEST_MODE=true mocha -r ts-node/register ec2tests.ts
 ```
 
 {{% /choosable %}}
@@ -691,7 +691,7 @@ $ mocha -r ts-node/register ec2tests.ts
 Run the following command to execute your Python tests:
 
 ```bash
-$ python -m unittest
+$ PULUMI_TEST_MODE=true python -m unittest
 ```
 
 {{% /choosable %}}
@@ -699,7 +699,7 @@ $ python -m unittest
 Run the following command to execute your Go tests:
 
 ```bash
-$ go test
+$ PULUMI_TEST_MODE=true go test
 ```
 
 {{% /choosable %}}
@@ -707,7 +707,7 @@ $ go test
 Run the following command to execute your Python tests:
 
 ```bash
-$ dotnet test
+$ PULUMI_TEST_MODE=true dotnet test
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
I was pulling my hair out trying to figure out why `pulumi.isDryRun`
was returning `false` when I was running my unit tests, given that
[the docs on the method][1] say:

> Note that we always consider executions in test mode to be
> “dry-runs”, since we will never actually carry out an update, and
> therefore certain output properties will never be resolved.

I’m still not sure if/where there is any canonical documentation on
“test mode” but I feel that it should probably always be enabled when
running unit tests. I’d prefer that there be a programmatic/imperative
way to enable it, e.g. `runtime.setDryRun(true)` or something similar,
but in lieu of that I feel the examples should include setting the env
var so as to plant seeds of awareness about this feature and how it
works.

[1]: https://www.pulumi.com/docs/reference/pkg/nodejs/pulumi/pulumi/runtime/#isDryRun