### PR TITLE
shortcode/install-go: Recommend "supported" versions of Go

### DIFF
--- a/themes/default/layouts/shortcodes/install-go.html
+++ b/themes/default/layouts/shortcodes/install-go.html
@@ -10,8 +10,9 @@
     </div>
     <div class="note-body">
         <p>
-            Pulumi requires Go 1.18 or later. If you're using Linux, your distribution may not provide an up to date version of the Go compiler. To check what version of Go you
-            have installed, use:<code>go version</code>.
+            Pulumi requires a <a href="https://go.dev/doc/devel/release#policy">supported version of Go</a>&mdash; this typically refers to the two most recent minor releases. If
+            you're using Linux, your distribution may not provide an up to date version of the Go compiler. To check what version of Go you have installed, use:
+            <code>go version</code>.
         </p>
     </div>
 </div>


### PR DESCRIPTION
Some of our documentation currently states that
we support Go 1.18 or higher.
This is not accurate.
We support only those versions of Go that are supported by upstream Go:
typically the latest two minor versions (e.g., 1.20 and 1.19 right now).

This tweaks the wording there to just "supported versions"
instead of hard-coding 1.18 or 1.19
and having to update that 6 months from now.

---

This shortcode is used on the following pages:

```
% rg -l install-go
themes/default/content/docs/get-started/aws/begin.md
themes/default/content/docs/get-started/gcp/begin.md
themes/default/content/docs/get-started/kubernetes/begin.md
themes/default/content/docs/get-started/azure/begin.md
themes/default/content/docs/guides/automation-api/getting-started-automation-api.md
```

Previews:

- http://pulumi-hugo-origin-pr-2476-fd37c0f5.s3-website.us-west-2.amazonaws.com/docs/get-started/aws/begin/
- https://pulumi-hugo-origin-pr-2476-fd37c0f5.s3-website.us-west-2.amazonaws.com/docs/get-started/gcp/begin/
- http://pulumi-hugo-origin-pr-2476-fd37c0f5.s3-website.us-west-2.amazonaws.com/docs/get-started/kubernetes/begin/
- http://pulumi-hugo-origin-pr-2476-fd37c0f5.s3-website.us-west-2.amazonaws.com/docs/get-started/azure/begin/
- http://pulumi-hugo-origin-pr-2476-fd37c0f5.s3-website.us-west-2.amazonaws.com/docs/guides/automation-api/getting-started-automation-api/