### PR TITLE
Change from getId() to id() in Java

### DIFF
--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -151,7 +151,7 @@ public class App {
 
             // Create an S3 Bucket object
             new BucketObject("index.html", BucketObjectArgs.builder()
-                .bucket(bucket.getId())
+                .bucket(bucket.id())
                 .source(new FileAsset("index.html"))
                 .build()
             );


### PR DESCRIPTION
bucket.getId() was deprecated - bucket.id() is the new method.