### PR TITLE
Fix typo in file name for build chooser

### DIFF
--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -139,7 +139,7 @@
                         </pulumi-choosable>
 
                         <pulumi-choosable type="language" class="highlight" value="csharp">
-                            <img src="/images/home/csharp.svg" alt="" />
+                            <img src="/images/home/c-sharp.svg" alt="" />
                         </pulumi-choosable>
 
                         <pulumi-choosable type="language" class="highlight" value="java">


### PR DESCRIPTION
The C# image was missing in the Build section of the home. This PR fixes the file name so it is there.