### PR TITLE
Point `Web console` to correct page

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/components/_index.md
+++ b/themes/default/content/docs/guides/self-hosted/components/_index.md
@@ -17,5 +17,5 @@ Self-hosting is only available with **Pulumi Business Critical**. If you would l
 | Component | Repository |
 | --------- | ---------- |
 | [API](/docs/guides/self-hosted/components/api/) | [https://hub.docker.com/r/pulumi/service/](https://hub.docker.com/r/pulumi/service/) |
-| [Web console](/docs/guides/self-hosted/console/) |	[https://hub.docker.com/r/pulumi/console/](https://hub.docker.com/r/pulumi/console/) |
+| [Web console](/docs/guides/self-hosted/components/console/) |	[https://hub.docker.com/r/pulumi/console/](https://hub.docker.com/r/pulumi/console/) |
 | Migrations | [https://hub.docker.com/r/pulumi/migrations/](https://hub.docker.com/r/pulumi/migrations/) |


### PR DESCRIPTION
The current link points to the wrong page, and with the `alias` on this page, it redirects to itself rather than the components subpage.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>