### PR TITLE
concepts/secrets: Use language shortcodes for APIs

### DIFF
--- a/themes/default/content/docs/intro/concepts/secrets.md
+++ b/themes/default/content/docs/intro/concepts/secrets.md
@@ -16,10 +16,10 @@ To encrypt a configuration setting before runtime, you can use the CLI command [
 
 An [`Output<T>`](/docs/reference/pkg/python/pulumi#outputs-and-inputs) can be marked secret in a number of ways:
 
-- By reading a secret from configuration using [`Config.get_secret`](/docs/reference/pkg/python/pulumi#pulumi.Config.get_secret)  or [`Config.require_secret`](/docs/reference/pkg/python/pulumi#pulumi.Config.require_secret).
-- By creating a new secret value with [`Output.secret`](/docs/reference/pkg/python/pulumi#pulumi.Output.secret), such as when generating a new random password.
+- By reading a secret from configuration using {{< pulumi-config-getsecret >}} or {{< pulumi-config-requiresecret >}}.
+- By creating a new secret value with {{< pulumi-secret-new >}}, such as when generating a new random password.
 - By marking a resource as having secret properties using [`additionalSecretOutputs`](/docs/intro/concepts/inputs-outputs).
-- By computing a secret value by using [`apply`](/docs/reference/pkg/python/pulumi#outputs-and-inputs) or [`Output.all`](/docs/reference/pkg/python/pulumi#pulumi.Output.all) with another secret value.
+- By computing a secret value by using [`apply`](/docs/reference/pkg/python/pulumi#outputs-and-inputs) or {{< pulumi-all >}} with another secret value.
 
 As soon as an `Output<T>` is marked secret, the Pulumi engine will encrypt it wherever it is stored.
 

--- a/themes/default/layouts/shortcodes/pulumi-config-getsecret.html
+++ b/themes/default/layouts/shortcodes/pulumi-config-getsecret.html
@@ -1,4 +1,4 @@
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,java" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-getSecret">Config.getSecret</a></code>
     </pulumi-choosable>
@@ -13,5 +13,8 @@
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="csharp">
         <code class="language-csharp">Config.GetSecret</code>
+    </pulumi-choosable>
+    <pulumi-choosable class="highlight" type="language" value="java">
+        <code class="language-java">ctx.config().getSecret(key)</code>
     </pulumi-choosable>
 </pulumi-chooser>

--- a/themes/default/layouts/shortcodes/pulumi-config-requiresecret.html
+++ b/themes/default/layouts/shortcodes/pulumi-config-requiresecret.html
@@ -1,4 +1,4 @@
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,java" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#Config-requireSecret">Config.requireSecret</a></code>
     </pulumi-choosable>
@@ -13,5 +13,8 @@
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="csharp">
         <code class="language-csharp">Config.RequireSecret</code>
+    </pulumi-choosable>
+    <pulumi-choosable class="highlight" type="language" value="java">
+        <code class="language-java">ctx.config().requireSecret(key)</code>
     </pulumi-choosable>
 </pulumi-chooser>

--- a/themes/default/layouts/shortcodes/pulumi-secret-new.html
+++ b/themes/default/layouts/shortcodes/pulumi-secret-new.html
@@ -1,4 +1,4 @@
-<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp" option-style="none" class="inline">
+<pulumi-chooser type="language" options="javascript,typescript,python,go,csharp,java" option-style="none" class="inline">
     <pulumi-choosable class="highlight" type="language" value="javascript">
         <code class="language-javascript"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi#secret">secret</a></code>
     </pulumi-choosable>
@@ -9,9 +9,12 @@
         <code class="language-python"><a href="/docs/reference/pkg/python/pulumi/#pulumi.Output.secret">Output.secret</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="go">
-        <code class="language-go">NewSecret</code>
+        <code class="language-go"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi#ToSecret">ToSecret</a></code>
     </pulumi-choosable>
     <pulumi-choosable class="highlight" type="language" value="csharp">
         <code class="language-csharp">CreateSecret</code>
+    </pulumi-choosable>
+    <pulumi-choosable class="highlight" type="language" value="java">
+        <code class="language-java">Output.of(value).asSecret()</code>
     </pulumi-choosable>
 </pulumi-chooser>


### PR DESCRIPTION
Some of the documentation for secrets hard-codes
links to the Python APIs.

Replace these with shortcodes for those APIs
that change as different languages are selected.

Additionally, the following changes were made to the shortcodes:

- getsecret, requiresecret, secret-new: teach about Java
- secret-new: Fix Go API -- there's no "NewSecret", only "ToSecret"

Supersedes #2404

---

Before:
![before](https://user-images.githubusercontent.com/41730/213005502-ea32c27b-d4fa-4e67-9126-0192306c72d7.gif)

After:
![after](https://user-images.githubusercontent.com/41730/213005538-9c65dfdb-da6c-4529-b020-eada110714d9.gif)
