### PR TITLE
Add a note about future-dated posts

### DIFF
--- a/BLOGGING.md
+++ b/BLOGGING.md
@@ -212,7 +212,7 @@ After your Pull Request is approved, but before merge/publication date, reach ou
 
 ## A Note on Dates and Scheduling for Future Publishing
 
-Because the website is deployed in response to a commit to pulumi/docs `master`, it isn't possible to schedule a post to be released automatically at a precise date and time. (The `date` frontmatter property is used only for sorting and display purposes.) You can, however, influence the timing of the publishing process manually. See the [Merging and Releasing section of the README](README.md#merging-and-releasing) for details.
+Because the website is deployed in response to a commit to pulumi/docs `master`, it isn't possible to schedule a post to be released automatically at a precise date and time. (The `date` frontmatter property is used only for sorting and display purposes; it has no effect on whether or when a post gets published.) You can, however, influence the timing of the publishing process manually. See the [Merging and Releasing section of the README](README.md#merging-and-releasing) for details.
 
 ## Publishing Check List
 


### PR DESCRIPTION
I thought we had a note about how future dates don't prevent blog posts from getting published, but I don't see it, so adding it here.