### PR TITLE
Revert "Remove Fn::StackReference doc"

### DIFF
--- a/themes/default/content/blog/shared-config-with-aws-systems-manager-parameter-store/index.md
+++ b/themes/default/content/blog/shared-config-with-aws-systems-manager-parameter-store/index.md
@@ -150,7 +150,7 @@ $ cd ../my-website
 $ pulumi new aws-yaml
 ```
 
-Once again, follow the prompts to create a new `dev` stack, then replace the contents of `Pulumi.yaml` with the program below. Here, we're fetching the names of the parameters being managed by `shared-config`, pulling their values from Systems Manager, and creating a one-page website to render those values in the browser. (Be sure to adjust the [`pulumi:pulumi:StackReference`](https://github.com/pulumi/pulumi-yaml#fnstackreference)s resource to point to your stack instead of mine.)
+Once again, follow the prompts to create a new `dev` stack, then replace the contents of `Pulumi.yaml` with the program below. Here, we're fetching the names of the parameters being managed by `shared-config`, pulling their values from Systems Manager, and creating a one-page website to render those values in the browser. (Be sure to adjust the [`Fn::StackReference`](https://github.com/pulumi/pulumi-yaml#fnstackreference)s to point to your stack instead of mine.)
 
 ```yaml
 name: my-website
@@ -159,8 +159,14 @@ runtime: yaml
 variables:
 
   # Get the names of the parameters we care about from the shared-config stack.
-  motd_param_ref: ${my-stack-reference.outputs["motd_param_name"]}
-  motd_secret_param_ref: ${my-stack-reference.outputs["motd_secret_param_name"]}
+  motd_param_ref:
+    Fn::StackReference:
+      - cnunciato/shared-config/dev  # <-- Change this.
+      - motd_param_name
+  motd_secret_param_ref:
+    Fn::StackReference:
+      - cnunciato/shared-config/dev  # <-- And this.
+      - motd_secret_param_name
 
   # Fetch (and decrypt) their values from Systems Manager.
   motd_param:
@@ -176,11 +182,6 @@ variables:
         withDecryption: true
 
 resources:
-  # Create the stack reference
-  my-stack-reference:
-    type: pulumi:pulumi:StackReference
-    properties:
-      name: cnunciato/shared-config/dev  # <-- Change this.
 
   # Create an S3 bucket and configure it as a website.
   my-bucket:

--- a/themes/default/content/docs/intro/concepts/stack.md
+++ b/themes/default/content/docs/intro/concepts/stack.md
@@ -449,14 +449,11 @@ var otherOutput = other.getOutput(Output.of("x"));
 {{% choosable language yaml %}}
 
 ```yaml
-resources:
-  my-stack-reference:
-    type: pulumi:pulumi:StackReference
-    properties:
-      name: acmecorp/infra/other
-
 variables:
-  stack_output: ${my-stack-reference.outputs["x"]}
+  otherOutput:
+    Fn::StackReference:
+      - acmecorp/infra/other
+      - x
 ```
 
 {{% /choosable %}}
@@ -670,12 +667,11 @@ public class App {
 
 ```yaml
 variables:
-  kubeConfig: ${my-stack-reference.outputs["KubeConfig"]}
+  cluster:
+    Fn::StackReference:
+      - mycompany/infra/${pulumi.stack}
+      - "KubeConfig"
 resources:
-  my-stack-reference:
-    type: pulumi:pulumi:StackReference
-    properties:
-      name: mycompany/infra/${pulumi.stack}
   provider:
     type: pulumi:providers:kubernetes
     properties:

--- a/themes/default/content/docs/reference/yaml/_index.md
+++ b/themes/default/content/docs/reference/yaml/_index.md
@@ -360,6 +360,18 @@ variables:
         Fn::FileArchive: ./folder
 ```
 
+##### `Fn::StackReference`
+
+[Stack References]({{< relref "/docs/intro/concepts/stack#stackreferences" >}}) allow accessing the outputs of a stack from a YAML program. Arguments are passed as a list, with the first item being the stack name and the second argument the name of an output to reference:
+
+```yaml
+variables:
+  reference:
+    Fn::StackReference:
+      - org/project/stack
+      - outputName
+```
+
 The expression `${reference}` will have the value of the `outputName` output from the stack `org/project/stack`.
 
 ##### `Fn::Secret`


### PR DESCRIPTION
Seeking to temporarily revert this, as we released docs before YAML support for this change.

Reverts pulumi/pulumi-hugo#1746
