### PR TITLE
Update aws summit dates

### DIFF
--- a/themes/default/layouts/page/aws-summit-2022.html
+++ b/themes/default/layouts/page/aws-summit-2022.html
@@ -4,7 +4,7 @@
 
 {{ define "main" }}
     <section id="ctas" class="container mx-auto my-16 text-center">
-        <h3>July 19 - NYC and August 24 - Chicago</h3>
+        <h3>July 12 - NYC and August 25 - Chicago</h3>
         <h2>Interact with us at AWS Summit 2022!</h2>
         <div class="my-16">
             <div class="lg:flex lg:flex-wrap justify-center items-stretch">


### PR DESCRIPTION
Apparently the dates of the summit got changed while we working on this, this updates them to the new dates.