### PR TITLE
Explicitly set GCP Project via `pulumi config`

### DIFF
--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -1,9 +1,10 @@
 When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and then [authorize access with a user
-account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). If `gcloud` is not configured to interact with your Google Cloud project, set it with the
-`config` command using the project's ID:
+account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). 
+
+Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials:
 
 <div class="highlight">
-    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>gcloud config set project your-gcp-project-id</code></pre>
+    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>gcloud auth application-default login</code></pre>
     <div class="copy-button-container">
         <pulumi-tooltip
             ><span class="tooltip-target"
@@ -13,10 +14,10 @@ account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_a
     </div>
 </div>
 
-Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials:
+To configure Pulumi to interact with your Google Cloud project, set it with the `config` command using the project's ID:
 
 <div class="highlight">
-    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>gcloud auth application-default login</code></pre>
+    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>pulumi config set gcp:project your-gcp-project-id</code></pre>
     <div class="copy-button-container">
         <pulumi-tooltip
             ><span class="tooltip-target"

--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -26,7 +26,14 @@ To configure Pulumi to interact with your Google Cloud project, set it with the 
     </div>
 </div>
 
-You may also set your GCP Project via environment variable (listed in order of precedence): - `GOOGLE_PROJECT` - `GOOGLE_CLOUD_PROJECT` - `GCLOUD_PROJECT` - `CLOUDSDK_CORE_PROJECT`
+You may also set your GCP Project via environment variable (listed in order of precedence):
+
+<ul>
+    <li>`GOOGLE_PROJECT`</li>
+    <li>`GOOGLE_CLOUD_PROJECT`</li>
+    <li>`GCLOUD_PROJECT`</li>
+    <li>`CLOUDSDK_CORE_PROJECT`</li>
+</ul>
 
 <div class="highlight">
     <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>$ export GOOGLE_PROJECT=your-gcp-project-id</code></pre>

--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -29,14 +29,14 @@ To configure Pulumi to interact with your Google Cloud project, set it with the 
 You may also set your GCP Project via environment variable (listed in order of precedence):
 
 <ul>
-    <li>`GOOGLE_PROJECT`</li>
-    <li>`GOOGLE_CLOUD_PROJECT`</li>
-    <li>`GCLOUD_PROJECT`</li>
-    <li>`CLOUDSDK_CORE_PROJECT`</li>
+    <li><code class="language-bash" data-lang="bash">GOOGLE_PROJECT</code></li>
+    <li><code class="language-bash" data-lang="bash">GOOGLE_CLOUD_PROJECT</code></li>
+    <li><code class="language-bash" data-lang="bash">GCLOUD_PROJECT</code></li>
+    <li><code class="language-bash" data-lang="bash">CLOUDSDK_CORE_PROJECT</code></li>
 </ul>
 
 <div class="highlight">
-    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>$ export GOOGLE_PROJECT=your-gcp-project-id</code></pre>
+    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>export GOOGLE_PROJECT=your-gcp-project-id</code></pre>
     <div class="copy-button-container">
         <pulumi-tooltip
             ><span class="tooltip-target"

--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -14,10 +14,28 @@ Next, Pulumi requires default application credentials to interact with your Goog
     </div>
 </div>
 
-To configure Pulumi to interact with your Google Cloud project, set it with the `config` command using the project's ID:
+To configure Pulumi to interact with your Google Cloud project, set it with the `pulumi config` command using the project's ID:
 
 <div class="highlight">
     <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>pulumi config set gcp:project your-gcp-project-id</code></pre>
+    <div class="copy-button-container">
+        <pulumi-tooltip
+            ><span class="tooltip-target"
+                ><button class="copy-button"><i class="far fa-copy copy text-xl"></i></button></span
+            ><span class="tooltip-content" role="tooltip"><span slot="content">Copy</span></span></pulumi-tooltip
+        >
+    </div>
+</div>
+
+You may also set your GCP Project via environment variable (listed in order of precedence):
+
+- `GOOGLE_PROJECT`
+- `GOOGLE_CLOUD_PROJECT`
+- `GCLOUD_PROJECT`
+- `CLOUDSDK_CORE_PROJECT`
+
+<div class="highlight">
+    <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>$ export GOOGLE_PROJECT=your-gcp-project-id</code></pre>
     <div class="copy-button-container">
         <pulumi-tooltip
             ><span class="tooltip-target"

--- a/themes/default/layouts/shortcodes/configure-gcp.html
+++ b/themes/default/layouts/shortcodes/configure-gcp.html
@@ -1,7 +1,6 @@
 When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and then [authorize access with a user
-account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). 
-
-Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials:
+account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account). Next, Pulumi requires default application credentials to interact with your Google Cloud
+resources, so run `auth application-default login` command to obtain those credentials:
 
 <div class="highlight">
     <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>gcloud auth application-default login</code></pre>
@@ -27,12 +26,7 @@ To configure Pulumi to interact with your Google Cloud project, set it with the 
     </div>
 </div>
 
-You may also set your GCP Project via environment variable (listed in order of precedence):
-
-- `GOOGLE_PROJECT`
-- `GOOGLE_CLOUD_PROJECT`
-- `GCLOUD_PROJECT`
-- `CLOUDSDK_CORE_PROJECT`
+You may also set your GCP Project via environment variable (listed in order of precedence): - `GOOGLE_PROJECT` - `GOOGLE_CLOUD_PROJECT` - `GCLOUD_PROJECT` - `CLOUDSDK_CORE_PROJECT`
 
 <div class="highlight">
     <pre class="chroma"><code class="language-bash" data-lang="bash"><span class="no-select">$ </span>$ export GOOGLE_PROJECT=your-gcp-project-id</code></pre>


### PR DESCRIPTION
We don't, at least in pulumi-gcp, use gcloud config, so we need to ask people to set Project the Pulumi way.