### PR TITLE
Remove dead links, handle missing URLs on the About page

### DIFF
--- a/themes/default/data/awards.toml
+++ b/themes/default/data/awards.toml
@@ -2,7 +2,6 @@
 title = "Best Innovation in Coding Tools, 2022"
 featured = true
 img = "/logos/press/awards/devies-2022.png"
-url = "https://www.developerweek.com/awards/"
 
 [[awards]]
 title = "Top Open Source Tech Startups 2021"
@@ -50,7 +49,6 @@ url = "https://www.crn.com/slide-shows/cloud/the-10-hottest-kubernetes-startups-
 title = "Gartner Cool Vendor 2020"
 featured = true
 img = "/logos/press/awards/gartner-cool-vendor.png"
-url = "https://www.gartner.com/doc/reprints?id=1-1Z160QCQ&ct=200514&st=sb"
 
 [[awards]]
 title = "IDC Innovator 2020"

--- a/themes/default/layouts/page/about.html
+++ b/themes/default/layouts/page/about.html
@@ -244,9 +244,13 @@
             <ul class="list-none block p-0 inline-flex flex-wrap justify-center">
                 {{ range first 8 (where $.Site.Data.awards.awards "featured" true) }}
                     <li class="mx-4 bg-white">
-                        <a data-track="award-{{ .url | urlize }}" href="{{ .url }}">
+                        {{ if .url }}
+                            <a data-track="award-{{ .url | urlize }}" href="{{ .url }}">
+                                <img class="inline-block w-32 rounded p-2 border-2 border-gray-300" src="{{ .img }}" title="{{ .title }}" />
+                            </a>
+                        {{ else }}
                             <img class="inline-block w-32 rounded p-2 border-2 border-gray-300" src="{{ .img }}" title="{{ .title }}" />
-                        </a>
+                        {{ end }}
                     </li>
                 {{ end }}
             </ul>


### PR DESCRIPTION
A couple of awards URLs are no longer valid and don't seem to have good replacements. This change removes them and updates the page template to handle records with no URLs. (The Awards page already seems to handle this.)
