### PR TITLE
Move links out of the header area

### DIFF
--- a/themes/default/content/templates/static-website/_index.md
+++ b/themes/default/content/templates/static-website/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Static Website Templates
 layout: overview
-description: Pulumi program templates are the fastest way to deploy static websites on [AWS](/aws), [Azure](/azure), or [Google Cloud Platform](/gcp). Templates come with predefined [infrastructure as code](/what-is/what-is-infrastructure-as-code) so you can get started instantly.
+description: Pulumi program templates are the fastest way to deploy static websites on AWS, Azure, or Google Cloud Platform. Templates come with predefined infrastructure as code so you can get started instantly.
 meta_desc: Pulumi program templates that make it easy to deploy static websites on AWS, Azure, or Google Cloud Platform.
 meta_image: meta.png
 weight: 1
@@ -12,15 +12,15 @@ weight: 1
 
 Static websites are an efficient and scalable way of building and serving websites created with HTML, CSS, and JavaScript. Popular frameworks for static websites include Next.js, Hugo, Gatsby, Jekyll, and more.
 
-**On AWS,** you can host a static website by configuring Amazon S3 for hosting and Amazon CloudFront as the CDN. You could also use AWS Amplify, which is designed for deploying static websites more easily.
+**On [AWS]({{< relref "/partner/aws" >}}),** you can host a static website by configuring Amazon S3 for hosting and Amazon CloudFront as the CDN. You could also use AWS Amplify, which is designed for deploying static websites more easily.
 
-**On Azure,** you can host a static website by configuring Azure Blob Storage for hosting and Azure CDN for content delivery. You could also use Azure Static Web Apps, which provides a CI/CD pipeline for deploying static websites.
+**On [Azure]({{< relref "/partner/azure" >}}),** you can host a static website by configuring Azure Blob Storage for hosting and Azure CDN for content delivery. You could also use Azure Static Web Apps, which provides a CI/CD pipeline for deploying static websites.
 
-**On Google Cloud Platform,** you can host a static website by configuring Cloud Storage for hosting and Cloud Load Balancing with HTTPS configured.
+**On [Google Cloud Platform]({{< relref "/partner/gcp" >}}),** you can host a static website by configuring Cloud Storage for hosting and Cloud Load Balancing with HTTPS configured.
 
 ### Building and deploying static websites on AWS, Azure, and Google Cloud
 
-Infrastructure as code is an efficient and repeatable way of building a static website with programming languages and deploying the website to your preferred cloud.
+[Infrastructure as code]({{< relref "/what-is/what-is-infrastructure-as-code" >}}) is an efficient and repeatable way of building a static website with programming languages and deploying the website to your preferred cloud.
 
 Pulumi’s open source, infrastructure as code SDK lets you build and deploy static websites with TypeScript/JavaScript, Python, Go, Java, .NET, and YAML. The main benefits include:
 


### PR DESCRIPTION
Looking closer at the content at the top of this page:

![image](https://user-images.githubusercontent.com/274700/190832684-ee50c5d4-f832-4cfe-997b-8cd5500a83e1.png)

... I'd like to propose that we pull the links to AWS, Azure, etc., out of the header area and into the body of the page instead, for a couple of reasons:

* Right now this reads as though clicking "AWS" may lead me to more information about how to "deploy a static website on AWS", which isn't the case.
* In general, links that pull users away from the page should be limited to the lower 2/3 or so of the page. (We have a note about this [in our style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md#content-design) in fact, which I believe was originally suggested by @SaraDPH.)

I know these links are meant to encourage traffic to the pages they link to, so I don't  want to lose that -- I'd just prefer they weren’t so prominent. Moving them down a bit seems an okay trade-off SEO-wise. The main thing I'm interested in is just making sure we aren't directing people away from the content they're most likely here for (and that we want them to engage with).