### PR TITLE
Update home page slot machine component

### DIFF
--- a/themes/default/content/_index.md
+++ b/themes/default/content/_index.md
@@ -15,7 +15,7 @@ overview:
   logos:
     languages:
       - /logos/tech/typescript.svg
-      - /logos/tech/dot-net.svg
+      - /logos/tech/dotnet.svg
       - /logos/tech/go.svg
       - /logos/tech/java.svg
       - /logos/tech/yaml.svg

--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -60,45 +60,53 @@
 {{ define "main" }}
     {{ $pageContext := . }}
 
-
-    <section class="container mx-auto mt-12">
-        <div class="flex flex-col lg:flex-row h-full">
-            <div class="w-full lg:w-1/2 mt-16 lg:mt-0 h-full flex items-center justify-center relative overflow-hidden">
-                <div class="slot-machine-overlay">
-                    <div class="overlay-top"></div>
-                    <div class="overlay-middle flex justify-center items-center">
-                        <div class="w-1/6 hidden lg:block"><object class="m-auto" data="/images/home/plus.svg"></object></div>
-                        <div class="w-1/6"></div>
-                        <div class="w-1/6 hidden lg:block"><object class="m-auto" data="/images/home/plus.svg"></object></div>
-                    </div>
-                    <div class="overlay-end"></div>
+    <section class="bg-violet-200">
+        <div class="container mx-auto py-6">
+            <div class="flex flex-wrap justify-center align-center">
+                <div class="w-full lg:w-1/2 text-center lg:text-left">
+                    <h4>Universal Infrastructure as Code</h4>
+                    <p>Every cloud, every language, every architecture, every builder</p>
                 </div>
-                <pulumi-slot-machine
-                    image-class="h-20"
-                    left-images="{{ delimit .Params.overview.logos.clouds "," }}"
-                    center-images="{{ delimit .Params.overview.logos.languages "," }}"
-                    right-images="{{ delimit .Params.overview.logos.identity "," }}"
-                >
-                </pulumi-slot-machine>
-            </div>
 
-            <div class="w-full lg:w-1/2 order-first lg:order-last h-full flex flex-col justify-center items-center">
-                <div class="w-8/12 text-center">
-                    <h2>
-                        {{ index (.Params.overview.title) 0 }}<br />
-                        {{ index (.Params.overview.title) 1 }}<br />
-                        {{ index (.Params.overview.title) 2 }}
-                    </h2>
-                    <p class="text-lg">{{ .Params.overview.description | markdownify }}</p>
-                    <div class="mt-16">
-                        {{ partial "cta/primary-get-started" . }}
-                    </div>
+                <div class="w-full lg:w-1/2 mt-4">
+                    <home-slots
+                        image-class="h-16 mx-auto"
+                        left-items="{{ delimit .Params.overview.logos.clouds "," }}"
+                        center-items="{{ delimit .Params.overview.logos.languages "," }}"
+                        right-items="{{ delimit .Params.overview.logos.identity "," }}"
+                    ></home-slots>
                 </div>
             </div>
         </div>
     </section>
 
-    <section class="mb-8 mt-12 lg:my-32 px-6 lg:px-0 relative">
+    <!-- Benefits -->
+    <section class="container mx-auto my-12 lg:my-24 relative">
+        <h2 class="text-center">{{ .Params.benefits.title }}</h2>
+        <div class="benefits-section relative">
+            <div class="shape-background home-benefits-section">
+                <div class="shape-container">
+                    <div class="circle-left"></div>
+                    <div class="circle-right"></div>
+                </div>
+            </div>
+            {{ range $item := .Params.benefits.items }}
+                <div class="benefits-item card z-10 bg-white">
+                    <div class="icon-section">
+                        {{ partial "color-icon.html" (dict "icon" $item.icon "icon_color" $item.icon_color) }}
+                    </div>
+                    <div>
+                        <h5>{{ $item.title }}</h5>
+                    </div>
+                    <div class="description">
+                        <p>{{ $item.description | markdownify }}</p>
+                    </div>
+                </div>
+            {{ end }}
+        </div>
+    </section>
+
+    <section class="mb-8 mt-12 lg:mt-0 lg:mb-24 px-6 lg:px-0 relative">
         <div class="shape-background home-build-section">
             <div class="shape-container">
                 <div class="circle-left"></div>
@@ -109,7 +117,7 @@
 
         <div class="container mx-auto">
             <div class="flex flex-col lg:flex-row">
-                <div class="w-full lg:w-1/2 lg:mr-32 z-10 bg-white px-8 rounded">
+                <div class="w-full lg:w-1/2 lg:mr-32 z-10 px-8 rounded">
                     <h2>{{ .Params.build.title }}</h2>
                     <p class="text-lg">{{ .Params.build.description | markdownify }}</p>
 
@@ -231,32 +239,6 @@
             <div class="w-full lg:w-1/2 flex items-center justify-center mt-12 lg:mt-0">
                 <img class="rounded-xl shadow-2xl" src="/images/home/pulumi-console.svg" alt="Pulumi Service" />
             </div>
-        </div>
-    </section>
-
-    <!-- Benefits -->
-    <section class="container mx-auto my-12 lg:my-12 relative">
-        <h2 class="text-center">{{ .Params.benefits.title }}</h2>
-        <div class="benefits-section relative">
-            <div class="shape-background home-benefits-section">
-                <div class="shape-container">
-                    <div class="circle-left"></div>
-                    <div class="circle-right"></div>
-                </div>
-            </div>
-            {{ range $item := .Params.benefits.items }}
-                <div class="benefits-item card z-10 bg-white">
-                    <div class="icon-section">
-                        {{ partial "color-icon.html" (dict "icon" $item.icon "icon_color" $item.icon_color) }}
-                    </div>
-                    <div>
-                        <h5>{{ $item.title }}</h5>
-                    </div>
-                    <div class="description">
-                        <p>{{ $item.description | markdownify }}</p>
-                    </div>
-                </div>
-            {{ end }}
         </div>
     </section>
 

--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -60,6 +60,7 @@
 {{ define "main" }}
     {{ $pageContext := . }}
 
+
     <section class="bg-violet-200">
         <div class="container mx-auto py-6">
             <div class="flex flex-wrap justify-center align-center">


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-hugo/issues/822
Part of https://github.com/pulumi/marketing/issues/416

This PR updates the home page slow machine component based on the new mockup. I also moved up the benefits section because it looked weird having the code example present twice so quickly.

Note: There is follow up PR in `theme` to randomize the order of slot items on each page load: https://github.com/pulumi/theme/pull/258