### PR TITLE
Updated CIDR block for Security Group

### DIFF
--- a/themes/default/content/docs/guides/crosswalk/aws/vpc.md
+++ b/themes/default/content/docs/guides/crosswalk/aws/vpc.md
@@ -736,7 +736,7 @@ const sg = new aws.ec2.SecurityGroup("webserver-sg", {
     fromPort: 443,
     toPort: 443,
     protocol: "tcp",
-    cidrBlocks: ["0.0.0.0"],
+    cidrBlocks: ["0.0.0.0/0"],
   }],
   egress: [{
     fromPort: 0,


### PR DESCRIPTION
Changed Line No: 739

From:     cidrBlocks: ["0.0.0.0"],
To:     cidrBlocks: ["0.0.0.0/0"],

Reason: To fix  "problem: "0.0.0.0" is not a valid CIDR block: invalid CIDR address: 0.0.0.0. Examine values at 'SecurityGroup.Ingresses'."