### PR TITLE
Add some space above the headings on template overview cards

### DIFF
--- a/themes/default/layouts/templates/overview.html
+++ b/themes/default/layouts/templates/overview.html
@@ -18,14 +18,14 @@
                 {{ range $page := .Page.CurrentSection.Pages }}
                     <li class="md:w-1/2 lg:w-1/3">
                         <div class="px-4 py-2 w-full h-full">
-                            <div class="shadow-xl rounded-xl bg-white p-4 h-full">
+                            <div class="shadow-xl rounded-xl bg-white py-4 px-6 h-full border border-gray-200">
                                 {{ with $page }}
                                     {{ if .Params.meta_image }}
                                         <a class="text-gray-900" href="{{ .RelPermalink }}">
-                                            <img class="rounded-t" src="{{ (.Resources.GetMatch .Params.meta_image).RelPermalink }}" alt="{{ .Title }}" />
+                                            <img class="rounded" src="{{ (.Resources.GetMatch .Params.meta_image).RelPermalink }}" alt="{{ .Title }}" />
                                         </a>
                                     {{ end }}
-                                    <h2 class="mt-0">
+                                    <h2 class="mt-4">
                                         <span class="text-2xl">
                                             <a class="text-gray-900" href="{{ .RelPermalink }}">{{ .Title }}</a>
                                         </span>

--- a/themes/default/layouts/templates/section.html
+++ b/themes/default/layouts/templates/section.html
@@ -18,14 +18,14 @@
             <ul class="w-full flex flex-col md:flex-row md:flex-wrap md:justify-center p-0 list-none">
                 {{ range $page := sort $pages ".Params.weight" "asc" }}
                     <li class="md:w-1/2 lg:w-1/3 m-4">
-                        <div class="shadow-xl rounded-xl bg-white p-6 w-full h-full">
+                        <div class="shadow-xl rounded-xl bg-white py-4 px-6 w-full h-full border border-gray-200">
                             {{ with $page }}
                                 {{ if .Params.meta_image }}
                                     <a href="{{ relref . $page.RelPermalink }}" title="{{ .Title }}">
-                                        <img class="rounded-t" src="{{ (.Resources.GetMatch .Params.meta_image).RelPermalink }}" alt="{{ .Title }}" />
+                                        <img class="rounded" src="{{ (.Resources.GetMatch .Params.meta_image).RelPermalink }}" alt="{{ .Title }}" />
                                     </a>
                                 {{ end }}
-                                <h2 class="mt-6">
+                                <h2 class="mt-4">
                                     <span class="text-2xl">
                                         <a class="text-gray-900" href="{{ relref . $page.RelPermalink }}">{{ .Title }}</a>
                                     </span>


### PR DESCRIPTION
Makes padding consistent on the section and overview pages and adds a one-pixel border around cards for definition. (We do this also in Registry.) 

![image](https://user-images.githubusercontent.com/274700/192040216-35d4fea6-ef9e-47f0-8d96-1a9dc1509873.png)
