### PR TITLE
Add layout for AWS serverless template

### DIFF
--- a/themes/default/content/templates/serverless-application/aws/index.md
+++ b/themes/default/content/templates/serverless-application/aws/index.md
@@ -1,5 +1,6 @@
 ---
 title: AWS Serverless Application
+layout: template
 meta_desc: The AWS Serverless Application template makes it easy to deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway.
 meta_image: meta.png
 card_desc: Deploy a serverless application on AWS with Pulumi, AWS Lambda, and Amazon API Gateway.


### PR DESCRIPTION
Noticed this page was missing the `template` layout setting (so losing the left and right nav, breadcrumb, styling, etc.):

![image](https://user-images.githubusercontent.com/274700/204682572-872a3e90-1b59-4429-844b-081e885a9d96.png)

This should fix it up.