### PR TITLE
Use full height for cards

### DIFF
--- a/themes/default/layouts/templates/overview.html
+++ b/themes/default/layouts/templates/overview.html
@@ -15,8 +15,8 @@
             <ul class="w-full md:flex md:flex-wrap lg:max-w-6xl mx-auto lg:justify-center p-0 list-none">
                 {{ range $page := .Page.CurrentSection.Pages }}
                     <li class="md:w-1/2 lg:w-1/3">
-                        <div class="px-4 py-2 w-full">
-                            <div class="shadow-xl rounded-xl bg-white p-4">
+                        <div class="px-4 py-2 w-full h-full">
+                            <div class="shadow-xl rounded-xl bg-white p-4 h-full">
                                 {{ with $page }}
                                     {{ if .Params.meta_image }}
                                         <a class="text-gray-900" href="{{ .RelPermalink }}">

--- a/themes/default/layouts/templates/section.html
+++ b/themes/default/layouts/templates/section.html
@@ -16,7 +16,7 @@
             <ul class="w-full flex flex-col md:flex-row md:flex-wrap md:justify-center p-0 list-none">
                 {{ range $page := sort $pages ".Params.weight" "asc" }}
                     <li class="md:w-1/2 lg:w-1/3 m-4">
-                        <div class="shadow-xl rounded-xl bg-white p-6 w-full">
+                        <div class="shadow-xl rounded-xl bg-white p-6 w-full h-full">
                             {{ with $page }}
                                 {{ if .Params.meta_image }}
                                     <a href="{{ relref . $page.RelPermalink }}" title="{{ .Title }}">


### PR DESCRIPTION
Little fix to make sure cards with wrapping content stay aligned horizontally.

Before:

![image](https://user-images.githubusercontent.com/274700/190760171-e7051bb0-0806-421d-8ff6-0b9e246b022c.png)

After:

![image](https://user-images.githubusercontent.com/274700/190757774-275880a6-d248-43b4-947d-95aca06575d6.png)
