### PR TITLE
Disable Prettier for HTML

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,4 @@ public
 yarn-error.log
 .hugo_build.lock
 *.md
+*.html

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -11,12 +11,6 @@
     "useTabs": false,
     "overrides": [
         {
-            "files": ["*.html"],
-            "options": {
-                "parser": "go-template"
-            }
-        },
-        {
             "files": ["*.yml", "*.yaml"],
             "options": {
                 "tabWidth": 2

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "sass": "^1.39.2"
     },
     "devDependencies": {
-        "prettier": "^2.6.2",
-        "prettier-plugin-go-template": "^0.0.13"
+        "prettier": "^2.6.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,13 +376,6 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-prettier-plugin-go-template@^0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.13.tgz#b4047bce76430bc89a8ee8f27fad1b1c14d942be"
-  integrity sha512-gG/xT5kd+kCzoMaTchXvdfBdsunyRCV6G8cgdPGPd2V5JGGKXUG7SjzBKU7jaGh2RTeblcAdBb/E+S/duOAMsA==
-  dependencies:
-    ulid "^2.3.0"
-
 prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
@@ -536,11 +529,6 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
-
-ulid@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.3.0.tgz#93063522771a9774121a84d126ecd3eb9804071f"
-  integrity sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==
 
 validate-npm-package-license@^3.0.1:
   version "3.0.4"


### PR DESCRIPTION
I love the idea of linting our HTML, but the plugin we're currently using for that (`prettier-plugin-go-template`) is more trouble than it's worth, so I'd like to remove it. 

Hopefully we can find a better replacement and switch HTML linting and auto-formatting back on. In the meantime, though, this plugin's not giving us enough value to be worth the hassle. I lose a lot of time to it myself, and I know others hit errors in PRs they can't decipher, too, which usually leads them to ping me for help, I have to step in to unblock them, they have to wait for subsequent checks to pass, etc., all because of random nits that none of us would actually care about in practice. All things considered, and since it's also leaving the code in a not-great state (see #1639), it seems reasonable to pull it out.

cc @kimberleyamackenzie 

Closes #1639.