### PR TITLE
Add Pulumi Deployments OIDC docs.

### DIFF
--- a/themes/default/content/docs/guides/oidc/_index.md
+++ b/themes/default/content/docs/guides/oidc/_index.md
@@ -47,7 +47,7 @@ As part of the process that exchanges your deployment's OIDC token for cloud pro
 
 The Subject and custom claims are particularly useful for configuring trust relationships, as they allow you to set very fine-grained conditions for credentials.
 
-## Configuring OpenID Connect for Your Cloud Provider
+## Configuring OpenID Connect for your cloud provider
 
 To configure OIDC for your cloud provider, refer to one of our guides:
 

--- a/themes/default/content/docs/guides/oidc/_index.md
+++ b/themes/default/content/docs/guides/oidc/_index.md
@@ -36,7 +36,7 @@ The token also contains custom claims that provide additional, deployment-specif
 | `deployment` | The deployment version. |
 | `scope` | The scope of the OIDC token. Always `write`. |
 
-## Configuring Trust Relationships
+## Configuring trust relationships
 
 As part of the process that exchanges your deployment's OIDC token for cloud provider credentials, the cloud provider must check the OIDC token's claims against the conditions configured in the provider's trust relationship. The configuration of a trust relationship varies depending on the cloud provider, but typically uses at least the Audience, Subject, and Issuer claims. These claims can be use to restrict trust to specific organizations, projects, stacks, etc.:
 

--- a/themes/default/content/docs/guides/oidc/_index.md
+++ b/themes/default/content/docs/guides/oidc/_index.md
@@ -1,0 +1,56 @@
+---
+title_tag: OpenID Connect Integration for Pulumi Deployments
+title: OpenID Connect Integration for Pulumi Deployments
+meta_desc: This page provides an overview of how to configure OpenID Connect integration between
+           Pulumi Deployments and supported cloud providers.
+menu:
+    userguides:
+        weight: 9
+        identifier: oidc
+
+---
+
+[Pulumi Deployments](https://www.pulumi.com/docs/reference/deployments-rest-api/) supports OpenID Connect (OIDC) integration with cloud providers. OIDC enables your deployments to exchange a signed, short-lived token issued by the Pulumi Service for short-term credentials from your cloud provider. This can improve the security of your deployments by eliminating the need for hardcoded cloud provider credentials. If you are unfamiliar with OIDC, GitHub provides a [fine introduction to the topic](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect).
+
+## Overview
+
+Every time a deployment runs, the Pulumi Service issues a new OIDC token specific to that deployment. The OIDC token is a short-lived, signed [JSON Web Token](https://jwt.io) that contains information about the deployment and that can be exchanged for credentials from a cloud provider. For AWS, Azure, and GCP, this credential exchange can be done automatically as part of deployment setup. For advanced scenarios or other cloud providers, the token is available in the `PULUMI_OIDC_TOKEN` environment variable as well as in the `/mnt/pulumi/pulumi.oidc` file.
+
+The token contains the standard audience, issuer, and subject claims:
+
+| Claim | Description |
+| ----- | ----------- |
+| `aud` | _(Audience)_ The name of the organization associated with the deployment. |
+| `iss` | _(Issuer)_ The issuer of the OIDC token: `https://api.pulumi.com/oidc`. |
+| `sub` | _(Subject)_ The subject of the OIDC token. Because this value is often used for configuring trust relationships, the subject claim contains information about the associated deployment. The value is composed as follows: `pulumi:deploy:org:<organization name>:project:<project name>:stack:<stack name>:operation:<operation kind>:scope:write`. Each component of the subject claim is also available as a custom claim. |
+
+The token also contains custom claims that provide additional, deployment-specific information:
+
+| Claim | Description |
+| ----- | ----------- |
+| `stackId` | The fully-qualified identifier of the stack being deployed. |
+| `operation` | The deployment operation (one of `preview`, `update`, `refresh`, or `destroy`). |
+| `org` | The name of the organization associated with the deployment. |
+| `project` | The name of the project being deployed. |
+| `stack` | The name of the stack being deployed. |
+| `deployment` | The deployment version. |
+| `scope` | The scope of the OIDC token. Always `write`. |
+
+## Configuring Trust Relationships
+
+As part of the process that exchanges your deployment's OIDC token for cloud provider credentials, the cloud provider must check the OIDC token's claims against the conditions configured in the provider's trust relationship. The configuration of a trust relationship varies depending on the cloud provider, but typically uses at least the Audience, Subject, and Issuer claims. These claims can be use to restrict trust to specific organizations, projects, stacks, etc.:
+
+- The Issuer claim is typically used to validate that the token is properly signed. The issuer's public signing key is fetched and used to validate the token's signature.
+- The Audience claim contains the name of the organization associated with the deployment. You can use this claim to restrict credentials to a specific organizaiton or organizations.
+- The Subject claim contains a variety of information about the deployment. You can use this claim to restrict credentials to a specific organization, project, stack, operation, or scope.
+- The various custom claims contain the same information as the Subject claim. If your cloud provider supports configuring trust relationships based on custom claims, you can use these claims for the same purposes as the Subject claim.
+
+The Subject and custom claims are particularly useful for configuring trust relationships, as they allow you to set very fine-grained conditions for credentials.
+
+## Configuring OpenID Connect for Your Cloud Provider
+
+To configure OIDC for your cloud provider, refer to one of our guides:
+
+- [Configuring OIDC for AWS](/docs/guides/oidc/aws/)
+- [Configuring OIDC for Azure](/docs/guides/oidc/azure/)
+- [Configuring OIDC for GCP](/docs/guides/oidc/gcp/)

--- a/themes/default/content/docs/guides/oidc/aws.md
+++ b/themes/default/content/docs/guides/oidc/aws.md
@@ -1,0 +1,56 @@
+---
+title_tag: Configuring OpenID Connect for AWS | OIDC
+title: Configuring OpenID Connect for AWS
+meta_desc: This page describes how to configure OIDC token exchange in AWS for use with Pulumi Deployments
+menu:
+    userguides:
+        parent: oidc
+        weight: 1
+---
+
+This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with AWS. OIDC in AWS uses a web identity provider to assume an IAM role. Access to the IAM role is authorized using a trust policy that validates the contents of the OIDC token issued by the Pulumi Service.
+
+## Prerequisites
+
+* You must be an admin of your Pulumi organization.
+
+## Adding the Identity Provider to AWS
+
+To add the Pulumi Service as an OIDC provider for IAM, see the [relevant AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
+
+* For the provider URL, use `https://api.pulumi.com/deploy`
+* For the audience, use the name of your organization
+
+## Configuring the IAM Role and Trust Policy
+
+To configure the role and trust in IAM, see the AWS documentation for [creating a role for web identity or OpenID connect federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html#idp_oidc_Create).
+
+* For the identity provider, choose the provider you created above
+* For the audience, choose the name of your organization
+
+For more granular access control, edit the trust policy to add the `sub` claim to the policy's conditions with an appropriate patter. In the following example, the role may only be assigned by stacks within the "Core" project:
+
+```json
+"Condition": {
+  "StringLike": {
+    "api.pulumi.com/oidc:aud": "<organization name>",
+    "api.pulumi.com/oidc:sub": "pulumi:deploy:org:<organization name>:project:Core:*"
+  }
+}
+```
+
+Make a note of the IAM role's ARN; it will be necessary to enable OIDC for your stack.
+
+## Enabling OIDC for your Stack
+
+1. Navigate to your stack in the Pulumi Console.
+2. Open the stack's "Settings" tab.
+3. Choose the "Deploy" panel.
+4. Under the "OpenID Connect" header, toggle "Enable AWS Integration".
+5. Enter the ARN of the IAM role to created above in the "Role ARN" field.
+6. Enter a name for the assumed role session in the "Session Name" field.
+7. If you would like to use additional policies to further constrain the session's capabilities, enter the policies' ARNs separated by commas in the "Policy ARNs" field.
+8. If you would like to constrain the duration of the assumed role session, enter a duration in the form "XhYmZs" in the "Session Duration" field.
+9. Click the "Save deployment configuration" button.
+
+With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for AWS credentials using the specified IAM role prior to running any pre-commands or Pulumi operations. The fetched credentials are published in the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.

--- a/themes/default/content/docs/guides/oidc/aws.md
+++ b/themes/default/content/docs/guides/oidc/aws.md
@@ -14,7 +14,7 @@ This document outlines the steps required to configure Pulumi Deployments to use
 
 * You must be an admin of your Pulumi organization.
 
-## Adding the Identity Provider to AWS
+## Adding the identity provider to AWS
 
 To add the Pulumi Service as an OIDC provider for IAM, see the [relevant AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).
 

--- a/themes/default/content/docs/guides/oidc/azure.md
+++ b/themes/default/content/docs/guides/oidc/azure.md
@@ -24,7 +24,7 @@ To create the Azure Active Directory App and service principal, see the [relevan
 
 After the AAD App has been created, take note of the Application (client) ID and Directory (tenant) ID. These values will be necessary when enabling OIDC for your stack.
 
-## Adding Federated Credentials
+## Adding federated credentials
 
 Navigate to the "Certificates & secrets" pane using the sidebar. Then, select the "Federated credentials" tab and click on the "Add credential" button.
 

--- a/themes/default/content/docs/guides/oidc/azure.md
+++ b/themes/default/content/docs/guides/oidc/azure.md
@@ -1,0 +1,57 @@
+---
+title_tag: Configuring OpenID Connect for Azure | OIDC
+title: Configuring OpenID Connect for Azure
+meta_desc: This page describes how to configure OIDC token exchange in Azure for use with Pulumi Deployments
+menu:
+    userguides:
+        parent: oidc
+        weight: 1
+---
+
+This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with Azure. OIDC in Azure uses [workload identity federation](https://learn.microsoft.com/en-us/azure/active-directory/develop/workload-identity-federation) to access Azure resources via an Azure Active Directory App. Access to the temporary credentials is authorized using federated credentials that validate the contents of the OIDC token issued by the Pulumi Service.
+
+{{% notes type="warning" %}}
+Although Pulumi Deployments can exchange an OIDC token for temporary Azure credentials, these credentials cannot be used with the Azure Classic or Azure Native packages. Enabling OIDC in these providers is tracked by [GitHub Issue #1324 in the Azure Native repository](https://github.com/pulumi/pulumi-azure-native/issues/1324).
+{{% /notes %}}
+
+## Prerequisites
+
+* You must be an admin of your Pulumi organization.
+
+## Creating the Azure Active Directory App
+
+To create the Azure Active Directory App and service principal, see the [relevant Azure documentation](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal).
+
+After the AAD App has been created, take note of the Application (client) ID and Directory (tenant) ID. These values will be necessary when enabling OIDC for your stack.
+
+## Adding Federated Credentials
+
+Navigate to the "Certificates & secrets" pane using the sidebar. Then, select the "Federated credentials" tab and click on the "Add credential" button.
+
+In the wizard, select "Other Issuer" as the "Federated credential scenario".
+
+Finally, fill in the "Issuer", "Subject Identifier", "Name", and "Audience" fields in the form.
+
+- "Issuer" must be `https://api.pulumi.com/oidc`
+- "Subject Identifier" must be a valid [subject claim](/docs/guides/oidc/#overview)
+- "Name" is an arbitrary name for the credential
+- "Audience" must be the name of your Pulumi organization
+
+Because Azure's federated credentials require that the subject identifier exactly matches an OIDC token's subject claim, this process must be repeated for each permutation of the subject claim that is possible for a stack. For example, in order to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
+
+- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:preview:scope:write`
+- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:update:scope:write`
+- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
+- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
+
+## Enabling OIDC for your Stack
+
+1. Navigate to your stack in the Pulumi Console.
+2. Open the stack's "Settings" tab.
+3. Choose the "Deploy" panel.
+4. Under the "OpenID Connect" header, toggle "Enable Azure Integration".
+5. Enter the client and tenant IDs for the app registration created above in the "Client ID" and "Tenant ID" fields, repsectively.
+6. Enter the ID of the subscription you want to use in the "Subscription ID" field.
+7. Click the "Save deployment configuration" button.
+
+With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for Azure credentials using the specified AAD App prior to running any pre-commands or Pulumi operations. The fetched credentials are published in the `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`,  and `AZURE_SUBSCRIPTION_ID` environment variables. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.

--- a/themes/default/content/docs/guides/oidc/azure.md
+++ b/themes/default/content/docs/guides/oidc/azure.md
@@ -32,17 +32,17 @@ In the wizard, select "Other Issuer" as the "Federated credential scenario".
 
 Finally, fill in the "Issuer", "Subject Identifier", "Name", and "Audience" fields in the form.
 
-- "Issuer" must be `https://api.pulumi.com/oidc`
-- "Subject Identifier" must be a valid [subject claim](/docs/guides/oidc/#overview)
-- "Name" is an arbitrary name for the credential
-- "Audience" must be the name of your Pulumi organization
+* "Issuer" must be `https://api.pulumi.com/oidc`
+* "Subject Identifier" must be a valid [subject claim](/docs/guides/oidc/#overview)
+* "Name" is an arbitrary name for the credential
+* "Audience" must be the name of your Pulumi organization
 
 Because Azure's federated credentials require that the subject identifier exactly matches an OIDC token's subject claim, this process must be repeated for each permutation of the subject claim that is possible for a stack. For example, in order to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
 
-- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:preview:scope:write`
-- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:update:scope:write`
-- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
-- `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:preview:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:update:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
 
 ## Enabling OIDC for your Stack
 

--- a/themes/default/content/docs/guides/oidc/gcp.md
+++ b/themes/default/content/docs/guides/oidc/gcp.md
@@ -1,0 +1,41 @@
+---
+title_tag: Configuring OpenID Connect for GCP | OIDC
+title: Configuring OpenID Connect for GCP
+meta_desc: This page describes how to configure OIDC token exchange in GCP for use with Pulumi Deployments
+menu:
+    userguides:
+        parent: oidc
+        weight: 1
+---
+
+This document outlines the steps required to configure Pulumi Deployments to use OpenID Connect to authenticate with GCP. OIDC in GCP uses [workload identity federation](https://cloud.google.com/iam/docs/workload-identity-federation) to allow access to resources. Access to the resources is authorized using attribute conditions that validate the contents of the OIDC token issued by the Pulumi Service.
+
+## Prerequisites
+
+* You must be an admin of your Pulumi organization.
+
+## Creating a GCP Workload Identity Provider
+
+To create the GCP Workload Identity Provider, see the [relevant GCP documentation](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers).
+
+When following the instructions in the documentation:
+
+* For the provider issuer, use `https://api.pulumi.com/deploy`
+* For the audience, use the name of your organization
+* Recall the [format of the subject claim](/docs/guides/oidc/#overview) when adding attribute conditions that check the value of the `google.subject` attribute
+
+Make a note of the workload identity pool ID, provider ID, and service account email address. These will be necessary to enable OIDC for your stack.
+
+## Enabling OIDC for your Stack
+
+1. Navigate to your stack in the Pulumi Console.
+2. Open the stack's "Settings" tab.
+3. Choose the "Deploy" panel.
+4. Under the "OpenID Connect" header, toggle "Enable GCP Integration".
+5. Enter the numerical ID of your GCP project in the "Project ID" field.
+6. Enter the workload pool ID, identity provider ID, and service account email address in the "Workload Pool ID", "Identity Provider ID", and "Service Account Email Address" fields.
+7. If desired, enter the stack's GCP region in the "Region" field. This is typically unnecessary.
+8. If you would like to constrain the duration of the temporary GCP credentials, enter a duration in the form "XhYmZs" in the "Session Duration" field.
+9. Click the "Save deployment configuration" button.
+
+With this configuration, each deployment of this stack will attempt to exchange the deployment's OIDC token for GCP credentials using the specified federated identity prior to running any pre-commands or Pulumi operations. The fetched credentials are published as a credential configuration in the `GOOGLE_CREDENTIALS` environment variable. The raw OIDC token is also available for advanced scenarios in the `PULUMI_OIDC_TOKEN` environment variable and the `/mnt/pulumi/pulumi.oidc` file.

--- a/themes/default/content/docs/reference/deployments-rest-api/_index.md
+++ b/themes/default/content/docs/reference/deployments-rest-api/_index.md
@@ -268,6 +268,7 @@ The following environment variables are used internally by Pulumi Deployments, a
 * **subscriptionId** (string): The ID of the subscription to use.
 
 `GCPOIDCConfiguration` has the following structure:
+
 * **projectId** (string): The numerical ID of the GCP project.
 * **region** (Optional[string]): The region of the GCP project.
 * **workloadPoolId** (string): The ID of the workload pool to use.

--- a/themes/default/content/docs/reference/deployments-rest-api/_index.md
+++ b/themes/default/content/docs/reference/deployments-rest-api/_index.md
@@ -246,6 +246,35 @@ The following environment variables are used internally by Pulumi Deployments, a
 
 {{% /notes %}}
 
+* **oidc** (Optional[OIDCConfiguration]): Allows the deployment to exchange an OIDC token for short-term credentials from a cloud provider.
+
+`OIDCConfiguration` has the following structure:
+
+* **aws** (Optional[AWSOIDCConfiguration]): Configures OIDC for AWS.
+* **azure** (Optional[AzureOIDCConfiguration]): Configures OIDC for Azure.
+* **gcp**: (Optional[GCPOIDCConfiguration]): Configures OIDC for GCP.
+
+`AWSOIDCConfiguration` has the following structure:
+
+* **duration** (Optional[string]): The duration of the assume-role session in "XhYmZs" format.
+* **policyArns** (Optional[list[string]]): A set of IAM policy ARNs that further restrict the assume-role session.
+* **roleArn** (string): The ARN of the role to assume using the OIDC token.
+* **sessionName** (string): The name of the assume-role session.
+
+`AzureOIDCConfiguration` has the following structure:
+
+* **clientId** (string): The client ID of the federated workload identity.
+* **tenantId** (string): The tenant ID of the federated workload identity.
+* **subscriptionId** (string): The ID of the subscription to use.
+
+`GCPOIDCConfiguration` has the following structure:
+* **projectId** (string): The numerical ID of the GCP project.
+* **region** (Optional[string]): The region of the GCP project.
+* **workloadPoolId** (string): The ID of the workload pool to use.
+* **providerId** (string): The ID of the identity provider associated with the workload pool.
+* **serviceAccount** (string): The email address of the service account to use.
+* **tokenLifetime** (Optional[string]): The lifetime of the temporary credentials in "XhYmZs" format.
+
 ##### Examples
 
 ```json
@@ -264,7 +293,7 @@ The following environment variables are used internally by Pulumi Deployments, a
 }
 ```
 
-Override default dependency installation step
+Override default dependency installation step:
 
 ```json
 {
@@ -281,6 +310,22 @@ Override default dependency installation step
   }
 }
 ```
+
+Use OIDC with AWS:
+
+{
+  "operation": "refresh",
+  "preRunCommands": [],
+  "environmentVariables": {
+    "AWS_REGION": "us-west-2"
+  },
+  "oidc": {
+    "aws": {
+      "roleArn": "arn:aws:iam::123456789000:role/pulumi-deploy-role",
+      "sessionName": "pulumi-deploy-session"
+    }
+  }
+}
 
 {{% notes "info" %}}
 

--- a/themes/default/content/docs/reference/deployments-rest-api/_index.md
+++ b/themes/default/content/docs/reference/deployments-rest-api/_index.md
@@ -316,7 +316,6 @@ Use OIDC with AWS:
 
 {
   "operation": "refresh",
-  "preRunCommands": [],
   "environmentVariables": {
     "AWS_REGION": "us-west-2"
   },


### PR DESCRIPTION
These changes add a new set of guides that explain how to configure Pulumi Deployments' OpenID Connect integration with AWS, Azure, and GCP.

These changes also add documentation for OpenID Connect in the Pulumi Deployments API.