### PR TITLE
Fix a syntax issue in the resource options docs

### DIFF
--- a/themes/default/content/docs/intro/concepts/resources/options/dependson.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/dependson.md
@@ -78,7 +78,8 @@ resources:
   res2:
     type: MyResource
     options:
-      dependsOn: ${res1}
+      dependsOn: 
+        - ${res1}
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/intro/concepts/resources/options/dependson.md
+++ b/themes/default/content/docs/intro/concepts/resources/options/dependson.md
@@ -78,7 +78,7 @@ resources:
   res2:
     type: MyResource
     options:
-      dependsOn: 
+      dependsOn:
         - ${res1}
 ```
 


### PR DESCRIPTION
When I use the syntax currently quoted in the docs, I get an error:

```
error: Error registering resource [record]: Pulumi.yaml:119,18-32: resource option dependsOn value must be a list of resources;
```

This seems to be what's needed. 