### PR TITLE
Clean up `bucketEndpoint` use in GCP Golang Get Started

### DIFF
--- a/themes/default/content/docs/get-started/gcp/deploy-changes.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-changes.md
@@ -299,13 +299,12 @@ bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketO
 if err != nil {
     return err
 }
-
-bucketEndpoint := pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name)
 ```
 
 Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:
 
 ```go
+bucketEndpoint := pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name)
 ctx.Export("bucketEndpoint", bucketEndpoint)
 ```
 

--- a/themes/default/content/docs/get-started/gcp/deploy-changes.md
+++ b/themes/default/content/docs/get-started/gcp/deploy-changes.md
@@ -296,10 +296,11 @@ bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketO
     ContentType: pulumi.String("text/html"),
     Source:      pulumi.NewFileAsset("index.html"),
 })
-bucketEndpoint := pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name)
 if err != nil {
     return err
 }
+
+bucketEndpoint := pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name)
 ```
 
 Finally, at the end of the program file, export the resulting bucket’s endpoint URL so you can easily access it:

--- a/themes/default/content/docs/get-started/gcp/modify-program.md
+++ b/themes/default/content/docs/get-started/gcp/modify-program.md
@@ -113,7 +113,6 @@ bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketO
     Bucket: bucket.Name,
     Source: pulumi.NewFileAsset("index.html"),
 })
-bucketEndpoint := pulumi.Sprintf("http://storage.googleapis.com/%s/%s", bucket.Name, bucketObject.Name)
 if err != nil {
     return err
 }


### PR DESCRIPTION
Addressing two issues I discovered while going through the GCP Golang Get Started guide:
1. On the Modify Program step of the guide, `bucketEndpoint` is assigned but never used and therefore cannot compile. If a User wanted to run this program before proceeding to the Deploy Changes step, they would get an error like this: `./main.go:47:3: bucketEndpoint declared and not used`.
2. At the Deploy Changes step, `bucketEndpoint` is assigned before error handling for the previous call, which means it may proceed to attempt to access attributes from a `nil` value during interpolation when it should be providing the error from the `NewBucketObject` call.