### PR TITLE
Sarah/resources cleanup

### DIFF
--- a/themes/default/content/resources/infrastructure-as-code-go-2020-04-01/index.md
+++ b/themes/default/content/resources/infrastructure-as-code-go-2020-04-01/index.md
@@ -46,7 +46,7 @@ main:
     # Webinar title.
     title: "Modern Cloud Infrastructure in Go"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2020-04-01T18:30:00.000 -04:00
+    sortable_date: 2020-04-01T18:30:00.000-04:00
     # Duration of the webinar.
     duration: "1.5 hours"
     # Datetime of the webinar.

--- a/themes/default/layouts/resources/list.html
+++ b/themes/default/layouts/resources/list.html
@@ -97,6 +97,12 @@
                     {{ $filters := slice "all" }}
 
 
+                    <!-- create values to determine if date is upcoming -->
+                    {{ $nowUnix := now.UnixMilli }}
+                    <!-- add 24 hours to event date to list it for an extra day -->
+                    {{ $eventDateUnix := (add (.date | time.AsTime).UnixMilli (duration "hour" 24).Milliseconds) }}
+
+
                     <!-- Set the values based on the type of the page. -->
                     {{ if eq $data.Type "webinars" }}
                         {{ $description = $data.Params.meta_desc }}
@@ -132,7 +138,7 @@
                         {{ else if $data.Params.pre_recorded }}
                             {{ $icon = "video" }}
                             {{ $filters = $filters | append "videos" }}
-                        {{ else }}
+                        {{ else if lt $nowUnix $eventDateUnix }}
                             {{ $filters = $filters | append "upcoming" }}
                         {{ end }}
 

--- a/themes/default/layouts/webinars/single.html
+++ b/themes/default/layouts/webinars/single.html
@@ -12,6 +12,13 @@
 {{ end }}
 
 {{ define "main" }}
+    <!-- time variables to remove registration forms from past events -->
+    {{ $nowUnix := now.UnixMilli }}
+    <!-- add 24 hours to event date to list it for an extra day -->
+    {{ $eventDateUnix := (add (.Params.main.sortable_date | time.AsTime).UnixMilli (duration "hour" 24).Milliseconds) }}
+    {{ $timePassed := gt $nowUnix $eventDateUnix }}
+
+
     <section id="webinarLandingPage" class="px-4">
         <div class="container mx-auto max-w-6xl pt-16 pb-8 md:flex">
             {{ if .Params.gated }}
@@ -59,7 +66,7 @@
                     {{ end }}
                 </div>
                 <div id="webinarRegistrationForm" class="mt-10 md:mt-0 md:w-1/2 md:mx-8 bg-gray-200 rounded p-6">
-                    {{ if .Params.unlisted }}
+                    {{ if (or .Params.unlisted $timePassed) }}
                         <h4 class="text-orange">Recording Coming Soon!</h4>
                         <p>This live webinar is no longer available. The recording will be posted to this page when it is available.</p>
                     {{ else }}


### PR DESCRIPTION
Automatically remove workshops from the "upcoming" tab when they've occurred more than 24 hours in the past, and replace the registration form with "Recording coming soon"

This doesn't remove them from the "all" tab, so we can still see which workshops need videos added