### PR TITLE
Hide broken icon in python docs

### DIFF
--- a/themes/default/theme/src/scss/_api-python.scss
+++ b/themes/default/theme/src/scss/_api-python.scss
@@ -32,7 +32,9 @@ section[id="pulumi-python-sdk"] {
     // Don't show the header link - there's an anchorjs link on this header that does the
     // job just as well.
     h1[id$="\B6"],
-    h2[id$="\B6"] {
+    h2[id$="\B6"],
+    h1[id$="\F0C1"],
+    h2[id$="\F0C1"] {
         a.headerlink {
             @apply hidden;
         }


### PR DESCRIPTION
Sphinx is now emitting a private unicode character ("\F0C1") corresponding to a FontAwesome chain icon next to headers, which renders as an empty box on our site.

![image (1)](https://user-images.githubusercontent.com/710598/223590917-6f085806-0003-4d21-83e9-f385f132a318.png)

Previously, it emitted a "¶" symbol ("\B6"), which we hid with CSS since we have our own way of injecting header links client side with JavaScript.

This change updates the styles to also hide the new unicode character.