### PR TITLE
Fix documentation for the Pulumi.yaml `refresh` option

### DIFF
--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -97,9 +97,9 @@ New Python projects created with `pulumi new` have this option set by default. I
 
 ### `options` options
 
-| Name | Required | Description | Default |
-| - | - | - | - |
-| `refresh` | optional | Boolean indicating whether to refresh the state before performing a Pulumi operation. | `true` |
+| Name | Required | Description |
+| - | - | - |
+| `refresh` | optional | Set to `always` to refresh the state before performing a Pulumi operation. |
 
 ### `template` options
 


### PR DESCRIPTION
It's not a boolean, it's a string that should be set to `always` to turn on the functionality.

Related to https://github.com/pulumi/pulumi/issues/10824