### PR TITLE
Remove warning for Node 19.x

### DIFF
--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -13,14 +13,6 @@ aliases: ["/docs/reference/javascript/"]
 
 Pulumi supports writing your infrastructure as code in any JavaScript language running on Node.js using any of the [Current, Active and Maintenance LTS versions](https://nodejs.org/en/about/releases/).
 
-{{% notes type="warning" %}}
-While we expect _most_ uses of Pulumi to work on 19.2 and higher our function serialization doesn't currently handle those versions due to internal V8 changes.
-
-See [the GitHub issue](https://github.com/pulumi/pulumi/issues/11488) for tracking this.
-
-Due to this we're not currently testing on 19.2 and as such don't consider it fully supported.
-{{% /notes %}}
-
 Because programs are just JavaScript, you may elect to write them in any manner you'd normally write Node.js programs.
 That includes TypeScript, CoffeeScript, or Babel, in addition to your favorite tools such as build systems, linters, or
 test frameworks.


### PR DESCRIPTION
The upstream issue should be resolved, with details in https://github.com/pulumi/pulumi/pull/11932 and https://github.com/pulumi/pulumi/issues/11488.

This should be merged after pulumi/pulumi#11932 has merged in case there are any other issues with Node current.