### PR TITLE
fix width of language chooser on mobile

### DIFF
--- a/themes/default/layouts/page/product.html
+++ b/themes/default/layouts/page/product.html
@@ -58,7 +58,7 @@
         </div>
 
         {{ range $item := .Params.key_features.items }}
-            <div class="container mx-auto text-center pt-20 w-9/12">
+            <div class="container mx-auto text-center pt-20 w-11/12 sm:w-9/12">
                 <h3>{{ $item.title }}</h3>
                 <h4>{{ $item.sub_title }}</h4>
                 <p class="mx-auto w-9/12 xl:w-7/12 my-12 text-center text-gray-600">


### PR DESCRIPTION
fixing rendering of language chooser on mobile. it was a bit off in the mobile view.

![Screenshot from 2023-03-15 11-59-43](https://user-images.githubusercontent.com/16751381/225415250-7e39a1f3-2293-419a-a994-17ee9d7e3b31.png)

![Screenshot from 2023-03-15 11-59-13](https://user-images.githubusercontent.com/16751381/225415282-b68e033d-6236-4d4e-a74b-1cb2f6b2eff3.png)
