### PR TITLE
get-started/*/create-project: Add prompt examples

### DIFF
--- a/themes/default/content/docs/get-started/aws/create-project.md
+++ b/themes/default/content/docs/get-started/aws/create-project.md
@@ -80,11 +80,34 @@ The [`pulumi new`](/docs/reference/cli/pulumi_new) command creates a new Pulumi 
 
 After logging in, the CLI will proceed with walking you through creating a new project.
 
-First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
+First, you will be asked for a **project name** and **project description**. Hit `ENTER` to accept the default values or specify new values.
 
-Next, you will be asked for the name of a stack. Hit `ENTER` to accept the default value of `dev`.
+```
+This command will walk you through creating a new Pulumi project.
+
+Enter a value or leave blank to accept the (default), and press <ENTER>.
+Press ^C at any time to quit.
+
+project name: (quickstart)
+project description: (A minimal AWS Pulumi program)
+Created project 'quickstart'
+```
+
+Next, you will be asked for a **stack name**. Hit `ENTER` to accept the default value of `dev`.
+
+```
+Please enter your desired stack name.
+To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
+stack name: (dev)
+Created stack 'dev'
+```
 
 Finally, you will be prompted for some configuration values for the stack. For AWS projects, you will be prompted for the AWS region. You can accept the default value or choose another value like `us-west-2`.
+
+```
+aws:region: The AWS region to deploy into: (us-west-2)
+Saved config
+```
 
 > What are [projects](/docs/intro/concepts/project/) and [stacks](/docs/intro/concepts/stack/)? Pulumi projects and stacks let you organize Pulumi code. Consider a Pulumi _project_ to be analogous to a GitHub repo---a single place for code---and a _stack_ to be an instance of that code with a separate configuration. For instance, _Project Foo_ may have multiple stacks for different development environments (Dev, Test, or Prod), or perhaps for different cloud configurations (geographic region for example). See [Organizing Projects and Stacks](/docs/guides/organizing-projects-stacks/) for some best practices on organizing your Pulumi projects and stacks.
 

--- a/themes/default/content/docs/get-started/azure/create-project.md
+++ b/themes/default/content/docs/get-started/azure/create-project.md
@@ -74,11 +74,34 @@ The [`pulumi new`](/docs/reference/cli/pulumi_new) command creates a new Pulumi 
 
 After logging in, the CLI will proceed with walking you through creating a new project.
 
-First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
+First, you will be asked for a **project name** and **project description**. Hit `ENTER` to accept the default values or specify new values.
 
-Next, you will be asked for the name of a stack. Hit `ENTER` to accept the default value of `dev`.
+```
+This command will walk you through creating a new Pulumi project.
+
+Enter a value or leave blank to accept the (default), and press <ENTER>.
+Press ^C at any time to quit.
+
+project name: (quickstart)
+project description: (A minimal Azure Native Pulumi program)
+Created project 'quickstart'
+```
+
+Next, you will be asked for a **stack name**. Hit `ENTER` to accept the default value of `dev`.
+
+```
+Please enter your desired stack name.
+To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
+stack name: (dev)
+Created stack 'dev'
+```
 
 For Azure projects, you will be prompted for the Azure location. You can accept the default value of `WestUS` or choose another location.
+
+```
+azure-native:location: The Azure location to use: (WestUS2)
+Saved config
+```
 
 To list all available locations, use the `az account list-locations` command.
 

--- a/themes/default/content/docs/get-started/gcp/create-project.md
+++ b/themes/default/content/docs/get-started/gcp/create-project.md
@@ -82,11 +82,34 @@ The [`pulumi new`](/docs/reference/cli/pulumi_new) command creates a new Pulumi 
 
 After logging in, the CLI will proceed with walking you through creating a new project.
 
-First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
+First, you will be asked for a **project name** and **project description**. Hit `ENTER` to accept the default values or specify new values.
 
-Next, you will be asked for the name of a stack. Hit `ENTER` to accept the default value of `dev`.
+```
+This command will walk you through creating a new Pulumi project.
 
-Finally, you will be prompted for some configuration values for the stack. For Google Cloud projects, you will be prompted for the Google Cloud region. You can accept the default value or choose another value like `us-west1`.
+Enter a value or leave blank to accept the (default), and press <ENTER>.
+Press ^C at any time to quit.
+
+project name: (quickstart)
+project description: (A minimal Google Cloud Pulumi program)
+Created project 'quickstart'
+```
+
+Next, you will be asked for a **stack name**. Hit `ENTER` to accept the default value of `dev`.
+
+```
+Please enter your desired stack name.
+To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
+stack name: (dev)
+Created stack 'dev'
+```
+
+Finally, you will be prompted for some configuration values for the stack. For Google Cloud projects, you will be prompted for the Google Cloud project. Enter your Google Cloud project ID at this prompt.
+
+```
+gcp:project: The Google Cloud project to deploy into: my-project
+Saved config
+```
 
 > What are [projects](/docs/intro/concepts/project/) and [stacks](/docs/intro/concepts/stack/)? Pulumi projects and stacks let you organize Pulumi code. Consider a Pulumi _project_ to be analogous to a GitHub repo---a single place for code---and a _stack_ to be an instance of that code with a separate configuration. For instance, _Project Foo_ may have multiple stacks for different development environments (Dev, Test, or Prod), or perhaps for different cloud configurations (geographic region for example). See [Organizing Projects and Stacks](/docs/guides/organizing-projects-stacks/) for some best practices on organizing your Pulumi projects and stacks.
 

--- a/themes/default/content/docs/get-started/kubernetes/create-project.md
+++ b/themes/default/content/docs/get-started/kubernetes/create-project.md
@@ -78,6 +78,8 @@ $ pulumi new kubernetes-yaml
 
 After logging in, the CLI will proceed with walking you through creating a new project.
 
+First, you will be asked for a **project name** and **project description**. Hit `ENTER` to accept the default values or specify new values.
+
 ```
 This command will walk you through creating a new Pulumi project.
 
@@ -87,14 +89,16 @@ Press ^C at any time to quit.
 project name: (quickstart)
 project description: (A minimal Kubernetes Pulumi program)
 Created project 'quickstart'
+```
 
+Next, you will be asked for a **stack name**. You can hit `ENTER` to accept the default value of `dev`.
+
+```
+Please enter your desired stack name.
+To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
 stack name: (dev)
 Created stack 'dev'
 ```
-
-First, you will be asked for a project name and description. Hit `ENTER` to accept the default values or specify new values.
-
-Next, you will be asked for the name of a stack. You can hit `ENTER` to accept the default value of `dev`.
 
 > What are [projects](/docs/intro/concepts/project/) and [stacks](/docs/intro/concepts/stack/)? Pulumi projects and stacks let you organize Pulumi code. Consider a Pulumi _project_ to be analogous to a GitHub repo---a single place for code---and a _stack_ to be an instance of that code with a separate configuration. For instance, _Project Foo_ may have multiple stacks for different development environments (Dev, Test, or Prod), or perhaps for different cloud configurations (geographic region for example). See [Organizing Projects and Stacks](/docs/guides/organizing-projects-stacks/) for some best practices on organizing your Pulumi projects and stacks.
 


### PR DESCRIPTION
In the Get Started documentation,
when we tell users to Create a New Project with `pulumi new`,
we include a handful of short paragraphs next to each other
with instructions.

This is not very skimmable:

- keywords like project name/description/stack name
  are hidden in the text
- the actual instruction of what to do is also just hidden
  in the text

For someone following along, it's better to have keywords
related to prompts they're seeing highlighted,
and to include a sample output they can follow along to.

This changes the create-project sections
of all four Get Started with Pulumi pages
in the following way:

- project name and description are bold
- change "name of a stack" to "a stack name", and bold "stack name"
- bold out any provider-specific configuration prompts
- add the output of `pulumi new` after each step;
  I've altered the output slightly to not be language-specific

Before this change, only the k8s tutorial included a sample prompt,
but that was at the top of the text rather than interspersed with it.

---

**Help wanted**:
One thing I'm unsure about is the GCP prompt.
It's unclear whether the project name is required or optional.