### PR TITLE
fix link failing pulumi/docs link check

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -1467,7 +1467,7 @@
                 <div class="compare-plans-table-row-container">
                     <div class="compare-plans-table-row-item">
                         <span
-                            ><a class="compare-table-link" href="{{ relref . " /docs/intro/pulumi-service/organization-access-tokens/" }}"
+                            ><a class="compare-table-link" href="{{ relref . " /docs/intro/pulumi-service/organization-access-tokens" }}"
                                 >Organization and Team Access Tokens</a
                             ></span
                         >


### PR DESCRIPTION
its currently failing on
>ERROR 2022/11/17 01:44:26 [en] REF_NOT_FOUND: Ref " /docs/intro/pulumi-service/organization-access-tokens/" from page "pricing/_index.md": page not found

