### PR TITLE
fix pulumi service docs nav order

### DIFF
--- a/themes/default/content/docs/intro/pulumi-service/audit-logs.md
+++ b/themes/default/content/docs/intro/pulumi-service/audit-logs.md
@@ -4,7 +4,7 @@ meta_desc: "This is a guide on how to audit your organization's infrastructure a
 menu:
   intro:
     parent: pulumi-service
-    weight: 8
+    weight: 9
 aliases:
 - /docs/intro/console/collaboration/auditing/
 - /docs/intro/console/auditing/

--- a/themes/default/content/docs/intro/pulumi-service/billing-managers.md
+++ b/themes/default/content/docs/intro/pulumi-service/billing-managers.md
@@ -4,7 +4,7 @@ meta_desc: Overview of Billing Managers in the Pulumi Service.
 menu:
   intro:
     parent: pulumi-service
-    weight: 11
+    weight: 4
 ---
 
 The Billing Manager role gives customers the ability to have someone in their Pulumi Organization manage billing operations without granting them any additional permissions to view or modify your stacks, policies, or other organizational settings.

--- a/themes/default/content/docs/intro/pulumi-service/ci-cd-integration-assistant.md
+++ b/themes/default/content/docs/intro/pulumi-service/ci-cd-integration-assistant.md
@@ -4,7 +4,7 @@ meta_desc: An overview of the CI/CD integration assistant in the Pulumi Service.
 menu:
   intro:
     parent: pulumi-service
-    weight: 7
+    weight: 8
 aliases:
 - /docs/intro/console/extensions/
 - /docs/intro/console/extensions/ci-cd-integration-assistant/

--- a/themes/default/content/docs/intro/pulumi-service/organization-access-tokens.md
+++ b/themes/default/content/docs/intro/pulumi-service/organization-access-tokens.md
@@ -4,7 +4,7 @@ meta_desc: Overview of Organization Access Tokens in the Pulumi Service.
 menu:
   intro:
     parent: pulumi-service
-    weight: 2
+    weight: 3
 ---
 
 Organization Access Tokens provide Enterprise and Business Critical customers the opportunity to manage resources and stack operations for their organization independent of a single-user account.

--- a/themes/default/content/docs/intro/pulumi-service/projects-and-stacks.md
+++ b/themes/default/content/docs/intro/pulumi-service/projects-and-stacks.md
@@ -4,7 +4,7 @@ meta_desc: An overivew of Project and Stack Management within the Pulumi Cloud S
 menu:
   intro:
     parent: pulumi-service
-    weight: 4
+    weight: 7
 aliases:
 - /docs/intro/console/project-and-stack-management/
 - /docs/reference/service/roles-and-access-controls/

--- a/themes/default/content/docs/intro/pulumi-service/pulumi-button.md
+++ b/themes/default/content/docs/intro/pulumi-service/pulumi-button.md
@@ -5,7 +5,7 @@ meta_desc: An overview of how to use the "Deploy with Pulumi" button to easily
 menu:
   intro:
     parent: pulumi-service
-    weight: 10
+    weight: 11
 aliases:
  - /docs/reference/service/pulumi-button/
  - /docs/console/extensions/pulumi-button/

--- a/themes/default/content/docs/intro/pulumi-service/team-access-tokens.md
+++ b/themes/default/content/docs/intro/pulumi-service/team-access-tokens.md
@@ -4,7 +4,7 @@ meta_desc: Overview of Team Access Tokens in the Pulumi Service.
 menu:
   intro:
     parent: pulumi-service
-    weight: 2
+    weight: 6
 ---
 {{% notes "info" %}}
 Team Access Tokens are only available to organizations using Pulumi Enterprise or Pulumi Business Critical.

--- a/themes/default/content/docs/intro/pulumi-service/teams.md
+++ b/themes/default/content/docs/intro/pulumi-service/teams.md
@@ -4,7 +4,7 @@ meta_desc: An overview of role-based access control (RBAC) using teams within th
 menu:
   intro:
     parent: pulumi-service
-    weight: 6
+    weight: 5
 aliases:
 - /docs/reference/service/teams/
 - /docs/console/collaboration/teams/

--- a/themes/default/content/docs/intro/pulumi-service/webhooks.md
+++ b/themes/default/content/docs/intro/pulumi-service/webhooks.md
@@ -4,7 +4,7 @@ meta_desc: An overview of how to use Webhooks within the Pulumi Cloud Service.
 menu:
   intro:
     parent: pulumi-service
-    weight: 9
+    weight: 10
 aliases:
 - /docs/reference/service/webhooks/
 - /docs/console/extensions/webhooks/


### PR DESCRIPTION
## overview
we are starting to collect some ux debt on the service docs, this attempts to organize things in a logical order that our users may be able to better understand.

i started this convo in [internal slack](https://pulumi.slack.com/archives/C8A7QG1CZ/p1661217840351789)

i will mention that i have usability concerns that we have token information spread out across 3 separate docs pages, and that we have role information spread out across 3 separate docs pages as well. this requires folks to read all these pages to understand how these things work together. for now, though im trying to do the smallest change to reduce some usability issues.

super open to feedback on the order!!

## before
<img width="291" alt="before-nav" src="https://user-images.githubusercontent.com/5489125/188505632-1b9ff312-58d8-43a2-accf-dbe7e90228b4.png">

## after
<img width="257" alt="after-nav" src="https://user-images.githubusercontent.com/5489125/188505638-b075916c-bdef-4a30-a12d-ae5d2ba3d992.png">
