### PR TITLE
Add lint script to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 make format
+make lint


### PR DESCRIPTION
Recently we added a pre-commit hook that runs `prettier` and in a recent blog post PR, I hit a lint error which failed my first build. This PR adds the lint script to the pre-commit hook so that folks will see the lint error before they push up to CI, hopefully saving folks time.