### PR TITLE
[deployments] - Add example to user different node version

### DIFF
--- a/themes/default/content/docs/intro/pulumi-service/deployments.md
+++ b/themes/default/content/docs/intro/pulumi-service/deployments.md
@@ -83,9 +83,9 @@ A list of API specifications for preview:
 
 - Each Pulumi Organization and Individual accounts have a limit of 10 concurrent Deployments
 - Deployments are queued, meaning a stack will only have 1 Deployment running at a time
-- An update ran through a Pulumi Deployment will timeout after 2 hours of update time
+- An update ran through a Pulumi Deployment will time out after 2 hours of update time
 - Deployment logs are retained for 90 days
-- Deployments are ran on a t3.large EC2 instance in an isolated AWS account
+- Deployments are run on a t3.large EC2 instance in an isolated AWS account
 - Secret environment variables are encrypted end-to-end
 
 ## Automation via the Pulumi Automation API

--- a/themes/default/content/docs/reference/deployments-rest-api/_index.md
+++ b/themes/default/content/docs/reference/deployments-rest-api/_index.md
@@ -294,7 +294,7 @@ The following environment variables are used internally by Pulumi Deployments, a
 }
 ```
 
-Override default dependency installation step:
+Override default dependency installation step to use poetry:
 
 ```json
 {
@@ -312,8 +312,29 @@ Override default dependency installation step:
 }
 ```
 
+Override default dependency installation step to use a different version of node:
+
+```json
+{
+  "preRunCommands": [
+    "node --version",
+    "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash",
+    ". ~/.bashrc && nvm use 17 && yarn"
+  ],
+  "operation": "update",
+  "environmentVariables": {
+    "NVM_DIR": "/usr/local/bin",
+    "NODE_VERSION": "17"
+  },
+  "options": {
+    "skipInstallDependencies": true
+  }
+}
+```
+
 Use OIDC with AWS:
 
+```json
 {
   "operation": "refresh",
   "environmentVariables": {
@@ -326,6 +347,7 @@ Use OIDC with AWS:
     }
   }
 }
+```
 
 {{% notes "info" %}}
 


### PR DESCRIPTION
This would be a lot less gnarly if the container had `nvm` pre-installed