### PR TITLE
Documented the missing SMTP environment variables.

### DIFF
--- a/themes/default/content/docs/guides/self-hosted/components/api.md
+++ b/themes/default/content/docs/guides/self-hosted/components/api.md
@@ -181,6 +181,15 @@ Only required if using GitLab as the backing identity provider for your organiza
 | GITLAB_OAUTH_SECRET | GitLab OAuth app client secret. See above to create a new GitLab OAuth app. |
 | GITLAB_OAUTH_ENDPOINT | The domain for your GitLab instance. It defaults to `https://gitlab.com`, which should be used unless you are running GitLab on a custom domain. |
 
+## Sending Emails
+
+| Variable Name | Description |
+| ------------- | ----------- |
+| SMTP_SERVER | Location of the SMTP server to use for sending notification emails. (must be in \<host>:\<port> format, e.g. `smtp.domain.com:465`) |
+| SMTP_USERNAME | Name of the SMTP user the Pulumi Service connects as. |
+| SMTP_PASSWORD | Password of the SMTP user the Pulumi Service connects as. |
+| SMTP_GENERIC_SENDER | Sender information used as `FROM:` for outgoing emails. |
+
 ## Other Environment Variables {#other-env-vars}
 
 | Variable Name | Description |


### PR DESCRIPTION
The SMTP environment variables weren't documented in our self-hosted component documentation.

Signed-off-by: Ringo De Smet <ringo@de-smet.name>