### PR TITLE
Add content to /migrate

### DIFF
--- a/themes/default/content/migrate/_index.md
+++ b/themes/default/content/migrate/_index.md
@@ -1,5 +1,6 @@
 ---
-private: true
-title: Migrate
-meta_desc: Information on migrating to Pulumi from an existing templating workflow.
+title: Migrate to Pulumi
+meta_desc: Interested in migrating to Pulumi from another infrastructure as code tool? Our conversion tools can help you make the transition.
 ---
+
+Interested in migrating to Pulumi from another infrastructure as code tool? Our conversion tools can help you make the transition.

--- a/themes/default/content/migrate/arm2pulumi.md
+++ b/themes/default/content/migrate/arm2pulumi.md
@@ -7,9 +7,9 @@ menu:
   converters:
     identifier: arm2pulumi
     weight: 1
-    
+aliases:
+    - /migrate/arm2pulumi
 meta_desc: See what your Azure ARM Template would look like in a modern language thanks to Pulumi.
-
 examples:
     - name: Storage Account
       filename: azuredeploy.json

--- a/themes/default/content/migrate/cf2pulumi.md
+++ b/themes/default/content/migrate/cf2pulumi.md
@@ -7,9 +7,9 @@ menu:
   converters:
     identifier: cf2pulumi
     weight: 1
-    
+aliases:
+    - /migrate/cf2pulumi
 meta_desc: See what your CloudFormation templates would look like in a modern programming language thanks to Pulumi.
-
 examples:
     - name: Provision a Log Group
       filename: instance.yaml

--- a/themes/default/content/migrate/kube2pulumi.md
+++ b/themes/default/content/migrate/kube2pulumi.md
@@ -7,8 +7,9 @@ menu:
   converters:
     identifier: kube2pulumi
     weight: 3
+aliases:
+    - /migrate/kube2pulumi
 meta_desc: See what your Kubernetes YAML would look like in a modern language thanks to Pulumi.
-
 examples:
     - name: Nginx Pod
       filename: kube.yaml

--- a/themes/default/content/migrate/tf2pulumi.md
+++ b/themes/default/content/migrate/tf2pulumi.md
@@ -7,8 +7,9 @@ menu:
   converters:
     identifier: tf2pulumi
     weight: 4
+aliases:
+    - /migrate/tf2pulumi
 meta_desc: See what your Terraform HCL would look like in a modern language thanks to Pulumi.
-
 examples:
     - name: AWS EC2 Instance
       filename: main.tf

--- a/themes/default/layouts/migrate/section.html
+++ b/themes/default/layouts/migrate/section.html
@@ -1,0 +1,37 @@
+{{ define "hero" }}
+    {{ partial "hero.html" (dict "title" .Title) }}
+{{ end }}
+
+{{ define "main" }}
+    <div class="container mx-auto text-center my-12">
+        <h5 class="mx-auto max-w-3xl mb-0 px-4">
+            {{ .Content }}
+        </h5>
+    </div>
+    <div class="container mx-auto max-w-2xl px-4 md:px-8">
+        <ul class="list-none p-0 text-lg md:text-xl">
+            <li class="my-8">
+                <p>
+                    <a href="/migrate/tf2pulumi">Convert Terraform HCL to Pulumi &rarr;</a>
+                </p>
+            </li>
+            <li class="my-8">
+                <p>
+                    <a href="/migrate/cf2pulumi">Convert CloudFormation templates to Pulumi &rarr;</a>
+                </p>
+            </li>
+            <li class="my-8">
+                <p>
+                    <a href="/migrate/arm2pulumi">Convert Azure Resource Manager (ARM) templates to Pulumi &rarr;</a>
+                </p>
+            </li>
+            <li class="my-8">
+                <p>
+                    <a href="/migrate/kube2pulumi">Convert Kubernetes YAML to Pulumi &rarr;</a>
+                </p>
+            </li>
+        </ul>
+    </div>
+
+    {{ partial "learnmore-contactus.html" . }}
+{{ end }}

--- a/themes/default/layouts/migrate/section.html
+++ b/themes/default/layouts/migrate/section.html
@@ -3,12 +3,12 @@
 {{ end }}
 
 {{ define "main" }}
-    <div class="container mx-auto text-center my-12">
-        <h5 class="mx-auto max-w-3xl mb-0 px-4">
+    <div class="container mx-auto text-center my-12 px-4 text-xl text-gray-900">
+        <div class="max-w-2xl mx-auto">
             {{ .Content }}
-        </h5>
+        </div>
     </div>
-    <div class="container mx-auto max-w-2xl px-4 md:px-8">
+    <div class="container mx-auto max-w-2xl px-4 md:px-8 mb-24">
         <ul class="list-none p-0 text-lg md:text-xl">
             <li class="my-8">
                 <p>
@@ -33,5 +33,5 @@
         </ul>
     </div>
 
-    {{ partial "learnmore-contactus.html" . }}
+    {{ partial "hand-raise-section" . }}
 {{ end }}


### PR DESCRIPTION
Just adds some reasonable content to the page to guide those who land here to the right place. (The page [currently empty](https://pulumi.com/migrate).)

Fixes #672.