### PR TITLE
Document Java codegen options

### DIFF
--- a/themes/default/content/docs/guides/pulumi-packages/schema.md
+++ b/themes/default/content/docs/guides/pulumi-packages/schema.md
@@ -318,6 +318,16 @@ For `csharp`:
 | `rootNamespace`          | `string`      | No       | The root namespace that the generated package should live under. This setting defaults to "Pulumi". |
 | `respectSchemaVersion`   | `boolean`     | No       | Use the [`package.version`](#package) field in the generated SDK.                                   |
 
+For `java`:
+
+| Property       | Type          | Required | Description                                                                                      |
+|----------------|---------------|----------|--------------------------------------------------------------------------------------------------|
+| `packages`     | `map[string]` | No       | Overrides for module names to Java package names. Example: "autoscaling/v1" -> "autoscaling.v1". |
+| `basePackage`  | `string`      | No       | Prefixes the generated Java package. This setting defaults to "com.pulumi".                      |
+| `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Currently supported values: "gradle".           |
+| `dependencies` | `map[string]` | No       | Java dependencies to use with the `buildFiles`. Example: "com.pulumi.gcp" -> "6.23.0".           |
+
+
 ### PropertyLanguage
 
 Language-specific info for a property.

--- a/themes/default/content/docs/guides/pulumi-packages/schema.md
+++ b/themes/default/content/docs/guides/pulumi-packages/schema.md
@@ -327,7 +327,6 @@ For `java`:
 | `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Supported values: "gradle".           |
 | `dependencies` | `map[string]` | No       | Java dependencies to use with the `buildFiles`. Example: "com.pulumi.gcp" -> "6.23.0".           |
 
-
 ### PropertyLanguage
 
 Language-specific info for a property.

--- a/themes/default/content/docs/guides/pulumi-packages/schema.md
+++ b/themes/default/content/docs/guides/pulumi-packages/schema.md
@@ -324,7 +324,7 @@ For `java`:
 |----------------|---------------|----------|--------------------------------------------------------------------------------------------------|
 | `packages`     | `map[string]` | No       | Overrides for module names to Java package names. Example: "autoscaling/v1" -> "autoscaling.v1". |
 | `basePackage`  | `string`      | No       | Prefixes the generated Java package. This setting defaults to "com.pulumi".                      |
-| `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Supported values: "gradle".           |
+| `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Supported values: "gradle".                     |
 | `dependencies` | `map[string]` | No       | Java dependencies to use with the `buildFiles`. Example: "com.pulumi.gcp" -> "6.23.0".           |
 
 ### PropertyLanguage

--- a/themes/default/content/docs/guides/pulumi-packages/schema.md
+++ b/themes/default/content/docs/guides/pulumi-packages/schema.md
@@ -324,7 +324,7 @@ For `java`:
 |----------------|---------------|----------|--------------------------------------------------------------------------------------------------|
 | `packages`     | `map[string]` | No       | Overrides for module names to Java package names. Example: "autoscaling/v1" -> "autoscaling.v1". |
 | `basePackage`  | `string`      | No       | Prefixes the generated Java package. This setting defaults to "com.pulumi".                      |
-| `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Currently supported values: "gradle".           |
+| `buildFiles`   | `string`      | No       | Generates build files for the chosen build tool. Supported values: "gradle".           |
 | `dependencies` | `map[string]` | No       | Java dependencies to use with the `buildFiles`. Example: "com.pulumi.gcp" -> "6.23.0".           |
 
 


### PR DESCRIPTION
Fixes pulumi/pulumi-java#646

Source of truth is documented more in the doc strings for https://github.com/pulumi/pulumi-java/blob/main/pkg/codegen/java/package_info.go#L35 

I considered including a link here (possibly via sourcegraph) but decided against it.