### PR TITLE
List languages in template frontmatter

### DIFF
--- a/themes/default/archetypes/templates/template/index.md
+++ b/themes/default/archetypes/templates/template/index.md
@@ -5,21 +5,28 @@ layout: template
 # Make sure this is description accurate for this template.
 meta_desc: The {{ replace .Name "-" " " | title }} template makes it easy to deploy a static website on $CLOUD with Pulumi, some service, and some other cloud service.
 
+# Be sure to replace this image. Figma source file:
+# https://www.figma.com/file/lGrSpwbGGmbixEuewMbtkh/Template-Architecture-Diagrams?node-id=15%3A196
+meta_image: meta.png
+
 # Appears on the cards on template-overview pages.
 card_desc: Deploy a $THING on $CLOUD with Pulumi, some cloud service, and some other cloud service.
 
-# Used for generating language-specific links to templates on GitHub. (Example: `static-website-aws`)
+# Used for generating language-specific CLI commands and links to the templates repo on GitHub.
 template:
-    prefix: architecture-cloud
+  prefix: architecture-cloud
+  dirname: my-project
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 
 # Used for generating links to sibling templates in the right-hand nav. Slug is this template's parent directory.
 cloud:
   name: Amazon Web Services
   slug: aws
-
-# Be sure to replace this image. Figma source file:
-# https://www.figma.com/file/lGrSpwbGGmbixEuewMbtkh/Template-Architecture-Diagrams?node-id=15%3A196
-meta_image: meta.png
 
 # The content below is meant help you get started and to serve as a guide to work by. Feel free to adjust it needed for your template.
 ---

--- a/themes/default/content/templates/container-service/_index.md
+++ b/themes/default/content/templates/container-service/_index.md
@@ -4,8 +4,6 @@ layout: overview
 description: Pulumi program templates are the fastest way to deploy container services on AWS, Azure, or Google Cloud Platform. Templates come with predefined infrastructure as code so you can get started instantly.
 meta_desc: Pulumi program templates that make it easy to deploy container services on AWS, Azure, or Google Cloud Platform.
 meta_image: meta.png
-template:
-    prefix: container-aws
 weight: 1
 ---
 

--- a/themes/default/content/templates/container-service/aws/index.md
+++ b/themes/default/content/templates/container-service/aws/index.md
@@ -1,11 +1,18 @@
 ---
 title: Container Service on AWS
+layout: template
 meta_desc: The Container Service template makes it easy to deploy a container service on AWS with Pulumi and Amazon Elastic Container Service (ECS).
 meta_image: meta.png
 card_desc: Deploy a container service on AWS with Pulumi and Amazon ECS.
-layout: template
 template:
-    prefix: container-aws
+  prefix: container-aws
+  dirname: my-container-service
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -19,52 +26,7 @@ The Container Service template creates an infrastructure as code project in your
 
 To use this template to deploy an ECS cluster that's running your container service, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your AWS credentials]({{< relref "/registry/packages/aws/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-container-service && cd my-container-service
-$ pulumi new container-aws-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-container-service && cd my-container-service
-$ pulumi new container-aws-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-container-service && cd my-container-service
-$ pulumi new container-aws-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-container-service && cd my-container-service
-$ pulumi new container-aws-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-container-service && cd my-container-service
-$ pulumi new container-aws-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/kubernetes/aws/index.md
+++ b/themes/default/content/templates/kubernetes/aws/index.md
@@ -1,27 +1,20 @@
 ---
 title: "Kubernetes Cluster on AWS"
 layout: template
-
-# Make sure this is description accurate for this template.
 meta_desc: The AWS Kubernetes template makes it easy to deploy a Kubernetes cluster on AWS with Pulumi and Amazon EKS.
-
-# Appears on the cards on template-overview pages.
+meta_image: meta.png
 card_desc: Deploy a Kubernetes cluster on AWS with Pulumi and Amazon EKS.
-
-# Used for generating language-specific links to templates on GitHub. (Example: `static-website-aws`)
 template:
-    prefix: kubernetes-aws
-
-# Used for generating links to sibling templates in the right-hand nav. Slug is this template's parent directory.
+  prefix: kubernetes-aws
+  dirname: my-k8s-cluster
+  languages:
+    - typescript
+    - python
+    - go
+    - yaml
 cloud:
   name: Amazon Web Services
   slug: aws
-
-# Be sure to replace this image. Figma source file:
-# https://www.figma.com/file/lGrSpwbGGmbixEuewMbtkh/Template-Architecture-Diagrams?node-id=15%3A196
-meta_image: meta.png
-
-# The content below is meant help you get started and to serve as a guide to work by. Feel free to adjust it needed for your template.
 ---
 
 The AWS Kubernetes Cluster template creates an infrastructure as code project in your favorite language and deploys a managed Kubernetes cluster to AWS. The architecture includes a VPC with public and private subnets and deploys an [Amazon EKS cluster]({{< relref "/registry/packages/eks/api-docs/cluster" >}}) that provides a managed Kubernetes control plane. Kubernetes worker nodes are deployed on private subnets for improved security. Load balancers created by workloads deployed on the EKS cluster will be automatically created in the public subnets. The template generates a complete infrastructure as code program to give you a working project out of the box that you can customize easily and extend to suit your needs.
@@ -32,52 +25,7 @@ The AWS Kubernetes Cluster template creates an infrastructure as code project in
 
 To use this template to deploy your own managed Kubernetes cluster, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your AWS credentials]({{< relref "/registry/packages/aws/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-k8s-cluster && cd my-k8s-cluster
-$ pulumi new kubernetes-aws-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-k8s-cluster && cd my-k8s-cluster
-$ pulumi new kubernetes-aws-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-k8s-cluster && my-k8s-cluster
-$ pulumi new kubernetes-aws-go
-```
-
-<!-- {{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-k8s-cluster && cd my-k8s-cluster
-$ pulumi new kubernetes-aws-csharp
-``` -->
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-k8s-cluster && cd my-k8s-cluster
-$ pulumi new kubernetes-aws-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/serverless-application/aws/index.md
+++ b/themes/default/content/templates/serverless-application/aws/index.md
@@ -1,14 +1,21 @@
 ---
 title: AWS Serverless Application
+layout: template
 meta_desc: The AWS Serverless Application template makes it easy to deploy a serverless application on AWS with Pulumi, AWS Lambda functions, and Amazon API Gateway.
 meta_image: meta.png
 card_desc: Deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway.
-layout: template
+template:
+  prefix: serverless-aws
+  dirname: my-serverless-app
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
   name: Amazon Web Services (AWS)
   slug: aws
-template:
-    prefix: serverless-aws
 ---
 
 The AWS Serverless Application template deploys a serverless website to AWS that displays the current time. It deploys an [Amazon S3 bucket]({{< relref "/registry/packages/aws/api-docs/s3/bucket" >}}) for hosting a static website, deploys an [AWS Lambda function]({{< relref "/registry/packages/aws/api-docs/lambda/function" >}}) that runs the business logic, and an [Amazon API Gateway REST API]({{< relref "/registry/packages/aws/api-docs/apigateway/restapi" >}}) that routes requests to HTML content and the Lambda function. The template ships with a placeholder website that displays the current time to give you a working Pulumi project out of the box that you can customize easily and extend to suit your needs.
@@ -19,52 +26,7 @@ The AWS Serverless Application template deploys a serverless website to AWS that
 
 To use this template to deploy your own AWS serverless application, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your AWS credentials]({{< relref "/registry/packages/aws/installation-configuration" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice.
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-aws-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-aws-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-aws-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-aws-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-aws-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it’s done, you’ll have a complete Pulumi project that’s ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/serverless-application/azure/index.md
+++ b/themes/default/content/templates/serverless-application/azure/index.md
@@ -1,24 +1,21 @@
 ---
-title: "Azure Serverless Application"
+title: Azure Serverless Application
 layout: template
-
-# Make sure this is description accurate for this template.
 meta_desc: The Azure Serverless Template makes it easy to deploy a serverless application on Azure with Pulumi, Azure Functions, and Azure Blob Storage.
-
-# Appears on the cards on template-overview pages.
+meta_image: meta.png
 card_desc: Deploy a serverless application on Azure with Pulumi, Azure Functions, and Azure Blob Storage.
-
-# Used for generating language-specific links to templates on GitHub. (Example: `static-website-aws`)
 template:
-    prefix: serverless-azure
-
-# Used for generating links to sibling templates in the right-hand nav. Slug is this template's parent directory.
+  prefix: serverless-azure
+  dirname: my-serverless-app
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
   name: Microsoft Azure
   slug: azure
-
-meta_image: meta.png
-
 ---
 
 The Serverless Application template creates an infrastructure as code project in your favorite language that deploys a serverless application to Azure with Pulumi. It deploys an [Azure Blob Storage account]({{< relref "/registry/packages/azure-native/api-docs/storage/storageaccount" >}}) configured for [static website hosting]({{< relref "/registry/packages/azure-native/api-docs/storage/storageaccountstaticwebsite" >}}) and an [Azure Function]({{< relref "/registry/packages/azure-native/api-docs/web/webappfunction" >}}) written in the same language as the template. The template ships with placeholder content to give you a working project out of the box that you can customize easily and extend to suit your needs.
@@ -29,52 +26,7 @@ The Serverless Application template creates an infrastructure as code project in
 
 To use this template to deploy your own serverless application, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Azure credentials]({{< relref "/registry/packages/azure/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-azure-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-azure-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-azure-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-azure-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-azure-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/serverless-application/gcp/index.md
+++ b/themes/default/content/templates/serverless-application/gcp/index.md
@@ -1,24 +1,21 @@
 ---
-title: "Google Cloud Serverless Application"
+title: Google Cloud Serverless Application
 layout: template
-
-# Make sure this is description accurate for this template.
 meta_desc: The Google Cloud Serverless Template makes it easy to deploy a serverless application on GCP with Pulumi, Google Cloud Functions, and Google Cloud Storage.
-
-# Appears on the cards on template-overview pages.
+meta_image: meta.png
 card_desc: Deploy a serverless application on Google Cloud with Pulumi, Google Cloud Functions, and Google Cloud Storage.
-
-# Used for generating language-specific links to templates on GitHub. (Example: `static-website-aws`)
 template:
-    prefix: serverless-gcp
-
-# Used for generating links to sibling templates in the right-hand nav. Slug is this template's parent directory.
+  prefix: serverless-gcp
+  dirname: my-serverless-app
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
   name: Google Cloud Platform
   slug: gcp
-
-meta_image: meta.png
-
 ---
 
 The Serverless Application template creates an infrastructure as code project in your favorite language that deploys a serverless application to Google Cloud Platform with Pulumi. It deploys a [Google Cloud Storage bucket]({{< relref "/registry/packages/gcp/api-docs/storage/bucket" >}}) configured for static website hosting and another bucket to host the source code for a [Cloud Function]({{< relref "/registry/packages/gcp/api-docs/cloudfunctions/function" >}}) written in the same language as the template. The template ships with placeholder content to give you a working project out of the box that you can customize easily and extend to suit your needs.
@@ -29,52 +26,7 @@ The Serverless Application template creates an infrastructure as code project in
 
 To use this template to deploy your own serverless application, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Google Cloud credentials]({{< relref "/registry/packages/gcp/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-gcp-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-gcp-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-gcp-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-gcp-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-serverless-app && cd my-serverless-app
-$ pulumi new serverless-gcp-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/static-website/aws/index.md
+++ b/themes/default/content/templates/static-website/aws/index.md
@@ -1,11 +1,18 @@
 ---
 title: AWS Static Website
+layout: template
 meta_desc: The AWS Static Website template makes it easy to deploy a static website on AWS with Pulumi, Amazon S3, and Amazon CloudFront.
 meta_image: meta.png
 card_desc: Deploy a static website on AWS with Pulumi, Amazon S3, and Amazon CloudFront.
-layout: template
 template:
-    prefix: static-website-aws
+  prefix: static-website-aws
+  dirname: my-site
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
   name: Amazon Web Services
   slug: aws
@@ -19,52 +26,7 @@ The AWS Static Website template deploys an HTML-based website on AWS with Pulumi
 
 To use this template to deploy a website of your own, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your AWS credentials]({{< relref "/registry/packages/aws/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-aws-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-aws-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-aws-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-aws-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-aws-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/static-website/azure/index.md
+++ b/themes/default/content/templates/static-website/azure/index.md
@@ -1,11 +1,18 @@
 ---
 title: Azure Static Website
+layout: template
 meta_desc: The Azure Static Website template makes it easy to deploy a static website on Azure with Pulumi, Azure Blob Storage, and Azure CDN.
 meta_image: meta.png
 card_desc: Deploy a static website on Azure with Pulumi, Azure Blob Storage, and Azure CDN.
-layout: template
 template:
-    prefix: static-website-azure
+  prefix: static-website-azure
+  dirname: my-site
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
     name: Microsoft Azure
     slug: azure
@@ -19,52 +26,7 @@ The Azure Static Website template deploys an HTML website on Microsoft Azure. It
 
 To use this template to deploy a website of your own, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Azure credentials]({{< relref "/registry/packages/azure-native/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-azure-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-azure-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-azure-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-azure-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-azure-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/content/templates/static-website/gcp/index.md
+++ b/themes/default/content/templates/static-website/gcp/index.md
@@ -5,7 +5,14 @@ meta_image: meta.png
 card_desc: Deploy a static website on Google Cloud with Pulumi, Google Cloud Storage, and Google Cloud CDN.
 layout: template
 template:
-    prefix: static-website-gcp
+  prefix: static-website-gcp
+  dirname: my-site
+  languages:
+    - typescript
+    - python
+    - go
+    - csharp
+    - yaml
 cloud:
     name: Google Cloud Platform
     slug: gcp
@@ -19,52 +26,7 @@ The Google Cloud Static Website template deploys an HTML website on Google Cloud
 
 To use this template to deploy a website of your own, make sure you've [installed Pulumi]({{< relref "/docs/get-started/install" >}}) and [configured your Google Cloud credentials]({{< relref "/registry/packages/gcp/installation-configuration#credentials" >}}), then create a new [project]({{< relref "/docs/intro/concepts/project" >}}) using the template in your language of choice:
 
-{{% chooser language "typescript,python,go,csharp,yaml" / %}}
-
-{{% choosable language typescript %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-gcp-typescript
-```
-
-{{% /choosable %}}
-
-{{% choosable language python %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-gcp-python
-```
-
-{{% /choosable %}}
-
-{{% choosable language go %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-gcp-go
-```
-
-{{% /choosable %}}
-
-{{% choosable language csharp %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-gcp-csharp
-```
-
-{{% /choosable %}}
-
-{{% choosable language yaml %}}
-
-```bash
-$ mkdir my-site && cd my-site
-$ pulumi new static-website-gcp-yaml
-```
-
-{{% /choosable %}}
+{{< templates/pulumi-new >}}
 
 Follow the prompts to complete the new-project wizard. When it's done, you'll have a finished project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
 

--- a/themes/default/layouts/partials/templates/right-nav.html
+++ b/themes/default/layouts/partials/templates/right-nav.html
@@ -20,7 +20,7 @@
 <div class="inline-flex items-center text-sm">
     <i class="fab fa-github text-lg mr-1.5"></i>
     <span class="whitespace-nowrap flex-1">
-        {{ partial "templates/source-link" (dict "prefix" .Params.template.prefix "languages" "typescript,python,go,csharp,yaml") }}
+        {{ partial "templates/source-link" (dict "prefix" .Params.template.prefix "languages" (delimit .Params.template.languages ",")) }}
     </span>
     <span><i class="text-blue-700 fas fa-external-link-alt text-xs ml-1.5 pb-1"></i></span>
 </div>

--- a/themes/default/layouts/shortcodes/templates/pulumi-new.html
+++ b/themes/default/layouts/shortcodes/templates/pulumi-new.html
@@ -1,0 +1,32 @@
+{{/* Generates a language chooser containing commands for `pulumi new`, using
+    frontmatter obtained from the surrounding content file.
+*/}}
+
+{{ $prefix := .Page.Params.template.prefix }}
+{{ $dirname := .Page.Params.template.dirname }}
+{{ $languages := .Page.Params.template.languages }}
+
+
+<div>
+    <pulumi-chooser type="language" options="{{ delimit $languages "," }}"></pulumi-chooser>
+</div>
+
+{{/* The formatting below (specifically what's contained within the `pre` tags) is
+    important because it controls how the code snippet is rendered on-page in terms of line breaks,
+    tabs, spaces, etc. The Prettier formatter mangles this spacing, so the formatting needs to
+    be ignored.
+*/}}
+
+
+<!-- prettier-ignore -->
+{{ range $language := $languages }}
+<div>
+    <pulumi-choosable type="language" values="{{ $language }}">
+        <div class="highlight">
+            <pre tabindex="0" class="chroma"><code class="language-bash" data-lang="bash"><span class="line"><span class="cl">$ mkdir {{ $dirname }} <span class="o">&amp;&amp;</span> <span class="nb">cd</span> {{ $dirname }}
+</span></span><span class="line"><span class="cl">$ pulumi new {{ $prefix }}-{{ $language }}
+</span></span></code></pre>
+        </div>
+    </pulumi-choosable>
+</div>
+{{ end }}


### PR DESCRIPTION
This change adds a new shortcode, `{{< templates/pulumi-new >}}`, that reads from template frontmatter to build the language chooser and `pulumi new` commands. Also adjusts the right-hand nav to use that same list to build the links to the templates repository. 

cc @gthuang as this makes a few tweaks to the templates archetype, which now expects that list of languages, along with the name to use for the Pulumi project directory (with defaults included of course). 