### PR TITLE
Add warning to resource options docs

### DIFF
--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 {{% notes "warning" %}}
-The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
 {{% /notes %}}
 
 The `additionalSecretOutputs` resource option specifies a list of named output properties that should be treated as [secrets]({{< relref "/docs/intro/concepts/secrets" >}}), which means they will be encrypted. It augments the list of values that Pulumi detects, based on secret inputs to the resource.

--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -82,6 +82,6 @@ resources:
 
 Only top-level resource properties can be designated secret. If sensitive data is nested inside of a property, you must mark the entire top-level output property as secret.
 
-{{% notes "warning" %}}
+{{% notes type="warning" %}}
 The `additionalSecretOutputs` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -8,6 +8,10 @@ menu:
     weight: 1
 ---
 
+{{% notes "warning" %}}
+The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+{{% /notes %}}
+
 The `additionalSecretOutputs` resource option specifies a list of named output properties that should be treated as [secrets]({{< relref "/docs/intro/concepts/secrets" >}}), which means they will be encrypted. It augments the list of values that Pulumi detects, based on secret inputs to the resource.
 
 This example ensures that the password generated for a database resource is an encrypted secret:

--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -83,5 +83,5 @@ resources:
 Only top-level resource properties can be designated secret. If sensitive data is nested inside of a property, you must mark the entire top-level output property as secret.
 
 {{% notes "warning" %}}
-The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+The `additionalSecretOutputs` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/additionalsecretoutputs.md
@@ -8,10 +8,6 @@ menu:
     weight: 1
 ---
 
-{{% notes "warning" %}}
-The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
-{{% /notes %}}
-
 The `additionalSecretOutputs` resource option specifies a list of named output properties that should be treated as [secrets]({{< relref "/docs/intro/concepts/secrets" >}}), which means they will be encrypted. It augments the list of values that Pulumi detects, based on secret inputs to the resource.
 
 This example ensures that the password generated for a database resource is an encrypted secret:
@@ -85,3 +81,7 @@ resources:
 {{< /chooser >}}
 
 Only top-level resource properties can be designated secret. If sensitive data is nested inside of a property, you must mark the entire top-level output property as secret.
+
+{{% notes "warning" %}}
+The `additionalSecretOutputs` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+{{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -88,5 +88,5 @@ resources:
 {{< /chooser >}}
 
 {{% notes "warning" %}}
-The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+The `customTimeouts` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -87,6 +87,6 @@ resources:
 
 {{< /chooser >}}
 
-{{% notes "warning" %}}
+{{% notes type="warning" %}}
 The `customTimeouts` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 {{% notes "warning" %}}
-The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
 {{% /notes %}}
 
 The `customTimeouts` resource option provides a set of custom timeouts for `create`, `update`, and `delete` operations on a resource. These timeouts are specified using a duration string such as "5m" (5 minutes), "40s" (40 seconds), or "1d" (1 day). Supported duration units are "ns", "us" (or "µs"), "ms", "s", "m", and "h" (nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively).

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -8,10 +8,6 @@ menu:
     weight: 3
 ---
 
-{{% notes "warning" %}}
-The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
-{{% /notes %}}
-
 The `customTimeouts` resource option provides a set of custom timeouts for `create`, `update`, and `delete` operations on a resource. These timeouts are specified using a duration string such as "5m" (5 minutes), "40s" (40 seconds), or "1d" (1 day). Supported duration units are "ns", "us" (or "µs"), "ms", "s", "m", and "h" (nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively).
 
 For the most part, Pulumi automatically waits for operations to complete and times out appropriately. In some circumstances, such as working around bugs in the infrastructure provider, custom timeouts may be necessary.
@@ -90,3 +86,7 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
+
+{{% notes "warning" %}}
+The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+{{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/customtimeouts.md
@@ -8,6 +8,10 @@ menu:
     weight: 3
 ---
 
+{{% notes "warning" %}}
+The `customTimeouts` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+{{% /notes %}}
+
 The `customTimeouts` resource option provides a set of custom timeouts for `create`, `update`, and `delete` operations on a resource. These timeouts are specified using a duration string such as "5m" (5 minutes), "40s" (40 seconds), or "1d" (1 day). Supported duration units are "ns", "us" (or "µs"), "ms", "s", "m", and "h" (nanoseconds, microseconds, milliseconds, seconds, minutes, and hours, respectively).
 
 For the most part, Pulumi automatically waits for operations to complete and times out appropriately. In some circumstances, such as working around bugs in the infrastructure provider, custom timeouts may be necessary.

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 {{% notes "warning" %}}
-The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
 {{% /notes %}}
 
 The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Any properties specified in this list that are also specified in the resource’s arguments will only be used when creating the resource.

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -138,6 +138,6 @@ For example, a property named `NestedResource` would turn into `nestedResource`.
 - `["root key with \"escaped\" quotes"].nested`
 - `["root key with a ."][100]`
 
-{{% notes "warning" %}}
+{{% notes type="warning" %}}
 The `ignoreChanges` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -8,6 +8,10 @@ menu:
     weight: 6
 ---
 
+{{% notes "warning" %}}
+The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+{{% /notes %}}
+
 The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Any properties specified in this list that are also specified in the resource’s arguments will only be used when creating the resource.
 
 For instance, in this example, the resource’s prop property "new-value" will be set when Pulumi initially creates the resource, but from then on, any updates will ignore it:

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -139,5 +139,5 @@ For example, a property named `NestedResource` would turn into `nestedResource`.
 - `["root key with a ."][100]`
 
 {{% notes "warning" %}}
-The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+The `ignoreChanges` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/ignorechanges.md
@@ -8,10 +8,6 @@ menu:
     weight: 6
 ---
 
-{{% notes "warning" %}}
-The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
-{{% /notes %}}
-
 The `ignoreChanges` resource option specifies a list of properties that Pulumi will ignore when it updates existing resources. Any properties specified in this list that are also specified in the resource’s arguments will only be used when creating the resource.
 
 For instance, in this example, the resource’s prop property "new-value" will be set when Pulumi initially creates the resource, but from then on, any updates will ignore it:
@@ -141,3 +137,7 @@ For example, a property named `NestedResource` would turn into `nestedResource`.
 - `root["key with a ."]`
 - `["root key with \"escaped\" quotes"].nested`
 - `["root key with a ."][100]`
+
+{{% notes "warning" %}}
+The `ignoreChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+{{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -8,6 +8,10 @@ menu:
     weight: 12
 ---
 
+{{% notes "warning" %}}
+The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+{{% /notes %}}
+
 The `replaceOnChanges` resource option can be used to indicate that changes to certain properties on a resource should force a replacement of the resource instead of an in-place update.  Typically users rely on the resource provider to make this decision based on whether the input property is one that the provider knows how to update in place, or if not, requires a replacement to modify.  However, there are cases where users want to replace a resource on a change to an input property even if the resource provider itself doesn't believe it has to replace the resource.
 
 For example, with Kubernetes `CustomResource` resources, the Kubernetes resource model doesn't know whether or not a specific input property on a specific kind of `CustomResource` requires a replacement, and so assumes that *any* change can be made without replacement.  However, in practice, many specific kinds of `CustomResource` in the Kubernetes ecosystem *do* require replacement when certain input properties are changed.  The Kubernetes provider itself can't know this, but users can use `replaceOnChanges` to ensure that these changes can be made correctly via Pulumi.

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -124,5 +124,5 @@ If there are initialization errors on a resource (because the resource was creat
 The `replaceOnChanges` resource option can be combined with the [`deleteBeforeReplace`]({{< relref "deletebeforereplace" >}}) resource option to trigger a resource to be deleted before it is replaced whenever a given input has changes.
 
 {{% notes "warning" %}}
-The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+The `replaceOnChanges` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -123,6 +123,6 @@ If there are initialization errors on a resource (because the resource was creat
 
 The `replaceOnChanges` resource option can be combined with the [`deleteBeforeReplace`]({{< relref "deletebeforereplace" >}}) resource option to trigger a resource to be deleted before it is replaced whenever a given input has changes.
 
-{{% notes "warning" %}}
+{{% notes type="warning" %}}
 The `replaceOnChanges` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -8,10 +8,6 @@ menu:
     weight: 12
 ---
 
-{{% notes "warning" %}}
-The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
-{{% /notes %}}
-
 The `replaceOnChanges` resource option can be used to indicate that changes to certain properties on a resource should force a replacement of the resource instead of an in-place update.  Typically users rely on the resource provider to make this decision based on whether the input property is one that the provider knows how to update in place, or if not, requires a replacement to modify.  However, there are cases where users want to replace a resource on a change to an input property even if the resource provider itself doesn't believe it has to replace the resource.
 
 For example, with Kubernetes `CustomResource` resources, the Kubernetes resource model doesn't know whether or not a specific input property on a specific kind of `CustomResource` requires a replacement, and so assumes that *any* change can be made without replacement.  However, in practice, many specific kinds of `CustomResource` in the Kubernetes ecosystem *do* require replacement when certain input properties are changed.  The Kubernetes provider itself can't know this, but users can use `replaceOnChanges` to ensure that these changes can be made correctly via Pulumi.
@@ -126,3 +122,7 @@ The property paths passed to `replaceOnChanges` should always be the "camelCase"
 If there are initialization errors on a resource (because the resource was created but failed to fully initialize correctly on a previous deployment) then the resource will normally be updated on the following Pulumi update, even if there are no other changes to the resource's inputs.  If `*` is specified as a property path for `replaceOnChanges`, then initialization errors will trigger a replacement instead of an update.
 
 The `replaceOnChanges` resource option can be combined with the [`deleteBeforeReplace`]({{< relref "deletebeforereplace" >}}) resource option to trigger a resource to be deleted before it is replaced whenever a given input has changes.
+
+{{% notes "warning" %}}
+The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+{{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/replaceonchanges.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 {{% notes "warning" %}}
-The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+The `replaceOnChanges` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
 {{% /notes %}}
 
 The `replaceOnChanges` resource option can be used to indicate that changes to certain properties on a resource should force a replacement of the resource instead of an in-place update.  Typically users rely on the resource provider to make this decision based on whether the input property is one that the provider knows how to update in place, or if not, requires a replacement to modify.  However, there are cases where users want to replace a resource on a change to an input property even if the resource provider itself doesn't believe it has to replace the resource.

--- a/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
@@ -8,6 +8,10 @@ menu:
     weight: 13
 ---
 
+{{% notes "warning" %}}
+The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+{{% /notes %}}
+
 The `retainOnDelete` resource option marks a resource to be retained. If this option is set then Pulumi will not call through to the resource provider's `Delete` method when deleting or replacing the resource during `pulumi up` or `pulumi destroy`. As a result, the resource will not be deleted from the backing cloud provider, but will be removed from the Pulumi state.
 
 If a retained resource is deleted by Pulumi and you later want to actually delete it from the backing cloud provider you will either need to use your provider's manual interface to find and delete the resource, or import the resource back into Pulumi to unset `retainOnDelete` and delete it again fully.

--- a/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
@@ -84,5 +84,5 @@ resources:
 {{< /chooser >}}
 
 {{% notes "warning" %}}
-The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+The `retainOnDelete` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
@@ -8,10 +8,6 @@ menu:
     weight: 13
 ---
 
-{{% notes "warning" %}}
-The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
-{{% /notes %}}
-
 The `retainOnDelete` resource option marks a resource to be retained. If this option is set then Pulumi will not call through to the resource provider's `Delete` method when deleting or replacing the resource during `pulumi up` or `pulumi destroy`. As a result, the resource will not be deleted from the backing cloud provider, but will be removed from the Pulumi state.
 
 If a retained resource is deleted by Pulumi and you later want to actually delete it from the backing cloud provider you will either need to use your provider's manual interface to find and delete the resource, or import the resource back into Pulumi to unset `retainOnDelete` and delete it again fully.
@@ -86,3 +82,7 @@ resources:
 {{% /choosable %}}
 
 {{< /chooser >}}
+
+{{% notes "warning" %}}
+The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
+{{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
@@ -83,6 +83,6 @@ resources:
 
 {{< /chooser >}}
 
-{{% notes "warning" %}}
+{{% notes type="warning" %}}
 The `retainOnDelete` resource option does not apply to component resources, and will not have the intended effect.
 {{% /notes %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/retainOnDelete.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 {{% notes "warning" %}}
-The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored. 
+The `retainOnDelete` resource options has no effect on component resources. If applied to a component resource, it will be ignored.
 {{% /notes %}}
 
 The `retainOnDelete` resource option marks a resource to be retained. If this option is set then Pulumi will not call through to the resource provider's `Delete` method when deleting or replacing the resource during `pulumi up` or `pulumi destroy`. As a result, the resource will not be deleted from the backing cloud provider, but will be removed from the Pulumi state.


### PR DESCRIPTION
This PR documents the warnings generated as part of https://github.com/pulumi/pulumi/pull/9921
It closes https://github.com/pulumi/pulumi-hugo/issues/1620

(Some) resource options are ignored when applied
to component resources. This commit adds a warning
to the docs explaining this behavior.