### PR TITLE
Shorten language nav items

### DIFF
--- a/themes/default/content/docs/intro/languages/dotnet.md
+++ b/themes/default/content/docs/intro/languages/dotnet.md
@@ -1,5 +1,7 @@
 ---
-title: "How to Use .NET (C#, VB, F#) for Pulumi"
+title: .NET (C#, VB, F#)
+title_tag: How to use .NET (C#, VB, F#) with Pulumi
+h1: How to use .NET (C#, VB, F#) with Pulumi
 meta_desc: An overview of how to use .NET languages like C# and F# with Pulumi for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:

--- a/themes/default/content/docs/intro/languages/go.md
+++ b/themes/default/content/docs/intro/languages/go.md
@@ -1,5 +1,7 @@
 ---
-title: "How to Use Go for Pulumi"
+title: Go
+title_tag: How to use Go with Pulumi
+h1: How to use Go with Pulumi
 meta_desc: An overview of how to use the Go language with Pulumi for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:

--- a/themes/default/content/docs/intro/languages/java.md
+++ b/themes/default/content/docs/intro/languages/java.md
@@ -1,5 +1,7 @@
 ---
-title: "How to Use Java for Pulumi"
+title: Java
+title_tag: How to use Java with Pulumi
+h1: How to use Java with Pulumi
 meta_desc: An overview of how to use the Java language with Pulumi for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:

--- a/themes/default/content/docs/intro/languages/javascript.md
+++ b/themes/default/content/docs/intro/languages/javascript.md
@@ -1,5 +1,7 @@
 ---
-title: "How to Use Pulumi with Node.js (TypeScript)"
+title: Node.js (TypeScript)
+title_tag: How to use Node.js (TypeScript) with Pulumi
+h1: How to use Node.js (TypeScript) with Pulumi
 meta_desc: Learn how to use Node.js languages like JavaScript and TypeScript with Pulumi for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:

--- a/themes/default/content/docs/intro/languages/python.md
+++ b/themes/default/content/docs/intro/languages/python.md
@@ -1,5 +1,7 @@
 ---
-title: "How to Use Pulumi with Python"
+title: Python
+title_tag: How to use Python with Pulumi
+h1: How to use Python with Pulumi
 meta_desc: An overview of how to use Python with Pulumi for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:

--- a/themes/default/content/docs/intro/languages/yaml.md
+++ b/themes/default/content/docs/intro/languages/yaml.md
@@ -1,6 +1,8 @@
 ---
-title: "How to use Pulumi YAML"
-meta_desc: An overview of how to use the Pulumi YAML config languages for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
+title: YAML
+title_tag: How to use Pulumi YAML
+h1: How to use Pulumi YAML
+meta_desc: An overview of how to use Pulumi YAML for infrastructure as code on any cloud (AWS, Azure, GCP, Kubernetes, etc.).
 menu:
   intro:
     parent: languages


### PR DESCRIPTION
This change makes a few tweaks to the frontmatter params of our language pages in order to shorten the items in the TOC navigation and make the titles themselves a bit more consistent. 

Right now, these list items are pretty verbose, so they aren't quite as amenable to scanning as they used to be. With this change, we should be able to keep the desired SEO changes introduced with https://github.com/pulumi/pulumi-hugo/pull/2214 (as page titles and H1s won't be affected), but restore the navigation to its previous state.

Before:

![image](https://user-images.githubusercontent.com/274700/214439860-fc74997d-2681-46a8-bca1-02b647a05d70.png)

After:

![image](https://user-images.githubusercontent.com/274700/214439941-8d2ee29f-f21b-4adc-b728-01b76b25fa00.png)

Hopefully this is acceptable; if the current UX is intentional, and it'd be significantly better to keep the longer titles in the navigation as well, let me know and I'll close. But this does seem like a better overall UX, and hopefully strikes a good  balance between UX and SEO.