### PR TITLE
Retarget YAML SDK link

### DIFF
--- a/themes/default/content/docs/reference/pulumi-sdk.md
+++ b/themes/default/content/docs/reference/pulumi-sdk.md
@@ -68,7 +68,7 @@ Choose your language runtime to view the API documentation for the Pulumi SDK:
         </a>
     </div>
     <div class="pb-4 md:w-1/2">
-        <a class="tile p-8 pb-16 text-center" href="https://github.com/pulumi/pulumi-yaml/#spec">
+        <a class="tile p-8 pb-16 text-center" href="/docs/reference/yaml/">
             <p class="mx-auto text-xl font-semibold link">
                 YAML
             </p>

--- a/themes/default/content/docs/reference/yaml/_index.md
+++ b/themes/default/content/docs/reference/yaml/_index.md
@@ -1,11 +1,7 @@
 ---
 title: Pulumi YAML Reference
-linktitle: Pulumi YAML
+linktitle: Pulumi YAML Reference
 meta_desc: Specification for the Pulumi YAML format and built-in functions
-menu:
-  reference:
-    name: Pulumi YAML
-    weight: 5
 ---
 
 Pulumi programs can be defined in many languages, and the Pulumi YAML dialect offers an additional language for authoring Pulumi programs.


### PR DESCRIPTION
- Retarget the link from the SDK page to the YAML spec, which is here as of https://github.com/pulumi/pulumi-hugo/pull/1665; and,
- Remove the implicit menu item, so https://github.com/pulumi/docs/pull/7764 doesn't result in an item in two different places in the navigation.
