### PR TITLE
fix: Adds Java and YAML language-specific shortcodes

### DIFF
--- a/themes/default/content/docs/support/troubleshooting.md
+++ b/themes/default/content/docs/support/troubleshooting.md
@@ -209,8 +209,7 @@ Resources:
 $
 ```
 
-If you have a system-wide proxy server running on your machine, it may be misconfigured. The [Pulumi architecture ](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/)
-has three different components, running as separate processes which talk to each other using a bidirectional gRPC protocol
+If you have a system-wide proxy server running on your machine, it may be misconfigured. The [Pulumi architecture](https://www.pulumi.com/docs/intro/concepts/how-pulumi-works/) has three different components, running as separate processes which talk to each other using a bidirectional gRPC protocol
 on IP address `127.0.0.1`. Your proxy server should be configured **NOT** to proxy
 these local network connections. Add both `127.0.0.1` and `localhost` to the exclusion list of your proxy server.
 

--- a/themes/default/layouts/shortcodes/pulumi-host.html
+++ b/themes/default/layouts/shortcodes/pulumi-host.html
@@ -1,7 +1,9 @@
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,java,yaml" option-style="none" class="inline">
     <pulumi-choosable type="language" value="javascript"> Node </pulumi-choosable>
     <pulumi-choosable type="language" value="typescript"> Node </pulumi-choosable>
     <pulumi-choosable type="language" value="python"> Python </pulumi-choosable>
     <pulumi-choosable type="language" value="go"> Go </pulumi-choosable>
     <pulumi-choosable type="language" value="csharp"> .NET </pulumi-choosable>
+    <pulumi-choosable type="language" value="java"> JVM </pulumi-choosable>
+    <pulumi-choosable type="language" value="yaml"> YAML </pulumi-choosable>
 </pulumi-chooser>

--- a/themes/default/layouts/shortcodes/pulumi-language.html
+++ b/themes/default/layouts/shortcodes/pulumi-language.html
@@ -1,7 +1,9 @@
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,java,yaml" option-style="none" class="inline">
     <pulumi-choosable type="language" value="javascript"> JavaScript </pulumi-choosable>
     <pulumi-choosable type="language" value="typescript"> TypeScript </pulumi-choosable>
     <pulumi-choosable type="language" value="python"> Python </pulumi-choosable>
     <pulumi-choosable type="language" value="go"> Go </pulumi-choosable>
     <pulumi-choosable type="language" value="csharp"> C# </pulumi-choosable>
+    <pulumi-choosable type="language" value="java"> Java </pulumi-choosable>
+    <pulumi-choosable type="language" value="yaml"> YAML </pulumi-choosable>
 </pulumi-chooser>


### PR DESCRIPTION
While working through some onboarding tasks, I ran into this bug:
![pulumidocsbug](https://user-images.githubusercontent.com/4128006/183648499-941df0b2-1101-460f-ab7d-904bc373a236.gif)

While selecting Java or YAML, the language names and language hosts would revert to `TypeScript` and would not recover without a refresh.  This PR adds those languages and corresponding runtimes.