### PR TITLE
Add class for download button styling

### DIFF
--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -12,7 +12,7 @@
             <p class="text-center max-w-3xl leading-7">{{ .Params.hero.description | markdownify }}</p>
             <div class="overlay-middle mt-8 flex text-center justify-center items-center flex-col md:flex-row">
                 <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="{{ relref . "/docs/get-started" }}">{{ .Params.hero.cta_text }}</a>
-                <a class="btn-secondary px-12 py-4" href="{{ relref . "/docs/get-started/install" }}">Download</a>
+                <a class="home-hero-btn-secondary btn-secondary px-12 py-4" href="{{ relref . "/docs/get-started/install" }}">Download</a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
Part of https://github.com/pulumi/theme/pull/161

This PR adds a class that will correctly style the button when we disable the `important` flag in the Tailwind config.