### PR TITLE
Change pull-request.yaml to run on ubuntu-latest

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}/go
     name: Build and deploy preview
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
Ubuntu 18 had a scheduled brownout that caused the workflow not to run. I've never experienced this with other workflows (all of which use `ubuntu-latest`). If we're intentionally using a pinned version of Ubuntu, please refuse this PR, let me know why, and I'll submit another PR to comment as to why we're using v18 and under what conditions we can upgrade.