### PR TITLE
add devops days landing page

### DIFF
--- a/themes/default/content/devops-days-2022/_index.md
+++ b/themes/default/content/devops-days-2022/_index.md
@@ -1,0 +1,6 @@
+---
+title: DevOps Days
+meta_desc: Join Pulumi at the AWS Summit to learn about the latest developments in cloud engineering and get hands-on experience with the newest Pulumi features.
+type: page
+layout: devops-days-2022
+---

--- a/themes/default/content/devops-days-2022/_index.md
+++ b/themes/default/content/devops-days-2022/_index.md
@@ -1,6 +1,6 @@
 ---
 title: DevOps Days
-meta_desc: Join Pulumi at the AWS Summit to learn about the latest developments in cloud engineering and get hands-on experience with the newest Pulumi features.
+meta_desc: Join Pulumi at DevOps Days to learn about the latest developments in cloud engineering and get hands-on experience with the newest Pulumi features.
 type: page
 layout: devops-days-2022
 ---

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -52,9 +52,9 @@
                         </div>
                         <div class="description flex flex-col items-center">
                             <div class="my-1 flex flex-row">
-                                <img src="/images/prizes/t-shirt.png" alt="Pulumi T-Shirt" class="h-24 md:mx-4 my-4" />
-                                <img src="/images/prizes/cat-ears.png" alt="Pulumi cat ears" class="h-24 md:mx-4 my-4" />
-                                <img src="/images/prizes/backpack-hat-handsup.png" alt="Pulumi sticker" class="h-24 md:mx-4 my-4" />
+                                <img src="/images/swag/t-shirt.png" alt="Pulumi T-Shirt" class="h-24 md:mx-4 my-4" />
+                                <img src="/images/swag/cat-ears.png" alt="Pulumi cat ears" class="h-24 md:mx-4 my-4" />
+                                <img src="/images/swag/backpack-hat-handsup.png" alt="Pulumi sticker" class="h-24 md:mx-4 my-4" />
                             </div>
                             <p>*items vary by event and location</p>
                         </div>
@@ -75,7 +75,7 @@
                         </div>
                         <div class="card-cta-btn">
                             <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary">Seattle</a>
-                            <a href="" target="_blank" rel="noopener noreferrer" class="btn-primary">LA</a>
+                            <a href="" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
                         </div>
                     </div>
                 </div>

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -1,0 +1,125 @@
+{{ define "hero" }}
+    {{ partial "hero.html" (dict "title" .Params.title) }}
+{{ end }}
+
+{{ define "main" }}
+    <section id="ctas" class="container mx-auto my-16 text-center">
+        <h3>July 18 & 19 - Seattle and July 27 & 28 - Los Angeles</h3>
+        <h2>Interact with us at DevOps Days!</h2>
+        <div class="my-16">
+            <div class="lg:flex lg:flex-wrap justify-center items-stretch">
+                <div class="lg:w-1/2 px-3 py-6">
+                    <div class="card text-center p-6 relative h-full">
+                        <div class="icon-section">
+                            {{ partial "color-icon.html" (dict "icon" "code" "icon_color" "salmon") }}
+                        </div>
+                        <div>
+                            <h5>Want to meet with us?</h5>
+                        </div>
+                        <div class="description">
+                            <p>Meet with our team in-person at DevOps Days! Use the link below to schedule some time.</p>
+                        </div>
+                        <div class="card-cta-btn">
+                            <a href="{{ relref . "/contact.md" }}?form=sales" class="btn-primary">Meet with us</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="lg:w-1/2 px-3 py-6">
+                    <div class="card text-center p-6 relative h-full">
+                        <div class="icon-section">
+                            {{ partial "color-icon.html" (dict "icon" "rocketship" "icon_color" "violet") }}
+                        </div>
+                        <div>
+                            <h5>Join our workshop</h5>
+                        </div>
+                        <div class="description">
+                            <p>Register for our on-site workshop. Limited space available, so save your spot now.</p>
+                        </div>
+                        <div class="card-cta-btn">
+                            <a href="https://www.bigmarker.com/pulumi/Getting-Started-with-Infrastructure-as-Code-on-AWS-09a76d558a62e8b0b4ef52d0" class="btn-primary">Register</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="lg:w-1/2 px-3 py-6">
+                    <div class="card text-center p-6 relative h-full">
+                        <div class="icon-section">
+                            {{ partial "color-icon.html" (dict "icon" "team" "icon_color" "blue") }}
+                        </div>
+                        <div>
+                            <h5>Come by our booth for fun swag!</h5>
+                        </div>
+                        <div class="description flex flex-col items-center">
+                            <div class="my-1 flex flex-row">
+                                <img src="/images/prizes/t-shirt.png" alt="Pulumi T-Shirt" class="h-24 md:mx-4 my-4" />
+                                <img src="/images/prizes/cat-ears.png" alt="Pulumi cat ears" class="h-24 md:mx-4 my-4" />
+                                <img src="/images/prizes/backpack-hat-handsup.png" alt="Pulumi sticker" class="h-24 md:mx-4 my-4" />
+                            </div>
+                            <p>*items vary by event and location</p>
+                        </div>
+                        <div class="card-cta-btn">
+                            <!-- <a href="#" class="btn-primary"></a> -->
+                        </div>
+                    </div>
+                </div>
+
+                <div class="lg:w-1/2 px-3 py-6">
+                    <div class="card text-center p-6 relative">
+                        <div class="icon-section">
+                            {{ partial "color-icon.html" (dict "icon" "pen" "icon_color" "yellow") }}
+                        </div>
+                        <div>
+                            <h5>Register to attend!</h5>
+                            <p>Register to attend DevOps Days in Seattle and Los Angeles</p>
+                        </div>
+                        <div class="card-cta-btn">
+                            <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary">Seattle</a>
+                            <a href="" target="_blank" rel="noopener noreferrer" class="btn-primary">LA</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="learn-more" class="container mx-auto my-20">
+        <div class="max-w-3xl mx-auto">
+            <h2>Additional learning materials</h2>
+            <div class="text-base text-left mb-8 flex flex-row my-6">
+                <div class="card-cta-btn pr-4">
+                    <a href="https://www.pulumi.com/learn/" target="_blank" rel="noopener noreferrer" class="btn-secondary">Learn Pulumi</a>
+                </div>
+                <div class="card-cta-btn pr-4">
+                    <a href="https://www.pulumi.com/docs/get-started/aws/" target="_blank" rel="noopener noreferrer" class="btn-secondary">Get Started</a>
+                </div>
+                <div class="card-cta-btn pr-4">
+                    <a href="https://www.youtube.com/c/PulumiTV" target="_blank" rel="noopener noreferrer" class="btn-secondary">Pulumi TV</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <section id="hiring" class="container mx-auto my-16">
+        <div class="max-w-3xl mx-auto">
+            <h2>Join the team</h2>
+            <div class="text-base text-left mb-8">
+                <p>
+                    Pulumi is reinventing how people build modern cloud applications, with a unique platform that combines deep systems and infrastructure innovation with elegant
+                    programming models and developer tools.
+                </p>
+                <p>
+                    Our team is a diverse and talented group of individuals, with backgrounds in distributed cloud systems, programming languages, developer tools, and operating
+                    systems, from companies from all corners of the industry. Our culture is one of technical excellence, passion for teamwork, and customer obsession.
+                </p>
+                <p>
+                    While we have a fabulous office in downtown Seattle, Pulumi cares about the health, safety and happiness of our employees, and we've been a fully remote company
+                    since March, 2020. We've learned and grown as a company this year, and &mdash; unless otherwise specified &mdash; all of our open positions are remote. We will
+                    continue to collaborate and grow from different locations, and are committed to making sure our team is successful from their home offices.
+                </p>
+                <h3 class="mb-0">Open Positions</h3>
+                <pulumi-greenhouse-jobs-list></pulumi-greenhouse-jobs-list>
+            </div>
+        </div>
+    </section>
+{{ end }}

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -77,7 +77,7 @@
                             <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary"
                                 >Seattle</a
                             >
-                            <a href="http://www.socallinuxexpo.org/scale12x/devops-day-la.html" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
+                            <a href="https://www.socallinuxexpo.org/scale/19x/devops-day-la" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
                         </div>
                     </div>
                 </div>

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -74,7 +74,9 @@
                             <p>Register to attend DevOps Days in Seattle and Los Angeles</p>
                         </div>
                         <div class="card-cta-btn">
-                            <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary">Seattle</a>
+                            <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary"
+                                >Seattle</a
+                            >
                             <a href="" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
                         </div>
                     </div>

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -71,7 +71,7 @@
                         </div>
                         <div>
                             <h5>Register to attend!</h5>
-                            <p>Register to attend DevOps Days in Seattle and Los Angeles</p>
+                            <p>Register to attend DevOps Days in Seattle and Los Angeles.</p>
                         </div>
                         <div class="card-cta-btn">
                             <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary"

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -34,10 +34,10 @@
                             <h5>Join our workshop</h5>
                         </div>
                         <div class="description">
-                            <p>Register for our on-site workshop. Limited space available, so save your spot now.</p>
+                            <p>Join us at one of our upcoming workshops.</p>
                         </div>
                         <div class="card-cta-btn">
-                            <a href="https://www.bigmarker.com/pulumi/Getting-Started-with-Infrastructure-as-Code-on-AWS-09a76d558a62e8b0b4ef52d0" class="btn-primary">Register</a>
+                            <a href="{{ relref . "/resources" }}" class="btn-primary">View workshops</a>
                         </div>
                     </div>
                 </div>
@@ -77,7 +77,7 @@
                             <a href="https://www.eventbrite.com/e/devopsdays-seattle-2022-registration-313011494807" target="_blank" rel="noopener noreferrer" class="btn-primary"
                                 >Seattle</a
                             >
-                            <a href="" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
+                            <a href="http://www.socallinuxexpo.org/scale12x/devops-day-la.html" target="_blank" rel="noopener noreferrer" class="btn-primary">Los Angeles</a>
                         </div>
                     </div>
                 </div>

--- a/themes/default/layouts/page/devops-days-2022.html
+++ b/themes/default/layouts/page/devops-days-2022.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <section id="ctas" class="container mx-auto my-16 text-center">
-        <h3>July 18 & 19 - Seattle and July 27 & 28 - Los Angeles</h3>
+        <h3>July 19 & 20 - Seattle and July 29 - Los Angeles</h3>
         <h2>Interact with us at DevOps Days!</h2>
         <div class="my-16">
             <div class="lg:flex lg:flex-wrap justify-center items-stretch">


### PR DESCRIPTION
Issue: https://github.com/pulumi/marketing/issues/369

This PR adds the devops days landing page. Is there a registration link available for the Los Angeles event? I can't seem to find it on their site. Also, will there be any companion workshops to link to, or if not should we put something else in its place?