### PR TITLE
Document the `nodeargs` runtime option in Pulumi.yaml

### DIFF
--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -71,9 +71,14 @@ The runtime attribute has an additional property called options where you can fu
 | Name | Use case | Description |
 | - | - | - |
 | `typescript` | Only applicable for the nodejs runtime | Boolean indicating whether to use `ts-node` or not. |
+| `nodeargs` | Only applicable for the nodejs runtime | Arguments to pass to `node`. |
 | `binary` | Applicable for the go, .net, and java runtimes | Path to pre-built executable. |
 | `virtualenv` | Ony applicable for the python runtime | Virtual environment path. |
 | `compiler` | Only applicable for YAML projects | Executable and arguments that emit to standard out. |
+
+#### About `nodeargs`
+
+Arguments specified here are passed to `node` when running the Pulumi program. For example, `nodeargs: "--trace-warnings"` will result in `node` being invoked as `node --trace-warnings`.
 
 #### About `binary`
 


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/8655 added support for a `nodeargs` runtime option for Node.js projects, but we never explicitly documented it. This PR does that.