### PR TITLE
Add a page listing all blog tags

### DIFF
--- a/themes/default/content/blog/tag.md
+++ b/themes/default/content/blog/tag.md
@@ -1,0 +1,7 @@
+---
+title: "Pulumi Blog: All tags"
+layout: tags
+meta_desc: A list of all Pulumi blog tags, sorted alphabetically.
+---
+
+All [Pulumi blog](/blog/) tags, sorted alphabetically.

--- a/themes/default/layouts/blog/tags.html
+++ b/themes/default/layouts/blog/tags.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+    <div class="container mx-auto px-4 py-8">
+        <div class="lg:flex">
+            <div class="lg:w-3/12 pr-8">
+                {{ partial "blog/sidebar.html" . }}
+            </div>
+
+            <div class="lg:w-7/12">
+                <header>
+                    <h1 class="no-anchor">{{ .Title }}</h1>
+
+                    {{ .Content }}
+
+
+                    <ul class="list-none p-0 my-8 inline-flex flex-wrap text-xs">
+                        {{ range $tag, $content := .Site.Taxonomies.tags }}
+                            <li>
+                                <a class="tag tag-blog text-xs m-1" href="{{ .Page.RelPermalink }}">{{ $tag }}</a>
+                            </li>
+                        {{ end }}
+                    </ul>
+                </header>
+            </div>
+            <div class="lg:w-2/12 pl-8"></div>
+        </div>
+    </div>
+{{ end }}

--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -45,21 +45,23 @@
             </ul>
         </div>
         <hr class="my-8" />
-        <ul class="list-none p-0 mb-4 inline-flex flex-wrap text-xs">
-            {{/* Only show the top N blog tags. We create a dict of them first so they're in alphabetical order. */}}
-            {{/* Note, we could have just deleted the other tags, but this will change over time. Also, we want */}}
-            {{/* to preserve the metadata -- some day we might even have a "View More ..." link at the bottom... */}}
-            {{ $topTags := dict }}
-            {{ range first 40 .Site.Taxonomies.tags.ByCount }}
-                {{ $topTags = merge $topTags (dict .Name .Count) }}
-            {{ end }}
-            {{ range $tag, $_ := .Site.Taxonomies.tags }}
-                {{ $count := index $topTags $tag }}
-                {{ if gt $count 0 }}
+
+        {{/* Only show the top N blog tags. This lists releases first, then features, then most popular descendingly. */}}
+
+        {{ $allTags := .Site.Taxonomies.tags.ByCount }}
+        {{ $releases := where $allTags "Name" "pulumi-releases" }}
+        {{ $features := where $allTags "Name" "features" }}
+        {{ $others := where $allTags "Name" "not in" "pulumi-releases features" }}
+
+
+        <ul class="list-none p-0 mb-2 inline-flex flex-wrap text-xs">
+            {{ range $i, $tagInfo := (slice $releases $features (first 40 $others)) }}
+                {{ range $tagInfo }}
+                    {{ $tag := .Name }}
                     <li>
                         <a
                             data-track="blog-tag-{{ $tag | urlize }}"
-                            class="tag tag-blog text-xs {{ if eq (lower $tag) (urlize ((lower $.Title))) }}active{{ end }}"
+                            class="tag tag-blog text-xs m-1 {{ if eq (lower $tag) (urlize ((lower $.Title))) }}active{{ end }}"
                             href="{{ .Page.RelPermalink }}"
                         >
                             {{ $tag }}
@@ -68,6 +70,7 @@
                 {{ end }}
             {{ end }}
         </ul>
+        <a class="text-blue-600 text-sm block m-1 mb-4" href="{{ relref . "/blog/tag" }}">All blog tags &rarr;</a>
     </div>
 
     <div class="lg:hidden pb-4">

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -267,7 +267,7 @@
     {{ end }}
 
     {{/* Tests to enforce required frontmatter for certain content types. */}}
-    {{ if and (eq .Type "blog") .IsPage }}
+    {{ if and (eq .Type "blog") (eq .BundleType "leaf") .IsPage }}
         {{ if not .Params.authors }}
             {{ errorf "Blog posts require authors: %s" .File.Path }}
         {{ else }}


### PR DESCRIPTION
Adds a page that lists all blog tags alphabetically. This is helpful mainly for reference, as blog-post authors frequently want to know what tags we've already defined so they can use them.

Also fixes a bug with the sidebar logic. (It now works as intended -- not sure what happened there, but in any case, should be good now!)