### PR TITLE
shortcode/secret-new: Fix Go sample

### DIFF
--- a/themes/default/layouts/shortcodes/pulumi-secret-new.html
+++ b/themes/default/layouts/shortcodes/pulumi-secret-new.html
@@ -9,7 +9,7 @@
         <code class="language-python"><a href="/docs/reference/pkg/python/pulumi/#pulumi.Output.secret">Output.secret</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="go">
-        <code class="language-go">NewSecret</code>
+        <code class="language-go"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi#ToSecret">ToSecret</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="csharp">
         <code class="language-csharp">CreateSecret</code>


### PR DESCRIPTION
The pulumi-secret-new refers to "NewSecret" for Go, which doesn't exist.
This likely meant to refer to "ToSecret", which other documentation refers to. Fix the short code and make it a link to the API reference.