### PR TITLE
cd/github: Recommend setup-go v3 with latest go-version

### DIFF
--- a/themes/default/content/docs/guides/continuous-delivery/github-actions.md
+++ b/themes/default/content/docs/guides/continuous-delivery/github-actions.md
@@ -144,9 +144,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.18.x
+          go-version: 'stable'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -284,9 +284,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 'stable'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -498,9 +498,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 'stable'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -657,9 +657,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 'stable'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -821,9 +821,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: 1.16.x
+          go-version: 'stable'
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Our documentation for how to use Pulumi with GitHub Actions
included GitHub Workflow files using setup-go@v2
referencing specific Go releases.

[actions/setup-go@v3](https://github.com/actions/setup-go#v3)
added support for a 'stable' (and 'oldstable') alias.
With this alias, the action will always use the latest stable Go release
instead of a specific version.

This updates our GitHub integration documentation
to recommend setup-go v3 and the 'stable' alias
over a specific pinned version.

That leaves this documentation and the sample workflow files
more future-proof as newer versions of Go are released.
