### PR TITLE
Change the Templates icon

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -302,7 +302,9 @@
                                         <li>
                                             <div class="list-title">
                                                 <a href="{{ relref . "/templates" }}">
-                                                    <i class="fas fa-project-diagram fa-fw"></i>
+                                                    <span class="px-1">
+                                                        <img src="/icons/ruler-triangle.svg" class="inline" />
+                                                    </span>
                                                     Templates
                                                     <div class="list-sub-title">Deploy common architectures on any cloud</div>
                                                 </a>

--- a/themes/default/static/icons/ruler-triangle.svg
+++ b/themes/default/static/icons/ruler-triangle.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1_3)">
+<path d="M13.66 13.66L12.6 14.72L11.89 14.01L12.95 12.95L11.01 11.01L9.95 12.07L9.24 11.36L10.3 10.3L8.36 8.36L7.3 9.42L6.59 8.71L7.65 7.65L5.7 5.7L4.64 6.76L3.93 6.05L4.99 4.99L3.05 3.05L1.99 4.11L1.28 3.4L2.34 2.34L0 0V14C0 15.1 0.9 16 2 16H16L13.66 13.66ZM3 13V7.24L8.76 13H3Z" fill="#4C5566"/>
+</g>
+<defs>
+<clipPath id="clip0_1_3">
+<rect width="16" height="16" fill="currentColor"/>
+</clipPath>
+</defs>
+</svg>


### PR DESCRIPTION
Uses a drafting triangle for the Templates icon instead. Follow-up from #1939, [convo](https://pulumi.slack.com/archives/C01E2KK808G/p1663178101821909) for context.