### PR TITLE
Fix links for GCP template

### DIFF
--- a/themes/default/content/templates/static-website/gcp/index.md
+++ b/themes/default/content/templates/static-website/gcp/index.md
@@ -5,7 +5,7 @@ meta_image: meta.png
 card_desc: Deploy a static website on Google Cloud with Pulumi, Google Cloud Storage, and Google Cloud CDN.
 layout: template
 template:
-    prefix: static-website-google-cloud
+    prefix: static-website-gcp
 cloud:
     name: Google Cloud Platform
     slug: gcp


### PR DESCRIPTION
This prefix is used to build the source-code links in the right-hand nav. Should be “gcp”, not “google-cloud”.