### PR TITLE
Update meta_desc for iac with yaml video

### DIFF
--- a/themes/default/content/resources/introduction-to-infrastructure-as-code-with-yaml/index.md
+++ b/themes/default/content/resources/introduction-to-infrastructure-as-code-with-yaml/index.md
@@ -1,7 +1,7 @@
 ---
 # Name of the webinar.
 title: "Introduction to Infrastructure as Code with Pulumi YAML"
-meta_desc: "In this workshop, you’re going to explore how to use Pulumi to build, configure, and deploy a real-life, modern application using Docker and YAML."
+meta_desc: "Learn how to use Infrastructure as Code (IaC) with Pulumi, using Docker, and YAML. This is an on-demand workshop. Source code available."
 
 # A featured webinar will display first in the list.
 featured: false


### PR DESCRIPTION
Update the meta description for the `/resources/introduction-to-infrastructure-as-code-with-yaml/` page. @SaraDPH asked to update the meta description for the  introduction to infrastructure as code with yaml workshop.

