### PR TITLE
Add templates as options on getting started landing page

### DIFF
--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -28,7 +28,7 @@ Select one of the following options to get started:
 <div class="tiles flex-wrap justify-center items-stretch mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with an S3 bucket.</p>
             <div class="flex flex-grow items-end">
                 <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
@@ -80,7 +80,7 @@ Select one of the following options to get started:
 <div class="tiles flex-wrap justify-center items-stretch mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with a Blob Storage Account.</p>
             <div class="flex flex-grow items-end">
                 <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
@@ -132,7 +132,7 @@ Select one of the following options to get started:
 <div class="tiles flex-wrap justify-center items-stretch mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with a Cloud Storage bucket.</p>
             <div class="flex flex-grow items-end">
                 <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
@@ -184,7 +184,7 @@ Select one of the following options to get started:
 <div class="tiles flex-wrap justify-center items-stretch mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
-            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Deploy NGINX and create a service to access your NGINX deployment.</p>
             <div class="flex flex-grow items-end">
                 <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -19,30 +19,208 @@ Pulumi is a [universal infrastructure as code]({{< relref "/what-is/what-is-infr
 
 Pulumi is free, [open source](https://github.com/pulumi/pulumi), and optionally pairs with the [Pulumi Service]({{< relref "/docs/intro/pulumi-service" >}}) to make managing infrastructure secure, reliable, and hassle-free.
 
-Select one of the following options to deploy a simple application in your cloud using Pulumi:
+Select one of the following options to get started:
 
-<div class="tiles flex-wrap mt-4">
+{{% chooser cloud "aws,azure,gcp,kubernetes" / %}}
+
+{{% choosable cloud aws %}}
+
+<div class="tiles flex-wrap justify-center items-stretch mt-4">
     <div class="pb-4 md:pr-4 md:w-1/2">
-        <a class="tile p-8" href="{{< relref "/docs/get-started/aws" >}}">
-            <img class="h-10 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="pb-4 md:w-1/2">
-        <a class="tile p-8" href="{{< relref "/docs/get-started/kubernetes" >}}">
-            <img class="h-10 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <p>Create a static website with an S3 bucket.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
+            </div>
+        </div>
     </div>
     <div class="pb-4 md:pr-4 md:w-1/2">
-        <a class="tile p-8" href="{{< relref "/docs/get-started/azure" >}}">
-            <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes with EKS</h4>
+            <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
     </div>
-    <div class="pb-4 md:w-1/2">
-        <a class="tile p-8" href="{{< relref "/docs/get-started/gcp" >}}">
-            <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>S3 and Cloudfront Website</h4>
+            <p>Create a static website hosted in S3 with a CloudFront Distribution to serve the website with caching and HTTPs.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/static-website/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
+            <p>Create an API Gateway REST API and a static website that consumes that API.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/serverless-application/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers with Fargate</h4>
+            <p>Run your container on AWS using ECS and Fargate.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/container-service/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
     </div>
 </div>
+
+{{< /choosable >}}
+
+{{% choosable cloud azure %}}
+
+<div class="tiles flex-wrap justify-center items-stretch mt-4">
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <p>Create a static website with a Blob Storage Account.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
+            <p>Create a static website with a Blob storage and a CDN to serve the website with caching and HTTPs.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/static-website/azure" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
+            <p>Create a Function App and a static website that consumes that Function.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/serverless-application/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Azure examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers on Azure</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Azure examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{< /choosable >}}
+
+{{% choosable cloud gcp %}}
+
+<div class="tiles flex-wrap justify-center items-stretch mt-4">
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <p>Create a static website with a Cloud Storage bucket.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
+            <p>Create a static website with a Cloud Storage bucket and a CDN to serve the website with caching and HTTPs.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/static-website/gcp" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
+            <p>Create a Cloud Function and a static website that consumes that function.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/serverless-application/gcp" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Google Cloud</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Google Cloud examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers on Google Cloud</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Google Cloud examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{< /choosable >}}
+
+{{% choosable cloud kubernetes %}}
+
+<div class="tiles flex-wrap justify-center items-stretch mt-4">
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Simple App</h4>
+            <p>Deploy NGINX and create a service to access your NGINX deployment.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes with EKS</h4>
+            <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
+            <div class="flex flex-grow items-end">
+                <a href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Kubernetes examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+    <div class="pb-4 md:pr-4 md:w-1/2">
+        <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
+            <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Google Cloud</h4>
+            <p>Coming soon! In the meantime you can select the link below to view a full list of Kubernetes examples.</p>
+            <div class="flex flex-grow items-end">
+                <a href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{< /choosable >}}
 
 Or, watch how to do it in this video walkthrough:
 

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -31,7 +31,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with an S3 bucket.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
+                <a data-track="aws-get-started" href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
             </div>
         </div>
     </div>
@@ -40,7 +40,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes with EKS</h4>
             <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="aws-kubernetes" href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -49,7 +49,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>S3 and Cloudfront Website</h4>
             <p>Create a static website hosted in S3 with a CloudFront Distribution to serve the website with caching and HTTPs.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/static-website/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="aws-static-website" href="{{< relref "/templates/static-website/aws" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -58,7 +58,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
             <p>Create an API Gateway REST API and a static website that consumes that API.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/serverless-application/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="aws-serverless" href="{{< relref "/templates/serverless-application/aws" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -67,7 +67,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers with Fargate</h4>
             <p>Run your container on AWS using ECS and Fargate.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/container-service/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="aws-container-service" href="{{< relref "/templates/container-service/aws" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -83,7 +83,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with a Blob Storage Account.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
+                <a data-track="azure-get-started" href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
             </div>
         </div>
     </div>
@@ -92,7 +92,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
             <p>Create a static website with a Blob storage and a CDN to serve the website with caching and HTTPs.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/static-website/azure" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="azure-static-website" href="{{< relref "/templates/static-website/azure" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -101,7 +101,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
             <p>Create a Function App and a static website that consumes that Function.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/serverless-application/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="azure-serverless" href="{{< relref "/templates/serverless-application/azure" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -110,7 +110,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Azure examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="azure-kubernetes-examples" href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>
@@ -119,7 +119,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers on Azure</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Azure examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="azure-container-examples" href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>
@@ -135,7 +135,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Create a static website with a Cloud Storage bucket.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
+                <a data-track="google-get-started" href="{{< relref "/docs/get-started/gcp" >}}" class="btn btn-primary">Get Started</a>
             </div>
         </div>
     </div>
@@ -144,7 +144,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cloud text-blue-400 pr-2"></i>Static Website with a CDN</h4>
             <p>Create a static website with a Cloud Storage bucket and a CDN to serve the website with caching and HTTPs.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/static-website/gcp" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="google-static-website" href="{{< relref "/templates/static-website/gcp" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -153,7 +153,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-sitemap text-blue-400 pr-2"></i>Full Stack Serverless App</h4>
             <p>Create a Cloud Function and a static website that consumes that function.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/serverless-application/gcp" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="google-serverless" href="{{< relref "/templates/serverless-application/gcp" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -162,7 +162,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Google Cloud</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Google Cloud examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="google-kubernetes-examples" href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>
@@ -171,7 +171,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-tasks text-blue-400 pr-2"></i>Containers on Google Cloud</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Google Cloud examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="google-container-examples" href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>
@@ -187,7 +187,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
             <p>Deploy NGINX and create a service to access your NGINX deployment.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
+                <a data-track="kubernetes-get-started" href="{{< relref "/docs/get-started/kubernetes" >}}" class="btn btn-primary">Get Started</a>
             </div>
         </div>
     </div>
@@ -196,7 +196,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes with EKS</h4>
             <p>Create an EKS cluster that provides a managed Kubernetes control plane.</p>
             <div class="flex flex-grow items-end">
-                <a href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
+                <a data-track="kubernetes-aws" href="{{< relref "/templates/kubernetes/aws" >}}" class="btn btn-secondary">Get Started</a>
             </div>
         </div>
     </div>
@@ -205,7 +205,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Kubernetes examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="kubernetes-azure-examples" href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>
@@ -214,7 +214,7 @@ Select one of the following options to get started:
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Google Cloud</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Kubernetes examples.</p>
             <div class="flex flex-grow items-end">
-                <a href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
+                <a data-track="kubernetes-google-examples" href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
     </div>

--- a/themes/default/content/docs/get-started/_index.md
+++ b/themes/default/content/docs/get-started/_index.md
@@ -29,7 +29,7 @@ Select one of the following options to get started:
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
-            <p>Create a static website with an S3 bucket.</p>
+            <p>If you are new to Pulumi, this guide helps you install Pulumi, configure AWS, and run your first update.</p>
             <div class="flex flex-grow items-end">
                 <a data-track="aws-get-started" href="{{< relref "/docs/get-started/aws" >}}" class="btn btn-primary">Get Started</a>
             </div>
@@ -81,7 +81,7 @@ Select one of the following options to get started:
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
-            <p>Create a static website with a Blob Storage Account.</p>
+            <p>If you are new to Pulumi, this guide helps you install Pulumi, configure Azure, and run your first update.</p>
             <div class="flex flex-grow items-end">
                 <a data-track="azure-get-started" href="{{< relref "/docs/get-started/azure" >}}" class="btn btn-primary">Get Started</a>
             </div>
@@ -105,7 +105,7 @@ Select one of the following options to get started:
             </div>
         </div>
     </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
+    <!--<div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Azure examples.</p>
@@ -122,7 +122,7 @@ Select one of the following options to get started:
                 <a data-track="azure-container-examples" href="https://github.com/pulumi/examples#azure" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
-    </div>
+    </div>-->
 </div>
 
 {{< /choosable >}}
@@ -133,7 +133,7 @@ Select one of the following options to get started:
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
-            <p>Create a static website with a Cloud Storage bucket.</p>
+            <p>If you are new to Pulumi, this guide helps you install Pulumi, configure Google Cloud, and run your first update.</p>
             <div class="flex flex-grow items-end">
                 <a data-track="google-get-started" href="{{< relref "/docs/get-started/gcp" >}}" class="btn btn-primary">Get Started</a>
             </div>
@@ -157,7 +157,7 @@ Select one of the following options to get started:
             </div>
         </div>
     </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
+    <!--<div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Google Cloud</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Google Cloud examples.</p>
@@ -174,7 +174,7 @@ Select one of the following options to get started:
                 <a data-track="google-container-examples" href="https://github.com/pulumi/examples#gcp" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
-    </div>
+    </div>-->
 </div>
 
 {{< /choosable >}}
@@ -185,7 +185,7 @@ Select one of the following options to get started:
     <div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-folder text-blue-400 pr-2"></i>Starter App</h4>
-            <p>Deploy NGINX and create a service to access your NGINX deployment.</p>
+            <p>If you are new to Pulumi, this guide helps you install Pulumi, configure the Kubernetes Provider, and run your first update.</p>
             <div class="flex flex-grow items-end">
                 <a data-track="kubernetes-get-started" href="{{< relref "/docs/get-started/kubernetes" >}}" class="btn btn-primary">Get Started</a>
             </div>
@@ -200,7 +200,7 @@ Select one of the following options to get started:
             </div>
         </div>
     </div>
-    <div class="pb-4 md:pr-4 md:w-1/2">
+    <!--<div class="pb-4 md:pr-4 md:w-1/2">
         <div class="block rounded shadow border border-gray-300 p-3 h-full flex flex-col">
             <h4><i class="fas fa-cubes text-blue-400 pr-2"></i>Kubernetes on Azure</h4>
             <p>Coming soon! In the meantime you can select the link below to view a full list of Kubernetes examples.</p>
@@ -217,7 +217,7 @@ Select one of the following options to get started:
                 <a data-track="kubernetes-google-examples" href="https://github.com/pulumi/examples#kubernetes" target="_blank" rel="noopener noreferrer" class="btn btn-secondary">View examples</a>
             </div>
         </div>
-    </div>
+    </div>-->
 </div>
 
 {{< /choosable >}}


### PR DESCRIPTION
This PR adds the newly shipped templates as options in the Getting Started Guide. The main goal here is increase awareness and usage of the templates, and by offering them as options on the getting started page we should get more visibility.

**Hypothesis**

By presenting users more use case specific options in the getting started guide we will increase the CTR of users to these templates/guides and in turn increase the conversion rate of the website resulting in new users.

<img width="868" alt="getting-started-options-tempaltes" src="https://user-images.githubusercontent.com/15146337/195916382-410a9e64-8bb8-42ba-9827-32b2613cb4c2.png">
