### PR TITLE
aws/create-project: Delete GOPATH comment

### DIFF
--- a/themes/default/content/docs/get-started/aws/create-project.md
+++ b/themes/default/content/docs/get-started/aws/create-project.md
@@ -44,7 +44,6 @@ $ pulumi new aws-python
 {{% choosable language go %}}
 
 ```bash
-# from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new aws-go
 ```


### PR DESCRIPTION
This comment isn't needed and interferes with copy-paste functionality.