### PR TITLE
Add link to slack archive

### DIFF
--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -35,6 +35,7 @@
 
             <ul>
                 <li><a data-track="footer-events" href="{{ relref . "/resources" }}" class="link">Resources</a></li>
+                <li><a data-track="footer-events" href="https://archive.pulumi.com/" target="_blank" rel="noopener noreferrer" class="link">Slack Archive</a></li>
                 <li><a data-track="footer-events" href="{{ relref . "/case-studies" }}" class="link">Case Studies</a></li>
                 <li><a data-track="footer-events" href="{{ relref . "/awards" }}" class="link">Awards &amp; Recognitions</a></li>
                 <li><a data-track="footer-brand" href="{{ relref . "/brand" }}" class="link">Brand Resources</a></li>


### PR DESCRIPTION
This PR adds the Slack Archive to the footer, which should be helpful when crawling the archive for SEO purposes.

Part of https://github.com/pulumi/pulumi-hugo/issues/2019