### PR TITLE
Add Azure, GCP static-website template pages

### DIFF
--- a/themes/default/content/templates/static-website/aws/index.md
+++ b/themes/default/content/templates/static-website/aws/index.md
@@ -66,7 +66,7 @@ $ pulumi new static-website-aws-yaml
 
 {{% /choosable %}}
 
-Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
+Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 
 ## Deploying the project
 
@@ -213,7 +213,7 @@ Templated projects are meant to be customized, and every web project comes with 
 
 ### Adding a custom domain
 
-Once your website is deployed on AWS, there's a good chance you'll want to give it a domain of its own. For this, you have many options, and they generally fall into one of two categories: using [Amazon Route 53](https://aws.amazon.com/route53/), which is a good choice if your domain is already being managed on AWS, or using a third-party service like [DNSimple](https://dnsimple.com) or [Google Cloud DNS](https://cloud.google.com/dns/). Both options are easily managed with Pulumi.
+Once your website is deployed on AWS, you may want to give it a domain of its own. For this, you have many options, and they generally fall into one of two categories: using [Amazon Route 53](https://aws.amazon.com/route53/), which is a good choice if your domain is already being managed on AWS, or using a third-party service like [DNSimple](https://dnsimple.com) or [Google Cloud DNS](https://cloud.google.com/dns/). Both options are easily managed with Pulumi.
 
 #### Using a Route 53 managed domain
 
@@ -784,7 +784,7 @@ Pulumi supports many third-party DNS providers, all of which are available in th
 
 Integration details vary by provider, so we suggest exploring the Pulumi API documentation of your provider of choice to learn more. [See the Registry]({{< relref "/registry" >}}) for a complete list supported providers.
 
-### Cleaning up
+## Tidying up
 
 You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`]({{< relref "/docs/reference/cli/pulumi_destroy" >}}):
 

--- a/themes/default/content/templates/static-website/azure/index.md
+++ b/themes/default/content/templates/static-website/azure/index.md
@@ -9,12 +9,15 @@ template:
 cloud:
     name: Microsoft Azure
     slug: azure
-draft: true
 ---
 
-The Azure Static Website template deploys an HTML website on Microsoft Azure.
+The Azure Static Website template deploys an HTML website on Microsoft Azure. It uses an [Azure Blob Storage account]({{< relref "/registry/packages/azure-native/api-docs/storage/storageaccount" >}}) for file storage, configures the storage account to host a website, and deploys an [Azure CDN Endpoint]({{< relref "/registry/packages/azure-native/api-docs/cdn/endpoint" >}}) to serve the website with low latency, caching, and HTTPS. The template generates a complete Pulumi program, including placeholder web content, to give you a working project out of the box that you can customize easily and extend to suit your needs.
 
 ![An architecture diagram of the Pulumi Azure Static Website template](./architecture.png)
+
+## Using this template
+
+To use this template to deploy a website of your own, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Azure credentials]({{< relref "/registry/packages/azure-native/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
 {{% chooser language "typescript,python,go,csharp,yaml" / %}}
 
@@ -62,3 +65,74 @@ $ pulumi new static-website-azure-yaml
 ```
 
 {{% /choosable %}}
+
+Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
+
+## Deploying the project
+
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`]({{< relref "/docs/reference/cli/pulumi_up" >}}):
+
+```bash
+$ pulumi up
+```
+
+When the deployment completes, Pulumi exports the following [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) values:
+
+originHostname
+: The provider-assigned hostname of the Azure Blob Storage container.
+
+originURL
+: The fully-qualified HTTP URL of the storage container endpoint.
+
+cdnHostname
+: The provider-assigned hostname of the Azure CDN. Useful for creating `CNAME` records to associate custom domains.
+
+cdnURL
+: The fully-qualified HTTPS URL of the Azure CDN.
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `cdnURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+```bash
+$ open $(pulumi stack output cdnURL)
+```
+
+## Customizing the project
+
+Projects created with the Static Website template expose the following [configuration]({{< relref "/docs/intro/concepts/config" >}}) settings:
+
+path
+: The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
+
+indexDocument
+: The file to use for top-level pages. Defaults to `index.html`.
+
+errorDocument
+: The file to use for error pages. Defaults to `error.html`.
+
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`]({{< relref "/docs/reference/cli/pulumi_config_set" >}}) as shown below.
+
+### Using your own web content
+
+If you already have a static website you'd like to deploy on Azure with Pulumi, you can do so either by replacing placeholder content in the `www` folder or by configuring the stack to point to another folder on your computer with the `path` setting:
+
+```bash
+$ pulumi config set path ../my-existing-website/build
+$ pulumi up
+```
+
+## Tidying up
+
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`]({{< relref "/docs/reference/cli/pulumi_destroy" >}}):
+
+```bash
+$ pulumi destroy
+```
+
+## Learn more
+
+Congratulations! You're now well on your way to managing a production-grade static website on Microsoft Azure with Pulumi --- and there's lots more you can do from here:
+
+* Discover more architecture templates as they're available in [Templates &rarr;]({{< relref "/templates" >}})
+* Dive into the Azure Native package by exploring the [API docs in the Registry &rarr;]({{< relref "/registry/packages/azure-native" >}})
+* Expand your understanding of how Pulumi works in [Architecture &amp; Concepts &rarr;]({{< relref "/docs/intro/concepts" >}})
+* Read up on the latest new features [in the Pulumi Blog &rarr;]({{< relref "/blog" >}})

--- a/themes/default/content/templates/static-website/gcp/index.md
+++ b/themes/default/content/templates/static-website/gcp/index.md
@@ -9,12 +9,15 @@ template:
 cloud:
     name: Google Cloud Platform
     slug: gcp
-draft: true
 ---
 
-The Google Cloud Static Website template deploys an HTML website on Google Cloud Platform.
+The Google Cloud Static Website template deploys an HTML website on Google Cloud Platform. It uses a [Cloud Storage bucket]({{< relref "/registry/packages/gcp/api-docs/storage/bucket" >}}) for file storage, configures the storage account to host a website, and provisions a [Global Address]({{< relref "/registry/packages/gcp/api-docs/compute/globaladdress" >}}) to route traffic to the CDN for lower latency and caching. The template generates a complete Pulumi program, including placeholder web content, to give you a working project out of the box that you can customize easily and extend to suit your needs.
 
 ![An architecture diagram of the Pulumi Google Cloud Static Website template](./architecture.png)
+
+## Using this template
+
+To use this template to deploy a website of your own, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Google Cloud credentials]({{< relref "/registry/packages/gcp/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
 {{% chooser language "typescript,python,go,csharp,yaml" / %}}
 
@@ -62,3 +65,74 @@ $ pulumi new static-website-gcp-yaml
 ```
 
 {{% /choosable %}}
+
+Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
+
+## Deploying the project
+
+The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`]({{< relref "/docs/reference/cli/pulumi_up" >}}):
+
+```bash
+$ pulumi up
+```
+
+When the deployment completes, Pulumi exports the following [stack output]({{< relref "/docs/intro/concepts/stack#outputs" >}}) values:
+
+originHostname
+: The provider-assigned hostname of the Azure Blob Storage container.
+
+originURL
+: The fully-qualified HTTP URL of the storage container endpoint.
+
+cdnHostname
+: The provider-assigned hostname of the Azure CDN. Useful for creating `CNAME` records to associate custom domains.
+
+cdnURL
+: The fully-qualified HTTPS URL of the Azure CDN.
+
+Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `cdnURL`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+
+```bash
+$ open $(pulumi stack output cdnURL)
+```
+
+## Customizing the project
+
+Projects created with the Static Website template expose the following [configuration]({{< relref "/docs/intro/concepts/config" >}}) settings:
+
+path
+: The path to the folder containing the files of the website. Defaults to `www`, which is the name (and relative path) of the folder included with the template.
+
+indexDocument
+: The file to use for top-level pages. Defaults to `index.html`.
+
+errorDocument
+: The file to use for error pages. Defaults to `error.html`.
+
+All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`]({{< relref "/docs/reference/cli/pulumi_config_set" >}}) as shown below.
+
+### Using your own web content
+
+If you already have a static website you'd like to deploy on AWS with Pulumi, you can do so either by replacing placeholder content in the `www` folder or by configuring the stack to point to another folder on your computer with the `path` setting:
+
+```bash
+$ pulumi config set path ../my-existing-website/build
+$ pulumi up
+```
+
+## Tidying up
+
+You can cleanly destroy the stack and all of its infrastructure with [`pulumi destroy`]({{< relref "/docs/reference/cli/pulumi_destroy" >}}):
+
+```bash
+$ pulumi destroy
+```
+
+## Learn more
+
+Congratulations! You're now well on your way to managing a production-grade static website on AWS with Pulumi --- and there's lots more you can do from here:
+
+* Discover more architecture templates as they're available in [Templates &rarr;]({{< relref "/templates" >}})
+* Dive into the Google Cloud package by exploring the [API docs in the Registry &rarr;]({{< relref "/registry/packages/gcp" >}})
+* Expand your understanding of how Pulumi works in [Architecture &amp; Concepts &rarr;]({{< relref "/docs/intro/concepts" >}})
+* Read up on the latest new features [in the Pulumi Blog &rarr;]({{< relref "/blog" >}})


### PR DESCRIPTION
Adds Static Website pages for Azure and GCP. As discussed, this initial version leaves out Next Steps sections; our plan is to circle back and add these sections later, once we've finished the first round of template pages.