### PR TITLE
add missing chooser to aws, azure, gcp deploy stack step

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-stack.md
+++ b/themes/default/content/docs/get-started/aws/deploy-stack.md
@@ -57,7 +57,7 @@ Duration: 14s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
-{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language javascript %}}
 

--- a/themes/default/content/docs/get-started/aws/deploy-stack.md
+++ b/themes/default/content/docs/get-started/aws/deploy-stack.md
@@ -57,6 +57,8 @@ Duration: 14s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+
 {{% choosable language javascript %}}
 
 ```bash

--- a/themes/default/content/docs/get-started/azure/deploy-stack.md
+++ b/themes/default/content/docs/get-started/azure/deploy-stack.md
@@ -59,6 +59,8 @@ Duration: 26s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the primary key of your bucket with the following command:
 
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+
 {{% choosable language typescript %}}
 
 ```bash

--- a/themes/default/content/docs/get-started/azure/deploy-stack.md
+++ b/themes/default/content/docs/get-started/azure/deploy-stack.md
@@ -59,7 +59,7 @@ Duration: 26s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the primary key of your bucket with the following command:
 
-{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language typescript %}}
 

--- a/themes/default/content/docs/get-started/gcp/deploy-stack.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-stack.md
@@ -56,6 +56,8 @@ Duration: 3s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+
 {{% choosable language javascript %}}
 
 ```bash

--- a/themes/default/content/docs/get-started/gcp/deploy-stack.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-stack.md
@@ -56,7 +56,7 @@ Duration: 3s
 
 Remember the output you defined in the previous step? That [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
-{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language javascript %}}
 


### PR DESCRIPTION
this came up in a recent study, and someone opened up an issue https://github.com/pulumi/pulumi-hugo/issues/1759
its not clear that this command can vary between languages because this was missing
this adds the chooser to reduce confusion

fixes  https://github.com/pulumi/pulumi-hugo/issues/1759