### PR TITLE
Update pulumi-yaml.md to include the `buildTarget` option.

### DIFF
--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -72,8 +72,8 @@ The runtime attribute has an additional property called options where you can fu
 | - | - | - |
 | `typescript` | Only applicable for the nodejs runtime | Boolean indicating whether to use `ts-node` or not. |
 | `nodeargs` | Only applicable for the nodejs runtime | Arguments to pass to `node`. |
-| `binary` | Applicable for the go, .net, and java runtimes | Path to pre-built executable. |
 | `buildTarget` | Only applicable for the go runtime | Path to save the compiled go binary to. |
+| `binary` | Applicable for the go, .net, and java runtimes | Path to pre-built executable. |
 | `virtualenv` | Ony applicable for the python runtime | Virtual environment path. |
 | `compiler` | Only applicable for YAML projects | Executable and arguments that emit to standard out. |
 

--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -84,12 +84,13 @@ Arguments specified here are passed to `node` when running the Pulumi program. F
 #### About `buildTarget`
 
 - For Go
-  - if specified, go sources in `$CWD` will be compiled via `go build` to the specified path before being run.
-  - if unspecified, go sources in `$CWD` will be compiled via `go build` to a temporary executable that is deleted after running.
+  - If specified, go sources in `$CWD` will be compiled via `go build` to the specified path before being run.
+  - If unspecified, go sources in `$CWD` will be compiled via `go build` to a temporary executable that is deleted after running.
+  - Cannot be specified with the `binary` runtime option.
 
 #### About `binary`
 
-- For Go, cannot be specified with the `buildTarget` `runtime` option.
+- For Go, cannot be specified with the `buildTarget` runtime option.
 - For .NET, if not specified, a .NET project in `$CWD` will be invoked via `dotnet run`.
 
 #### About `virtualenv`

--- a/themes/default/content/docs/reference/pulumi-yaml.md
+++ b/themes/default/content/docs/reference/pulumi-yaml.md
@@ -73,6 +73,7 @@ The runtime attribute has an additional property called options where you can fu
 | `typescript` | Only applicable for the nodejs runtime | Boolean indicating whether to use `ts-node` or not. |
 | `nodeargs` | Only applicable for the nodejs runtime | Arguments to pass to `node`. |
 | `binary` | Applicable for the go, .net, and java runtimes | Path to pre-built executable. |
+| `buildTarget` | Only applicable for the go runtime | Path to save the compiled go binary to. |
 | `virtualenv` | Ony applicable for the python runtime | Virtual environment path. |
 | `compiler` | Only applicable for YAML projects | Executable and arguments that emit to standard out. |
 
@@ -80,9 +81,15 @@ The runtime attribute has an additional property called options where you can fu
 
 Arguments specified here are passed to `node` when running the Pulumi program. For example, `nodeargs: "--trace-warnings"` will result in `node` being invoked as `node --trace-warnings`.
 
+#### About `buildTarget`
+
+- For Go
+  - if specified, go sources in `$CWD` will be compiled via `go build` to the specified path before being run.
+  - if unspecified, go sources in `$CWD` will be compiled via `go build` to a temporary executable that is deleted after running.
+
 #### About `binary`
 
-- For Go, if not specified, go sources in `$CWD` will be invoked via `go run`.
+- For Go, cannot be specified with the `buildTarget` `runtime` option.
 - For .NET, if not specified, a .NET project in `$CWD` will be invoked via `dotnet run`.
 
 #### About `virtualenv`


### PR DESCRIPTION
- Update pulumi-yaml.md to include the `buildTarget` option.
- Also updates the `binary` option for go to be up to date with internal details.

https://github.com/pulumi/pulumi/issues/10473