### PR TITLE
Add precommit hook for file size

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 yarn run lint-staged
+
+./scripts/lint/check-file-size.sh

--- a/scripts/lint/check-file-size.sh
+++ b/scripts/lint/check-file-size.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# list files staged for commit
+git diff --staged --name-only | \
+while read line; do 
+    # get size in bytes
+    size=$(wc -c "$line" | awk '{print $1}');
+    # verify staged files less than 1MB
+    if [ $((size)) -gt 1048576 ]; then
+        echo -e "\033[93m WARNING: $line greater than 1MB in size. \033[0m"
+        exit 1
+    fi
+done


### PR DESCRIPTION
This PR adds a file size check to the pre-commit hook to warn users about committing large files since we are starting to get close to hitting a size limit with our hugo build. See https://github.com/pulumi/docs/issues/8220#issuecomment-1309325148

I set this to warn for files greater than 1MB, but open to other suggestions. I only added this to warn for newly committed files as a pre-commit hook since this would continue fail for existing large files. Users can also get around the hook by committing with `--no-verify` in the event they really need to add such a large file.

![image](https://user-images.githubusercontent.com/16751381/200959924-2d05b940-b21e-4b6c-a8a1-66e2053687bf.png)