### PR TITLE
cd/github: Fix language on code fences

### DIFF
--- a/themes/default/content/docs/guides/continuous-delivery/github-actions.md
+++ b/themes/default/content/docs/guides/continuous-delivery/github-actions.md
@@ -573,7 +573,7 @@ project directory. For example:
 
 {{% choosable language typescript %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -608,7 +608,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language python %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -645,7 +645,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language go %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -682,7 +682,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -733,7 +733,7 @@ as follows:
 
 {{% choosable language typescript %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -771,7 +771,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language python %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -809,7 +809,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language go %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request
@@ -847,7 +847,7 @@ jobs:
 {{% /choosable %}}
 {{% choosable language csharp %}}
 
-```diff
+```yaml
 name: Pulumi
 on:
   - pull_request


### PR DESCRIPTION
A few code fences on the GitHub Actions page use 'diff'
even though they contain YAML.

This switches those fences to YAML.
