### PR TITLE
add getting started with google cloud workshop 2/9/2023

### DIFF
--- a/themes/default/content/resources/infrastructure-as-code-google-cloud/index.md
+++ b/themes/default/content/resources/infrastructure-as-code-google-cloud/index.md
@@ -1,0 +1,53 @@
+---
+preview_image: ""
+hero:
+  image: /icons/containers.svg
+  title: Getting Started with Infrastructure as Code on Google Cloud
+main:
+  duration: 60 minutes
+  presenters:
+    - name: Josh Kodroff
+      role: Sr. Solutions Architect, Pulumi
+  sortable_date: 2023-02-09T17:00:00.000Z
+  datetime: 2023-02-09T17:00:00.000Z
+  title: Getting Started with Infrastructure as Code on Google Cloud
+  description: In this workshop, you will learn the fundamentals of infrastructure
+    as code through guided exercises. You will be introduced to Pulumi, an
+    infrastructure-as-code platform, where you can use familiar programming
+    languages to provision modern cloud infrastructure. This workshop is
+    designed to help new users become familiar with the core concepts needed to
+    effectively deploy resources on Google Cloud. We will guide you through the
+    Pulumi platform with diagrams and a series of labs to help accelerate your
+    cloud projects.
+event_data:
+  name: Getting Started with Infrastructure as Code on Google Cloud
+  start_date: 2023-02-09T17:00:00.000Z
+  end_date: 2023-02-09T18:00:00.000Z
+  url: https://www.pulumi.com/resources/infrastructure-as-code-google-cloud
+  description: In this workshop, you will learn the fundamentals of infrastructure
+    as code through guided exercises. You will be introduced to Pulumi, an
+    infrastructure-as-code platform, where you can use familiar programming
+    languages to provision modern cloud infrastructure. This workshop is
+    designed to help new users become familiar with the core concepts needed to
+    effectively deploy resources on Google Cloud. We will guide you through the
+    Pulumi platform with diagrams and a series of labs to help accelerate your
+    cloud projects.
+form:
+  hubspot_form_id: 857e74b9-4bbe-408f-860d-b40c3985e872
+  salesforce_campaign_id: 701Du0000009l8dIAA
+  gotowebinar_key: ""
+featured: false
+pre_recorded: false
+pulumi_tv: false
+unlisted: false
+gated: true
+type: webinars
+external: false
+block_external_search_index: false
+aws_only: false
+title: Getting Started with Infrastructure as Code on Google Cloud
+meta_desc: This workshop is designed to help new users become familiar with the
+  core concepts needed to effectively deploy resources on Google Cloud using
+  Pulumi.
+url_slug: infrastructure-as-code-google-cloud
+---

--- a/themes/default/content/resources/infrastructure-as-code-google-cloud/index.md
+++ b/themes/default/content/resources/infrastructure-as-code-google-cloud/index.md
@@ -8,6 +8,8 @@ main:
   presenters:
     - name: Josh Kodroff
       role: Sr. Solutions Architect, Pulumi
+    - name: Gary Bowers
+      role: Senior Cloud Consultant, Google Cloud
   sortable_date: 2023-02-09T17:00:00.000Z
   datetime: 2023-02-09T17:00:00.000Z
   title: Getting Started with Infrastructure as Code on Google Cloud


### PR DESCRIPTION
issue: https://github.com/pulumi/marketing/issues/679

create workshop for getting started with google cloud on 2/9/2023