### PR TITLE
Bring YAML spec up to date with Fn::ToJSON

### DIFF
--- a/themes/default/content/docs/reference/yaml/_index.md
+++ b/themes/default/content/docs/reference/yaml/_index.md
@@ -201,6 +201,20 @@ variables:
 
 The expression `${greeting}` will return `Hello, World!`
 
+##### `Fn::ToJSON`
+
+Converts a value into its JSON representation.
+
+```yaml
+variables:
+  item:
+    Fn::ToJSON:
+      key1: value1
+      key2: 123
+```
+
+The expression `${item}` will return a JSON value `{ "key1": "value1", "key2": 123 }`.
+
 ##### `Fn::Invoke`
 
 Calls a function from a package and returns either the whole object or a single key if given the "Return" property. The schema is:


### PR DESCRIPTION
This applies the change made since I moved the spec over (see https://github.com/pulumi/pulumi-yaml/commits/main/README.md). Until https://github.com/pulumi/pulumi-yaml/pull/261 is merged, the two docs must be kept synced by hand (or by automation that I have not developed :-).