### PR TITLE
Fix TypeScript example for creating a stack README

### DIFF
--- a/themes/default/content/docs/intro/pulumi-service/projects-and-stacks.md
+++ b/themes/default/content/docs/intro/pulumi-service/projects-and-stacks.md
@@ -96,7 +96,7 @@ import { readFileSync } from "fs";
 export const strVar = "foo";
 export const arrVar = ["fizz", "buzz"];
 // add readme to stack outputs. must be named "readme".
-export const readme = readFileSync("./Pulumi.README.md");
+export const readme = readFileSync("./Pulumi.README.md").toString();
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
If you use the TypeScript example code (just exporting `readFileSync(...)`) it returns a `Buffer` type, which gets exported as a byte array. In order for this to work correctly, you need to convert that `Buffer` into a string.

With this change the snippet now matches the [blog post](https://www.pulumi.com/blog/stack-readme/#step-1) announcing the feature.