### PR TITLE
fix misleading template config mention

### DIFF
--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -101,7 +101,7 @@ New Python projects created with `pulumi new` have this option set by default. I
 | Name | Required | Description |
 | - | - | - |
 | `description` | optional | Description of the template. |
-| `config` | required | Config to apply to each stack in the project. |
+| `config` | required | Config to request when using this template with `pulumi new`. |
 
 #### `config` options
 


### PR DESCRIPTION
fixes #1906 

the config option for templates only asks for that config when this template is used as part of `pulumi new`. it does not auto-apply this config for all stacks within a project.

I've tried a pass at more clear words, also open to removing this from the docs. not sure whats best.

this came from a issue report over in pulumi/pulumi: https://github.com/pulumi/pulumi/issues/10581