### PR TITLE
Name of environment variable was wrong in the example

### DIFF
--- a/themes/default/content/docs/reference/cli/environment-variables.md
+++ b/themes/default/content/docs/reference/cli/environment-variables.md
@@ -50,7 +50,7 @@ meta_desc: A list of different environment variables the Pulumi CLI supports.
         <p>
             <strong>This environment variable is ignored during normal Pulumi operations -- e.g., <code>up</code>, <code>preview</code>, etc.</strong>
         </p>
-        <pre><code class="text-xs">PULUMI_HOME="{'project:myTag':'val1','project:mySecret':'val2'}"</code></pre>
+        <pre><code class="text-xs">PULUMI_CONFIG="{'project:myTag':'val1','project:mySecret':'val2'}"</code></pre>
     </dd>
     <dt>
         <span class="font-mono">


### PR DESCRIPTION
The example for `PULUMI_CONFIG` environment variable uses `PULUMI_HOME` in the example.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>