### PR TITLE
Fix action url link in slack alert

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [build]
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: docker://sholung/action-slack-notify:v2.3.0
         env:
           SLACK_CHANNEL: docs-ops
           SLACK_COLOR: "#F54242"

--- a/.github/workflows/scheduled-upstream-sync.yaml
+++ b/.github/workflows/scheduled-upstream-sync.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: [sync_latest_from_upstream]
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: docker://sholung/action-slack-notify:v2.3.0
         env:
           SLACK_CHANNEL: docs-ops
           SLACK_COLOR: "#F54242"


### PR DESCRIPTION
There was a bug with the github action that is being used and there has been a [PR](https://github.com/rtCamp/action-slack-notify/pull/142) open in that repo for a few weeks to fix it and looks like the action maintainer has not gotten around to addressing it.  I went and forked the repo and applied the fix. I then rebuilt the action's docker image and published a new docker image with the fix for this to use. This PR just updates the action to reference the new docker image I published with the fix. We switch back to using the "official" action once they get around to addressing that PR.

The problem was that the action was coded to reference the workflow by a specific commit. The issue with that, is that often times when things are merged to master or pulled in from upstream, it kicks off multiple workflows that run against that same commit, so the link that was there did not know specifically which workflow failed, it only knew the commit sha it failed at. This fix now links to the specific workflow run that failed from that commit. 

Here is a before and after of the URL that was being linked to: 

before fix:
https://github.com/pulumi/docs/commit/b299b33f5a6277493020174e552c14ffd17bdc1c/checks

after fix
https://github.com/pulumi/docs/actions/runs/4087423781/attempts/1

This should resolve the issue now that we are referencing the specific run, though we won't know for real until it actually gets used in real life.
