### PR TITLE
add slack alerting to notify on build failures

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,3 +53,19 @@ jobs:
         with:
           file_pattern: go.*
           commit_message: Update go.mod
+
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "build failure in pulumi-hugo repo :meow_sad:"
+          SLACK_USERNAME: hugobot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png

--- a/.github/workflows/scheduled-upstream-sync.yaml
+++ b/.github/workflows/scheduled-upstream-sync.yaml
@@ -38,3 +38,19 @@ jobs:
 
       - name: Show value of 'has_new_commits'
         run: echo ${{ steps.sync.outputs.has_new_commits }}
+
+  notify:
+    if: failure()
+    name: Send slack notification
+    runs-on: ubuntu-latest
+    needs: [sync_latest_from_upstream]
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: docs-ops
+          SLACK_COLOR: "#F54242"
+          SLACK_MESSAGE: "upstream sync failure in pulumi-hugo repo :meow_sad:"
+          SLACK_USERNAME: hugobot
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_ICON: https://www.pulumi.com/logos/brand/avatar-on-white.png


### PR DESCRIPTION
part of issue: https://github.com/pulumi/home/issues/2566

This PR adds slack notifications on failures for workflows in this repo. These are enabled for the workflows that run on push to master and the upstream sync job. They are not turned on any jobs that run before a pull request merges. These notifications will get posted to the docs-ops channel in slack, which contains a link to the failed job and the name of the workflow that failed (listed as the actions url in the image below). 

The image below says "Pull Request" as the name of the workflow that failed, because I was using that workflow just for testing (they are not actually turned on for pull request failures though).

![image](https://user-images.githubusercontent.com/16751381/216197106-be6283fb-26dc-4a69-bb67-92dbf0d70eca.png)

