### PR TITLE
fix css filename in startup challenge

### DIFF
--- a/themes/default/content/challenge/startup-in-a-box.md
+++ b/themes/default/content/challenge/startup-in-a-box.md
@@ -104,7 +104,7 @@ fs.readdirSync(staticWebsiteDirectory).forEach((file) => {
 });
 ```
 
-We need our actual website too, though. Create a directory called `website` at `pulumi-challenge/website`, and inside it, add `index.html`, `styles.css`, and `normalize.css`.
+We need our actual website too, though. Create a directory called `website` at `pulumi-challenge/website`, and inside it, add `index.html`, `style.css`, and `normalize.css`.
 
 For `index.html`, we have the structure of a simple website, with places to put links to your project's GitHub and Twitter, as well as your LinkedIn:
 


### PR DESCRIPTION
noticed that we ask folks to name this file `styles.css` but then in later content (including the html file) we use `style.css` so if folks copy directly the css wont actually work.

if anyone prefers that i keep this line as styles and change the other 2 lines to styles, happy to do so, let me know