### PR TITLE
Update getting started guides for dotnet 6 using newer templates

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -96,7 +96,7 @@ $ aws s3 ls $(pulumi stack output bucketName)
 {{% choosable language csharp %}}
 
 ```bash
-$ aws s3 ls $(pulumi stack output BucketName)
+$ aws s3 ls $(pulumi stack output bucketName)
 ```
 
 {{% /choosable %}}
@@ -281,17 +281,11 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```csharp
-// Export the name of the bucket
-this.BucketName = bucket.Id;
-this.BucketEndpoint = Output.Format($"http://{bucket.WebsiteEndpoint}");
-```
-
-```csharp
-[Output]
-public Output<string> BucketName { get; set; }
-
-[Output]
-public Output<string> BucketEndpoint { get; set; }
+return new Dictionary<string, object?>
+{
+    ["bucketName"] = bucket.Id,
+    ["bucketEndpoint"] = Output.Format($"http://{bucket.WebsiteEndpoint}")
+};
 ```
 
 {{% /choosable %}}
@@ -494,7 +488,7 @@ $ curl $(pulumi stack output bucketEndpoint)
 {{% choosable language csharp %}}
 
 ```bash
-$ curl $(pulumi stack output BucketEndpoint)
+$ curl $(pulumi stack output bucketEndpoint)
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/aws/deploy-stack.md
+++ b/themes/default/content/docs/get-started/aws/deploy-stack.md
@@ -92,7 +92,7 @@ $ pulumi stack output bucketName
 {{% choosable language csharp %}}
 
 ```bash
-$ pulumi stack output BucketName
+$ pulumi stack output bucketName
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -122,13 +122,13 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `MyStack.cs`, create the `BucketObject` right after creating the bucket itself.
+In `Program.cs`, create a new `BucketObject` right after creating the bucket itself. 
 
 ```csharp
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
-    Source = new FileAsset("index.html")
+    Source = new FileAsset("./index.html")
 });
 ```
 
@@ -176,7 +176,9 @@ resources:
 
 {{% /choosable %}}
 
-Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what S3 bucket the object should live in.
+This bucket object is part of the `Bucket` that we deployed earlier because we _reference_ the bucket name in the properties of the bucket object. 
+
+We refer to this relationship as the `BucketObject` being a _child_ resource of the S3 `Bucket` that is the _parent_ resource. This is how Pulumi knows what S3 bucket the object should live in.
 
 Next, you'll deploy your changes.
 

--- a/themes/default/content/docs/get-started/aws/review-project.md
+++ b/themes/default/content/docs/get-started/aws/review-project.md
@@ -30,7 +30,7 @@ Let's review some of the generated project files:
 
 {{% choosable language csharp %}}
 
-- `Program.cs` with a simple entry point.
+- `Program.cs` is the Pulumi program that defines your stack resources.
 
 {{% /choosable %}}
 
@@ -40,7 +40,7 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,python,go,csharp,java" %}}
+{{% choosable language "javascript,typescript,python,go,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.
@@ -131,21 +131,19 @@ func main() {
 ```csharp
 using Pulumi;
 using Pulumi.Aws.S3;
+using System.Collections.Generic;
 
-class MyStack : Stack
+await Deployment.RunAsync(() =>
 {
-    public MyStack()
-    {
-        // Create an AWS resource (S3 Bucket)
-        var bucket = new Bucket("my-bucket");
-
-        // Export the name of the bucket
-        this.BucketName = bucket.Id;
-    }
-
-    [Output]
-    public Output<string> BucketName { get; set; }
-}
+   // Create an AWS resource (S3 Bucket)
+   var bucket = new Bucket("my-bucket");
+   
+   // Export the name of the bucket
+   return new Dictionary<string, object?>
+   {
+      ["bucketName"] = bucket.Id
+   };
+});
 ```
 
 {{% /choosable %}}
@@ -230,8 +228,10 @@ ctx.Export("bucketName", bucket.ID())
 {{% choosable language csharp %}}
 
 ```csharp
-[Output]
-public Output<string> BucketName { get; set; }
+return new Dictionary<string, object?>
+{
+   ["bucketName"] = bucket.Id
+};
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/azure/deploy-changes.md
+++ b/themes/default/content/docs/get-started/azure/deploy-changes.md
@@ -92,7 +92,7 @@ $ curl $(pulumi stack output staticEndpoint)
 {{% choosable language csharp %}}
 
 ```bash
-$ curl $(pulumi stack output StaticEndpoint)
+$ curl $(pulumi stack output staticEndpoint)
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/azure/deploy-stack.md
+++ b/themes/default/content/docs/get-started/azure/deploy-stack.md
@@ -86,7 +86,7 @@ $ pulumi stack output primaryStorageKey
 {{% choosable language csharp %}}
 
 ```bash
-$ pulumi stack output PrimaryStorageKey
+$ pulumi stack output primaryStorageKey
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/azure/modify-program.md
+++ b/themes/default/content/docs/get-started/azure/modify-program.md
@@ -217,12 +217,12 @@ if err != nil {
 
 ```csharp
 // Upload the file
-var index_html = new Blob("index.html", new BlobArgs
+var indexHtml = new Blob("index.html", new BlobArgs
 {
     ResourceGroupName = resourceGroup.Name,
     AccountName = storageAccount.Name,
     ContainerName = staticWebsite.ContainerName,
-    Source = new FileAsset("index.html"),
+    Source = new FileAsset("./index.html"),
     ContentType = "text/html",
 });
 ```
@@ -300,17 +300,15 @@ ctx.Export("staticEndpoint", account.PrimaryEndpoints.Web())
 
 {{% choosable language csharp %}}
 
-Finally, at the end of `MyStack.cs`, export the resulting storage container's endpoint URL to stdout for easy access:
+Finally, at the end of `Program.cs`, export the resulting storage container's endpoint URL to stdout for easy access:
 
 ```csharp
 // Web endpoint to the website
-this.StaticEndpoint = storageAccount.PrimaryEndpoints.Apply(
-        primaryEndpoints => primaryEndpoints.Web);
-```
-
-```csharp
-[Output]
-public Output<string> StaticEndpoint { get; set; }
+return new Dictionary<string, object?>
+{
+    ["primaryStorageKey"] = primaryStorageKey,
+    ["staticEndpoint"] = storageAccount.PrimaryEndpoints.Apply(primaryEndpoints => primaryEndpoints.Web)
+};
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/azure/review-project.md
+++ b/themes/default/content/docs/get-started/azure/review-project.md
@@ -30,7 +30,7 @@ Let's review some of the generated project files:
 
 {{% choosable language csharp %}}
 
-- `Program.cs` with a simple entry point.
+- `Program.cs` is the Pulumi program that defines your stack resources.
 
 {{% /choosable %}}
 
@@ -164,46 +164,46 @@ func main() {
 {{% choosable language csharp %}}
 
 ```csharp
-using System.Threading.Tasks;
 using Pulumi;
 using Pulumi.AzureNative.Resources;
 using Pulumi.AzureNative.Storage;
 using Pulumi.AzureNative.Storage.Inputs;
+using System.Collections.Generic;
 
-class MyStack : Stack
+await Pulumi.Deployment.RunAsync(() =>
 {
-    public MyStack()
+    // Create an Azure Resource Group
+    var resourceGroup = new ResourceGroup("resourceGroup");
+
+    // Create an Azure resource (Storage Account)
+    var storageAccount = new StorageAccount("sa", new StorageAccountArgs
     {
-        // Create an Azure Resource Group
-        var resourceGroup = new ResourceGroup("resourceGroup");
-
-        // Create an Azure resource (Storage Account)
-        var storageAccount = new StorageAccount("sa", new StorageAccountArgs
+        ResourceGroupName = resourceGroup.Name,
+        Sku = new SkuArgs
         {
-            ResourceGroupName = resourceGroup.Name,
-            Sku = new SkuArgs
-            {
-                Name = SkuName.Standard_LRS
-            },
-            Kind = Kind.StorageV2
-        });
+            Name = SkuName.Standard_LRS
+        },
+        Kind = Kind.StorageV2
+    });
 
-        // Export the primary key of the Storage Account
-        this.PrimaryStorageKey = GetStorageAccountPrimaryKey(resourceGroup.Name, storageAccount.Name);
-    }
-
-    [Output]
-    public Output<string> PrimaryStorageKey { get; set; }
-
-    private static Output<string> GetStorageAccountPrimaryKey(Input<string> resourceGroupName, Input<string> accountName)
+    var storageAccountKeys = ListStorageAccountKeys.Invoke(new ListStorageAccountKeysInvokeArgs
     {
-        return ListStorageAccountKeys.Invoke(new ListStorageAccountKeysInvokeArgs
-        {
-            ResourceGroupName = resourceGroupName,
-            AccountName = accountName
-        }).Apply(accountKeys => Output.CreateSecret(accountKeys.Keys[0].Value));
-    }
-}
+        ResourceGroupName = resourceGroup.Name,
+        AccountName = storageAccount.Name
+    });
+
+    var primaryStorageKey = storageAccountKeys.Apply(accountKeys =>
+    {
+        var firstKey = accountKeys.Keys[0].Value;
+        return Output.CreateSecret(firstKey);
+    });
+
+    // Export the primary key of the Storage Account
+    return new Dictionary<string, object?>
+    {
+        ["primaryStorageKey"] = primaryStorageKey
+    };
+});
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/gcp/deploy-changes.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-changes.md
@@ -98,7 +98,7 @@ $ gsutil ls $(pulumi stack output bucketName)
 {{% choosable language csharp %}}
 
 ```bash
-$ gsutil ls $(pulumi stack output BucketName)
+$ gsutil ls $(pulumi stack output bucketName)
 ```
 
 {{% /choosable %}}
@@ -317,7 +317,7 @@ Now that `index.html` is in your bucket, modify the program file to have the buc
 First, set the `website` property on your bucket. And, to align with Google Cloud Storage recommendations, set uniform bucket-level access on the bucket to `true`.
 
 ```csharp
-// Add this import
+// Add this using statement
 using Pulumi.Gcp.Storage.Inputs;
 ```
 
@@ -350,19 +350,18 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.Name,
     ContentType = "text/html",
-    Source = new FileAsset("index.html")
+    Source = new FileAsset("./index.html")
 });
 ```
 
 Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```csharp
-this.BucketEndpoint = Output.Format($"http://storage.googleapis.com/{bucket.Name}/{bucketObject.Name}");
-```
-
-```csharp
-[Output]
-public Output<string> BucketEndpoint { get; set; }
+return new Dictionary<string, object?>
+{
+    ["bucketName"] = bucket.Url,
+    ["bucketEndpoint"] = Output.Format($"http://storage.googleapis.com/{bucket.Name}/{bucketObject.Name}")
+};
 ```
 
 {{% /choosable %}}
@@ -601,7 +600,7 @@ $ curl $(pulumi stack output bucketEndpoint)
 {{% choosable language csharp %}}
 
 ```bash
-$ curl $(pulumi stack output BucketEndpoint)
+$ curl $(pulumi stack output bucketEndpoint)
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/gcp/deploy-stack.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-stack.md
@@ -91,7 +91,7 @@ $ pulumi stack output bucketName
 {{% choosable language csharp %}}
 
 ```bash
-$ pulumi stack output BucketName
+$ pulumi stack output bucketName
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/gcp/modify-program.md
+++ b/themes/default/content/docs/get-started/gcp/modify-program.md
@@ -123,13 +123,13 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `MyStack.cs`, create the `BucketObject` right after creating the bucket itself.
+In `Program.cs`, create the `BucketObject` right after creating the bucket itself.
 
 ```csharp
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.Name,
-    Source = new FileAsset("index.html")
+    Source = new FileAsset("./index.html")
 });
 ```
 

--- a/themes/default/content/docs/get-started/gcp/review-project.md
+++ b/themes/default/content/docs/get-started/gcp/review-project.md
@@ -28,12 +28,6 @@ Let's review some of the generated project files:
 
 - `Pulumi.dev.yaml` contains [configuration]({{< relref "/docs/intro/concepts/config" >}}) values for the [stack]({{< relref "/docs/intro/concepts/stack" >}}) you initialized.
 
-{{% choosable language csharp %}}
-
-- `Program.cs` with a simple entry point.
-
-{{% /choosable %}}
-
 {{% choosable language java %}}
 
 - `src/main/java/myproject` defines the project's Java package root.
@@ -131,21 +125,23 @@ func main() {
 ```csharp
 using Pulumi;
 using Pulumi.Gcp.Storage;
+using System.Collections.Generic;
 
-class MyStack : Stack
+await Deployment.RunAsync(() =>
 {
-    public MyStack()
+    // Create a GCP resource (Storage Bucket)
+    var bucket = new Bucket("my-bucket", new BucketArgs
     {
-        // Create a GCP resource (Storage Bucket)
-        var bucket = new Bucket("my-bucket");
+        Location = "US"
+    });
+    
+    // Export the DNS name of the bucket
+    return new Dictionary<string, object?>
+    {
+        ["bucketName"] = bucket.Url
+    };
+});
 
-        // Export the DNS name of the bucket
-        this.BucketName = bucket.Url;
-    }
-
-    [Output]
-    public Output<string> BucketName { get; set; }
-}
 ```
 
 {{% /choosable %}}
@@ -233,8 +229,10 @@ ctx.Export("bucketName", bucket.Url)
 {{% choosable language csharp %}}
 
 ```csharp
-[Output]
-public Output<string> BucketName { get; set; }
+return new Dictionary<string, object?>
+{
+    ["bucketName"] = bucket.Url
+};
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/kubernetes/modify-program.md
+++ b/themes/default/content/docs/get-started/kubernetes/modify-program.md
@@ -259,96 +259,95 @@ func main() {
 ```csharp
 using Pulumi;
 using Pulumi.Kubernetes.Core.V1;
-using Pulumi.Kubernetes.Apps.V1;
 using Pulumi.Kubernetes.Types.Inputs.Core.V1;
 using Pulumi.Kubernetes.Types.Inputs.Apps.V1;
 using Pulumi.Kubernetes.Types.Inputs.Meta.V1;
+using System.Collections.Generic;
 
-class MyStack : Stack
+await Pulumi.Deployment.RunAsync(() =>
 {
-    public MyStack()
+    var config = new Pulumi.Config();
+    var isMinikube = config.GetBoolean("isMinikube") ?? false;
+
+    var appName = "nginx";
+    var appLabels = new InputMap<string>
     {
-        var config = new Pulumi.Config();
-        var isMinikube = config.GetBoolean("isMinikube") ?? false;
+        { "app", appName },
+    };
 
-        var appName = "nginx";
-
-        var appLabels = new InputMap<string>{
-            { "app", appName },
-        };
-
-        var deployment = new Pulumi.Kubernetes.Apps.V1.Deployment(appName, new DeploymentArgs
+    var deployment = new Pulumi.Kubernetes.Apps.V1.Deployment(appName, new DeploymentArgs
+    {
+        Spec = new DeploymentSpecArgs
         {
-            Spec = new DeploymentSpecArgs
+            Selector = new LabelSelectorArgs
             {
-                Selector = new LabelSelectorArgs
+                MatchLabels = appLabels,
+            },
+            Replicas = 1,
+            Template = new PodTemplateSpecArgs
+            {
+                Metadata = new ObjectMetaArgs
                 {
-                    MatchLabels = appLabels,
+                    Labels = appLabels,
                 },
-                Replicas = 1,
-                Template = new PodTemplateSpecArgs
+                Spec = new PodSpecArgs
                 {
-                    Metadata = new ObjectMetaArgs
+                    Containers =
                     {
-                        Labels = appLabels,
-                    },
-                    Spec = new PodSpecArgs
-                    {
-                        Containers =
+                        new ContainerArgs
                         {
-                            new ContainerArgs
+                            Name = appName,
+                            Image = "nginx",
+                            Ports =
                             {
-                                Name = appName,
-                                Image = "nginx",
-                                Ports =
+                                new ContainerPortArgs
                                 {
-                                    new ContainerPortArgs
-                                    {
-                                        ContainerPortValue = 80
-                                    },
+                                    ContainerPortValue = 80
                                 },
                             },
                         },
                     },
                 },
             },
-        });
+        },
+    });
 
-        var frontend = new Service(appName, new ServiceArgs
+    var frontend = new Service(appName, new ServiceArgs
+    {
+        Metadata = new ObjectMetaArgs
         {
-            Metadata = new ObjectMetaArgs
+            Labels = deployment.Spec.Apply(spec =>
+                spec.Template.Metadata.Labels
+            ),
+        },
+        Spec = new ServiceSpecArgs
+        {
+            Type = isMinikube
+                ? "ClusterIP"
+                : "LoadBalancer",
+            Selector = appLabels,
+            Ports = new ServicePortArgs
             {
-                Labels = deployment.Spec.Apply(spec =>
-                    spec.Template.Metadata.Labels
-                ),
+                Port = 80,
+                TargetPort = 80,
+                Protocol = "TCP",
             },
-            Spec = new ServiceSpecArgs
-            {
-                Type = isMinikube
-                    ? "ClusterIP"
-                    : "LoadBalancer",
-                Selector = appLabels,
-                Ports = new ServicePortArgs
-                {
-                    Port = 80,
-                    TargetPort = 80,
-                    Protocol = "TCP",
-                },
-            }
+        }
+    });
+
+    var ip = isMinikube
+        ? frontend.Spec.Apply(spec => spec.ClusterIP)
+        : frontend.Status.Apply(status =>
+        {
+            var ingress = status.LoadBalancer.Ingress[0];
+            return ingress.Ip ?? ingress.Hostname;
         });
 
-        this.IP = isMinikube
-            ? frontend.Spec.Apply(spec => spec.ClusterIP)
-            : frontend.Status.Apply(status =>
-            {
-                var ingress = status.LoadBalancer.Ingress[0];
-                return ingress.Ip ?? ingress.Hostname;
-            });
-    }
-
-    [Output("ip")]
-    public Output<string> IP { get; set; }
-}
+    return new Dictionary<string, object?>
+    { 
+        ["ip"] = ip
+    };
+});
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/kubernetes/review-project.md
+++ b/themes/default/content/docs/get-started/kubernetes/review-project.md
@@ -173,63 +173,61 @@ func main() {
 
 ```csharp
 using Pulumi;
-using Pulumi.Kubernetes.Apps.V1;
 using Pulumi.Kubernetes.Types.Inputs.Core.V1;
 using Pulumi.Kubernetes.Types.Inputs.Apps.V1;
 using Pulumi.Kubernetes.Types.Inputs.Meta.V1;
+using System.Collections.Generic;
 
-class MyStack : Stack
+await Deployment.RunAsync(() =>
 {
-    public MyStack()
-    {
-        var appLabels = new InputMap<string>
-        {
-            { "app", "nginx" }
-        };
+    var appLabels = new InputMap<string> 
+    { 
+        { "app", "nginx" }
+    };
 
-        var deployment = new Pulumi.Kubernetes.Apps.V1.Deployment("nginx", new DeploymentArgs
-        {
-            Spec = new DeploymentSpecArgs
+    var deployment = new Pulumi.Kubernetes.Apps.V1.Deployment("nginx", new DeploymentArgs
+    {
+        Spec = new DeploymentSpecArgs
+        { 
+            Selector = new LabelSelectorArgs
             {
-                Selector = new LabelSelectorArgs
-                {
-                    MatchLabels = appLabels
+                MatchLabels = appLabels
+            },
+            Replicas = 1,
+            Template = new PodTemplateSpecArgs
+            { 
+                Metadata = new ObjectMetaArgs 
+                { 
+                    Labels = appLabels
                 },
-                Replicas = 1,
-                Template = new PodTemplateSpecArgs
+                Spec = new PodSpecArgs
                 {
-                    Metadata = new ObjectMetaArgs
+                    Containers =
                     {
-                        Labels = appLabels
-                    },
-                    Spec = new PodSpecArgs
-                    {
-                        Containers =
+                        new ContainerArgs
                         {
-                            new ContainerArgs
+                            Name = "nginx",
+                            Image = "nginx",
+                            Ports =
                             {
-                                Name = "nginx",
-                                Image = "nginx",
-                                Ports =
+                                new ContainerPortArgs
                                 {
-                                    new ContainerPortArgs
-                                    {
-                                        ContainerPortValue = 80
-                                    }
+                                    ContainerPortValue = 80
                                 }
                             }
                         }
                     }
-                }
+                }       
             }
-        });
+        }
+    });
 
-        this.Name = deployment.Metadata.Apply(m => m.Name);
-    }
-
-    [Output]
-    public Output<string> Name { get; set; }
-}
+    // export the deployment name
+    return new Dictionary<string, object?>
+    { 
+        ["name"] =  deployment.Metadata.Apply(m => m.Name)
+    };
+});
 ```
 
 {{% /choosable %}}

--- a/themes/default/layouts/shortcodes/langfile.html
+++ b/themes/default/layouts/shortcodes/langfile.html
@@ -4,9 +4,9 @@
     <pulumi-choosable type="language" value="typescript"><code>index.ts</code></pulumi-choosable>
     <pulumi-choosable type="language" value="python"><code>__main__.py</code></pulumi-choosable>
     <pulumi-choosable type="language" value="go"><code>main.go</code></pulumi-choosable>
-    <pulumi-choosable type="language" value="csharp"><code>MyStack.cs</code></pulumi-choosable>
+    <pulumi-choosable type="language" value="csharp"><code>Program.cs</code></pulumi-choosable>
     <pulumi-choosable type="language" value="fsharp"><code>Program.fs</code></pulumi-choosable>
-    <pulumi-choosable type="language" value="visualbasic"><code>MyStack.vb</code></pulumi-choosable>
+    <pulumi-choosable type="language" value="visualbasic"><code>Program.vb</code></pulumi-choosable>
     <pulumi-choosable type="language" value="java"><code>App.java</code></pulumi-choosable>
     <pulumi-choosable type="language" value="yaml"><code>Pulumi.yaml</code></pulumi-choosable>
 </pulumi-chooser>


### PR DESCRIPTION
This PR uses updates the getting started guides for dotnet/csharp which will use the new templates from [pulumi/templates#305](https://github.com/pulumi/templates/pull/305). Ideally, both PRs are to be merged at the same time but I would love to hear first whether more resources/docs need an update that might reference old templates