### PR TITLE
Add pre-commit hook that formats code

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn prettier --write
+make format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn prettier --write

--- a/package.json
+++ b/package.json
@@ -12,7 +12,11 @@
         "sass": "^1.39.2"
     },
     "devDependencies": {
+        "husky": "^8.0.1",
         "prettier": "^2.6.2",
         "prettier-plugin-go-template": "^0.0.13"
+    },
+    "scripts": {
+        "prepare": "husky install"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -242,6 +242,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"


### PR DESCRIPTION
In the last frontend working group meeting, we discussed the challenge of mis-formatted code causing confusing errors for folks when their branches were pushed.  We decided that we'd try a pre-commit hook that automatically formats code with Prettier, and see if that resolved some of the difficulties.  