### PR TITLE
add generated css bundle file to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 _vendor
 node_modules
 /resources
+/assets/css/bundle.css
 themes/*/resources
 public
 .idea


### PR DESCRIPTION
Prettier was taking ~7 minutes on this file during commits
```
yarn run v1.22.19
$ /Users/sarah/workspace/pulumi-hugo/node_modules/.bin/prettier --write .
.devcontainer/devcontainer.json 25ms
.github/workflows/pull-request-closed.yml 18ms
.github/workflows/pull-request.yml 5ms
.github/workflows/push.yml 4ms
.github/workflows/scheduled-cleanup.yml 3ms
.github/workflows/scheduled-upstream-sync.yaml 3ms
.prettierrc.json 3ms
assets/css/bundle.css 431030ms
assets/css/marketing.css 49ms
assets/js/bundle.js 1238ms
assets/js/marketing.js 1ms
```
^ an excerpt