### PR TITLE
Add noindex to taxonomy pages

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -27,6 +27,16 @@
     {{ end }}
 
 
+    <!--
+        We use taxonomy pages for tags and authors for our blog posts. These
+        pages end up cannibalising other pages on our site that rank for key terms.
+        To avoid this, we add the `noidex` tag to tell search engines not index taxonomy pages.
+    -->
+    {{ if .Data.Singular }}
+        <meta name="robots" content="noindex" />
+    {{ end }}
+
+
     <!-- Events info for Google events. -->
     {{ if .Params.event_data }}
         <script type="application/ld+json">


### PR DESCRIPTION
Currently our taxonomy pages are taking away from the ranking of some of more core pages pages for certain terms. To avoid it, this PR adds the `noindex` tag to the taxonomy pages so search engines will crawling those pages.

Based on Hugo's docs, taxonomy pages have specific added variables that we can key off to add the tag: https://gohugo.io/variables/taxonomy/#example-usage-of-site-taxonomies