### PR TITLE
python: __opts__ => opts

### DIFF
--- a/themes/default/content/blog/deploy-to-multiple-regions/index.md
+++ b/themes/default/content/blog/deploy-to-multiple-regions/index.md
@@ -111,7 +111,7 @@ const buck = new aws.s3.Bucket("my-bucket", {
 ```python
 buck = aws.s3.Bucket('my-bucket',
     # ...
-    __opts__=pulumi.ResourceOptions(provider=aws_west_2)
+    opts=pulumi.ResourceOptions(provider=aws_west_2)
 )
 ```
 
@@ -486,7 +486,7 @@ primary_db = aws.rds.Instance('primary',
     password=db_password.result,
     backup_retention_period=retention_period,
     skip_final_snapshot=True,
-    __opts__=pulumi.ResourceOptions(provider=us_provider)
+    opts=pulumi.ResourceOptions(provider=us_provider)
 )
 ```
 
@@ -587,7 +587,7 @@ secondary_db = aws.rds.Instance("secondary",
     replicate_source_db=primary_db.arn,
     backup_retention_period=retention_period,
     skip_final_snapshot=True,
-    __opts__=pulumi.ResourceOptions(provider=eu_provider)
+    opts=pulumi.ResourceOptions(provider=eu_provider)
 )
 ```
 

--- a/themes/default/content/docs/guides/adopting/from_kubernetes.md
+++ b/themes/default/content/docs/guides/adopting/from_kubernetes.md
@@ -850,14 +850,14 @@ dep = Deployment('nginx-dep',
             'metadata': { 'labels': labels },
             'spec': { 'containers': [{ 'name': 'nginx', 'image': 'nginx' }] },
         },
-    }, __opts__=ResourceOptions(provider=render_provider)
+    }, opts=ResourceOptions(provider=render_provider)
 )
 svc = Service('nginx-svc',
     spec={
         'type': 'LoadBalancer',
         'selector': labels,
         'ports': [{'port': 80}],
-    }, __opts__=ResourceOptions(provider=render_provider)
+    }, opts=ResourceOptions(provider=render_provider)
 )
 ```
 

--- a/themes/default/content/docs/intro/concepts/resources/providers.md
+++ b/themes/default/content/docs/intro/concepts/resources/providers.md
@@ -184,7 +184,7 @@ useast1 = aws.Provider("useast1", region="us-east-1")
 cert = aws.acm.Certificate("cert",
     domain_name="foo.com",
     validation_method="EMAIL",
-    __opts__=pulumi.ResourceOptions(provider=useast1))
+    opts=pulumi.ResourceOptions(provider=useast1))
 
 # Create an ALB listener in the default region that references the ACM certificate created above.
 listener = aws.lb.Listener("listener",
@@ -351,8 +351,8 @@ let myResource = new MyResource("myResource", { providers: { aws: useast1, kuber
 ```python
 class MyResource(pulumi.ComponentResource):
     def __init__(self, name, opts):
-        instance = aws.ec2.Instance("instance", ..., __opts__=pulumi.ResourceOptions(parent=self))
-        pod = kubernetes.core.v1.Pod("pod", ..., __opts__=pulumi.ResourceOptions(parent=self))
+        instance = aws.ec2.Instance("instance", ..., opts=pulumi.ResourceOptions(parent=self))
+        pod = kubernetes.core.v1.Pod("pod", ..., opts=pulumi.ResourceOptions(parent=self))
 
 useast1 = aws.Provider("useast1", region="us-east-1")
 myk8s = kubernetes.Provider("myk8s", context="test-ci")


### PR DESCRIPTION
Some of the examples pass options to Python APIs
via `__opts__` instead of `opts`.
The only time `__opts__` is supposed to be used is when
the resource has an existing `opts` parameter,
which is not the case for the resources in these examples.

This updates them to use `opts`.

Resolves #2471
