### PR TITLE
get-started/{azure, gcp}: Don't mention GOPATH

### DIFF
--- a/themes/default/content/docs/get-started/azure/create-project.md
+++ b/themes/default/content/docs/get-started/azure/create-project.md
@@ -44,7 +44,6 @@ $ pulumi new azure-csharp
 {{% choosable language go %}}
 
 ```bash
-# from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new azure-go
 ```

--- a/themes/default/content/docs/get-started/gcp/create-project.md
+++ b/themes/default/content/docs/get-started/gcp/create-project.md
@@ -44,7 +44,6 @@ $ pulumi new gcp-python
 {{% choosable language go %}}
 
 ```bash
-# from within your $GOPATH
 $ mkdir quickstart && cd quickstart
 $ pulumi new gcp-go
 ```


### PR DESCRIPTION
This is a follow up to #2372,
making the same change to the Azure and GCP guidance.
Go projects no longer need to use GOPATH.
