### PR TITLE
Add Templates to the Learn menu

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -301,6 +301,15 @@
                                         </li>
                                         <li>
                                             <div class="list-title">
+                                                <a href="{{ relref . "/templates" }}">
+                                                    <i class="fas fa-project-diagram fa-fw"></i>
+                                                    Templates
+                                                    <div class="list-sub-title">Deploy common architectures on any cloud</div>
+                                                </a>
+                                            </div>
+                                        </li>
+                                        <li>
+                                            <div class="list-title">
                                                 <a href="{{ relref . "/learn" }}">
                                                     <i class="fas fa-chalkboard-teacher fa-fw"></i>
                                                     Learn Pulumi
@@ -394,6 +403,7 @@
                             <li class="mobile-menu-item"><a href="#">Learn</a></li>
                             <li class="mobile-menu-subitem"><a href="{{ relref . "/blog" }}">Blog</a></li>
                             <li class="mobile-menu-subitem"><a href="{{ relref . "/learn" }}">Learn Pulumi</a></li>
+                            <li class="mobile-menu-subitem"><a href="{{ relref . "/templates" }}">Templates</a></li>
                             <li class="mobile-menu-subitem"><a href="{{ relref . "/resources" }}">Resources</a></li>
                             <li class="mobile-menu-subitem"><a href="{{ relref . "/resources#upcoming" }}">Workshops</a></li>
                             <li class="mobile-menu-subitem"><a href="{{ relref . "/learn/glossary" }}">Cloud Engineering Glossary</a></li>


### PR DESCRIPTION
Adds a link to the Templates section in the Learn menu of the main nav. A few notes:

- I chose the `project-diagram` icon because it was the closest thing I could find to an architecture diagram, but open to alternative suggestions if anyone has one!
- For the subhead, the most important words are probably "deploy" (also to align with verbs in other subheads) and "common architectures", but open to suggestions on this as well.
- I chose this placement because I want to make sure Learn has more prominence, and to me, that right side (Blog, etc.) still seems more prominent than the left -- but again, open to discussion!