### PR TITLE
Include caveat on "simple" and "easy"

### DIFF
--- a/STYLE-GUIDE.md
+++ b/STYLE-GUIDE.md
@@ -15,6 +15,7 @@ Words are important. Pulumi strives to use language that is clear, harmonious, a
 * Avoid pop-culture references as such references may not be familiar to all readers.
 * Instead of "go to," use "navigate".
 * Avoid directional words. Instead, link directly to the section you are referencing.
+* Avoid using "easy", "simple" or their adjectives, as they make a judgment about the difficulty of a concept explained, or the level of a reader's subject matter expertise. Often, you can omit these words entirely.
 
 ## Headings
 


### PR DESCRIPTION
While we obviously want every Pulumi customer to have a wonderful experience with no trouble at all, the use of the words "simple" "easy" and their adjectives in our documentation can be alienating when folks run into trouble during a tutorial or Pulumi operation. What is easy to one person may be difficult for the next.