### PR TITLE
Corrected error in Organization Access Tokens docs that listed Audit Log Export/List as possible

### DIFF
--- a/themes/default/content/docs/intro/pulumi-service/organization-access-tokens.md
+++ b/themes/default/content/docs/intro/pulumi-service/organization-access-tokens.md
@@ -109,5 +109,5 @@ See the Pulumi [Service REST API docs](https://www.pulumi.com/docs/reference/ser
 
 | Action |  |
 |--------|------|
-| Get Audit Log Events (JSON) | ✅ |
-| Export Audit Log Events (CSV or CEF) | ✅ |
+| Get Audit Log Events (JSON) |  |
+| Export Audit Log Events (CSV or CEF) |  |


### PR DESCRIPTION
The Org Tokens docs were erroneously showing audit log events list/export features as possible. This is not possible at this time as org tokens are given only Member-level permissions, and these are Admin endpoints. As we receive feedback we [may opt to change this](https://github.com/pulumi/service-requests/issues/135).

## Issue
Fixes https://github.com/pulumi/service-requests/issues/131