### PR TITLE
General functions documentation

### DIFF
--- a/themes/default/content/docs/intro/concepts/resources/_index.md
+++ b/themes/default/content/docs/intro/concepts/resources/_index.md
@@ -154,3 +154,10 @@ The following topics provide more details on the core concepts for working with 
         <p>Learn how to configure stacks for different deployment scenarios.</p>
     </div>
 </div>
+
+<div class="md:flex flex-row mt-6 mb-6">
+    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="{{< relref "/docs/intro/concepts/resources/functions" >}}"><i class="fas fa-file-alt pr-2"></i>Provider Functions</a></h3>
+        <p>Learn how to use the functions included with Pulumi packages.</p>
+    </div>
+</div>

--- a/themes/default/content/docs/intro/concepts/resources/functions.md
+++ b/themes/default/content/docs/intro/concepts/resources/functions.md
@@ -7,7 +7,7 @@ menu:
     weight: 7
 ---
 
-A provider may make **functions** available in its SDK as well as resource types. For example, the AWS provider includes the function [`aws.apigateway.getDomainName`](https://www.pulumi.com/registry/packages/aws/api-docs/apigateway/getdomainname/), among many others.
+A provider may make **functions** available in its SDK as well as resource types. These "provider functions" are often for calling a platform API to get a value that is not part of a resource. For example, the AWS provider includes the function [`aws.apigateway.getDomainName`](https://www.pulumi.com/registry/packages/aws/api-docs/apigateway/getdomainname/):
 
 <div><pulumi-examples>
 <div><pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser></div>
@@ -133,10 +133,9 @@ Provider functions are exposed in each language as regular functions, in two var
 
 The documentation for a provider function will tell you the name and signature for each of the variations.
 
-### Invoke options
+#### Invoke options
 
-Each function also accepts "invoke options", either as an object or as varargs depending on the host
-language. The options are as follows:
+Each function and method also accepts "invoke options", either as an object or as varargs depending on the host language. The options are as follows:
 
 | Option | Explanation                                                  |
 |--------|--------------------------------------------------------------|
@@ -153,3 +152,66 @@ The `provider` option gives an explicit provider to use when running the invoked
 The `version` option specifies an exact version for the provider plugin. This can be used when you need to pin to a specific version to avoid a backward-incompatible change.
 
 The `pluginDownloadURL` option gives a URL for fetching the provider plugin. It may be necessary to supply this for third-party packages (those not hosted at [https://get.pulumi.com](https://get.pulumi.com)).
+
+### Provider methods
+
+Provider SDKs may also include methods attached to a resource type. For example, in the [EKS](https://www.pulumi.com/registry/packages/eks/api-docs/) SDK, the `Cluster` resource has a method [.GetKubeconfig](https://www.pulumi.com/registry/packages/eks/api-docs/cluster/#method_GetKubeconfig):
+
+<div><pulumi-examples>
+<div><pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser></div>
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+getKubeconfig(args?: Cluster.GetKubeconfigArgs): Output<Cluster.GetKubeconfigResult>
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+public Output<string> GetKubeconfig(Cluster.GetKubeconfigArgs? args)
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+func (r *Cluster) GetKubeconfig(ctx *Context, args *ClusterGetKubeconfigArgs) (pulumi.StringOutput, error)
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+def get_kubeconfig(self,
+                   profile_name: Optional[pulumi.Input[str]] = None,
+                   role_arn: Optional[pulumi.Input[str]] = None) -> Output[str]
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="java">
+
+(no example available for Java)
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+(no example available for YAML)
+
+</pulumi-choosable>
+</div>
+
+</pulumi-examples></div>
+
+Unlike provider functions, methods always take `Input` arguments, and return an `Output`. Methods do not have invoke options.

--- a/themes/default/content/docs/intro/concepts/resources/functions.md
+++ b/themes/default/content/docs/intro/concepts/resources/functions.md
@@ -1,0 +1,155 @@
+---
+title: "Provider Functions"
+meta_desc: Provider SDKs export functions that can be called in a Pulumi program
+menu:
+  intro:
+    parent: resources
+    weight: 7
+---
+
+A provider may make **functions** available in its SDK as well as resource types. For example, the AWS provider includes the function [`aws.apigateway.getDomainName`](https://www.pulumi.com/registry/packages/aws/api-docs/apigateway/getdomainname/), among many others.
+
+<div><pulumi-examples>
+<div><pulumi-chooser type="language" options="typescript,python,go,csharp,java,yaml"></pulumi-chooser></div>
+<div>
+<pulumi-choosable type="language" values="csharp">
+
+```csharp
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var example = Output.Create(Aws.ApiGateway.GetDomainName.InvokeAsync(new Aws.ApiGateway.GetDomainNameArgs
+        {
+            DomainName = "api.example.com",
+        }));
+    }
+}
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="go">
+
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/apigateway"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := apigateway.LookupDomainName(ctx, &apigateway.LookupDomainNameArgs{
+			DomainName: "api.example.com",
+		}, nil)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="java">
+
+```java
+package generated_program;
+
+import java.util.*;
+import java.io.*;
+import java.nio.*;
+import com.pulumi.*;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        final var example = Output.of(ApigatewayFunctions.getDomainName(GetDomainNameArgs.builder()
+            .domainName("api.example.com")
+            .build()));
+    }
+}
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="python">
+
+```python
+import pulumi
+import pulumi_aws as aws
+
+example = aws.apigateway.get_domain_name(domain_name="api.example.com")
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="typescript">
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const example = pulumi.output(aws.apigateway.getDomainName({
+    domainName: "api.example.com",
+}));
+```
+
+</pulumi-choosable>
+</div>
+<div>
+<pulumi-choosable type="language" values="yaml">
+
+```yaml
+variables:
+  example:
+    Fn::Invoke:
+      Function: aws:apigateway:getDomainName
+      Arguments:
+        domainName: api.example.com
+```
+
+</pulumi-choosable>
+</div>
+</pulumi-examples></div>
+
+Provider functions are exposed in each language as regular functions, in two variations:
+
+ 1. a function that accepts plain arguments (strings and so on) and returns a Promise, or blocks until the result is available; and,
+ 2. a function that accepts `Input` values and returns an [Output]({{< relref "/docs/intro/concepts/inputs-outputs" >}}).
+
+The documentation for a provider function will tell you the name and signature for each of the variations.
+
+### Invoke options
+
+Each function also accepts "invoke options", either as an object or as varargs depending on the host
+language. The options are as follows:
+
+| Option | Explanation                                                  |
+|--------|--------------------------------------------------------------|
+| parent | Supply a parent resource, which will be used to determine default providers |
+| provider | Supply the provider to use explicitly. |
+| version | Use exactly this version of the provider plugin. |
+| pluginDownloadURL | Download the provider plugin from this URL. The download URL is otherwise inferred from the provider package. |
+| _async_ | _This option is deprecated and will be removed in a future release_ |
+
+The `parent` option has a similar purpose to the [parent option]({{< relref "/docs/intro/concepts/resources/options/parent" >}}) used when creating a resource. The parent is consulted when determining the provider to use.
+
+The `provider` option gives an explicit provider to use when running the invoked function. This is useful, for example, if you want to invoke a function in each of a set of AWS regions.
+
+The `version` option specifies an exact version for the provider plugin. This can be used when you need to pin to a specific version to avoid a backward-incompatible change.
+
+The `pluginDownloadURL` option gives a URL for fetching the provider plugin. It may be necessary to supply this for third-party packages (those not hosted at [https://get.pulumi.com](https://get.pulumi.com)).


### PR DESCRIPTION
This turns the explanation of getter functions into a general explanation of provider functions, with a special case of getter functions.

I found it difficult to uncover the purpose of some of the InvokeOptions fields, and I suspect `version` and `pluginDownloadURL` in particular are more for plumbing than for end users, so I have been a little circumspect in places. Advice on improving those and any other bits is welcome!

Fixes #1628.