### PR TITLE
Clarify Copy on Supported Py Version

### DIFF
--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -12,7 +12,7 @@ aliases: ["/docs/reference/python/"]
 
 <img src="/logos/tech/logo-python.svg" align="right" width="150" style="padding:8px; margin-top: -64px">
 
-Pulumi supports programs written in Python 3. Python version 3.6 or later is required.
+Pulumi supports programs written in Python 3.6 or later.
 
 {{< install-python >}}
 


### PR DESCRIPTION
This PR clarifies some unclear language around the minimum supported Python version.
As it was written, I can't imagine how we would support Python 3.x < 3.6.