### PR TITLE
Use RelPermalink instead of Permalink

### DIFF
--- a/themes/default/layouts/blog/list.html
+++ b/themes/default/layouts/blog/list.html
@@ -9,7 +9,7 @@
                 {{ $paginator := .Paginate (where .Pages "Type" "blog").ByDate.Reverse }}
                 {{ range $paginator.Pages }}
                     <article class="mb-8 pb-8 border-b border-gray-200">
-                        <h2 class="no-anchor"><a data-track="post-{{ .Title | urlize }}" href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                        <h2 class="no-anchor"><a data-track="post-{{ .Title | urlize }}" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                         <div class="flex items-center text-sm text-gray-700">
                             <span>
                                 {{ partial "blog/authors.html" (dict "context" . "authors" .Params.authors ) }}

--- a/themes/default/layouts/community/developer-advocates/single.html
+++ b/themes/default/layouts/community/developer-advocates/single.html
@@ -264,7 +264,7 @@
                                 </div>
                                 <div class="lg:w-3/5 pt-2 lg:pt-1 md:py-4">
                                     <h4 class="no-anchor text-2xl mt-0 md:mb-1 lg:pr-4">
-                                        <a class="text-gray-800" data-track="post-{{ .Title | urlize }}" href="{{ .Permalink }}">
+                                        <a class="text-gray-800" data-track="post-{{ .Title | urlize }}" href="{{ .RelPermalink }}">
                                             {{ .Title }}
                                         </a>
                                     </h4>

--- a/themes/default/layouts/partials/blog/authors.html
+++ b/themes/default/layouts/partials/blog/authors.html
@@ -6,10 +6,10 @@
 
         <span class="flex items-center">
             {{ if $authorData }}
-                <a data-track="{{ $authorData.name | urlize }}-img" class="rounded-full p-1 bg-blue-200 mr-2" href="{{ $authorPage.Permalink }}">
+                <a data-track="{{ $authorData.name | urlize }}-img" class="rounded-full p-1 bg-blue-200 mr-2" href="{{ $authorPage.RelPermalink }}">
                     <img class="w-8 rounded-full" src="/images/team/{{ $authorData.id }}.jpg" alt="{{ $authorData.name }}" title="{{ $authorData.name }}" />
                 </a>
-                <a data-track="{{ $authorData.name | urlize }}-name" class="mr-2 hover:text-gray-800" href="{{ $authorPage.Permalink }}">{{ $authorData.name }}</a>
+                <a data-track="{{ $authorData.name | urlize }}-name" class="mr-2 hover:text-gray-800" href="{{ $authorPage.RelPermalink }}">{{ $authorData.name }}</a>
             {{ end }}
         </span>
     {{ end }}

--- a/themes/default/layouts/partials/blog/sidebar.html
+++ b/themes/default/layouts/partials/blog/sidebar.html
@@ -38,7 +38,7 @@
                         {{/* The /blog/_index.md file unfortunately shows up in the list, so we skip it. */}}
                     {{ else }}
                         <li class="my-4 leading-snug">
-                            <a data-track="recent-post" class="text-sm" href="{{ $post.Permalink }}">{{ $post.Title }}</a>
+                            <a data-track="recent-post" class="text-sm" href="{{ $post.RelPermalink }}">{{ $post.Title }}</a>
                         </li>
                     {{ end }}
                 {{ end }}
@@ -60,7 +60,7 @@
                         <a
                             data-track="blog-tag-{{ $tag | urlize }}"
                             class="tag tag-blog text-xs {{ if eq (lower $tag) (urlize ((lower $.Title))) }}active{{ end }}"
-                            href="{{ .Page.Permalink }}"
+                            href="{{ .Page.RelPermalink }}"
                         >
                             {{ $tag }}
                         </a>

--- a/themes/default/layouts/partials/blog/summary.html
+++ b/themes/default/layouts/partials/blog/summary.html
@@ -6,5 +6,5 @@
     {{ .Summary }}
 </p>
 <p>
-    <a data-track="read-more" href="{{ .Permalink }}"> Read more &rarr; </a>
+    <a data-track="read-more" href="{{ .RelPermalink }}"> Read more &rarr; </a>
 </p>

--- a/themes/default/layouts/taxonomy/author.html
+++ b/themes/default/layouts/taxonomy/author.html
@@ -37,7 +37,7 @@
 
                 {{ range $paginator.Pages }}
                     <article class="my-8 pb-8 border-b border-gray-200">
-                        <h2 class="no-anchor"><a data-track="{{ .Title | urlize }}" href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                        <h2 class="no-anchor"><a data-track="{{ .Title | urlize }}" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                         <div class="flex items-center">
                             <time class="text-sm text-gray-700">
                                 {{ .Date.Format "Monday, Jan 2, 2006" }}

--- a/themes/default/layouts/taxonomy/tag.html
+++ b/themes/default/layouts/taxonomy/tag.html
@@ -22,7 +22,7 @@
 
                 {{ range $paginator.Pages }}
                     <article class="my-8 pb-8 border-b border-gray-200">
-                        <h2><a data-track="{{ .Title | urlize }}" href="{{ .Permalink }}">{{ .Title }}</a></h2>
+                        <h2><a data-track="{{ .Title | urlize }}" href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                         <div class="flex items-center">
                             <time>
                                 {{ .Date.Format "Monday, Jan 2, 2006" }}

--- a/themes/default/layouts/what-is/list.html
+++ b/themes/default/layouts/what-is/list.html
@@ -18,7 +18,7 @@
             {{ range $topics }}
                 <div class="lg:w-1/2 p-6">
                     <div class="card p-6 h-full">
-                        <a class="hover:underline" href="{{ .Permalink }}">
+                        <a class="hover:underline" href="{{ .RelPermalink }}">
                             <div>
                                 <h5>{{ .Params.title }}</h5>
                             </div>


### PR DESCRIPTION
Hugo's `.Permalink` builds fully-qualified URLs (using the configured URL), but in most cases, relative URLs are preferable because they're more portable). This PR replaces all occurrences but in the `<head>` tag, which we should keep for canonical URLs and social media images.