### PR TITLE
Make Zephyr ToC entries consistent

### DIFF
--- a/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
@@ -21,12 +21,11 @@ The ultimate goal of this series is to discuss recommended practices for using P
 
 Here are links to all the blog posts in the series (entries below that are not linked are planned but haven't yet been published---this will get updated as new posts are published):
 
-* [**IaC Recommended Practices: Code Organization and Stacks**](/blog/iac-recommended-practices-code-organization-and-stacks/) (this post)
+* **IaC Recommended Practices: Code Organization and Stacks** (this post)
 * [IaC Recommended Practices: Developer Stacks and Git Branches](/blog/iac-recommended-practices-developer-stacks-git-branches/)
-* IaC Recommended Practices: Structuring Pulumi Projects
-* IaC Recommended Practices: Local Testing with Pulumi
-* IaC Recommended Practices: Moving Infrastructure State Between Projects
+* [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * IaC Recommended Practices: Tying Stacks Together with Stack References
+* IaC Recommended Practices: Local Testing with Pulumi
 * IaC Recommended Practices: Evolving the Application
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse

--- a/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
@@ -22,11 +22,10 @@ The ultimate goal of this series is to discuss recommended practices for using P
 Here are links to all of the posts in the series. Entries below that are not yet linked are planned, but not yet published:
 
 * [IaC Recommended Practices: Code Organization and Stacks](/blog/iac-recommended-practices-code-organization-and-stacks/)
-* [**IaC Recommended Practices: Developer Stacks and Git Branches**](/blog/iac-recommended-practices-developer-stacks-git-branches/) (this post)
-* IaC Recommended Practices: Structuring Pulumi Projects
-* IaC Recommended Practices: Local Testing with Pulumi
-* IaC Recommended Practices: Moving Infrastructure State Between Projects
+* **IaC Recommended Practices: Developer Stacks and Git Branches** (this post)
+* [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * IaC Recommended Practices: Tying Stacks Together with Stack References
+* IaC Recommended Practices: Local Testing with Pulumi
 * IaC Recommended Practices: Evolving the Application
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse

--- a/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
@@ -19,21 +19,14 @@ The [first blog post](/blog/iac-recommended-practices-code-organization-and-stac
 
 Here are links to all the blog posts in the series (entries below that are not linked are planned but haven't yet been published---this will get updated as new posts are published):
 
-[IaC Recommended Practices: Code Organization and Stacks](/blog/iac-recommended-practices-code-organization-and-stacks/)
-
-[IaC Recommended Practices: Developer Stacks and Git Branches](/blog/iac-recommended-practices-developer-stacks-git-branches/)
-
-**IaC Recommended Practices: Structuring Pulumi Projects** (this post)
-
-IaC Recommended Practices: Tying Stacks Together with Stack References
-
-IaC Recommended Practices: Local Testing with Pulumi
-
-IaC Recommended Practices: Evolving the Application
-
-IaC Recommended Practices: Adding Pulumi Deployments
-
-IaC Recommended Practices: Refactoring for Reuse
+* [IaC Recommended Practices: Code Organization and Stacks](/blog/iac-recommended-practices-code-organization-and-stacks/)
+* [IaC Recommended Practices: Developer Stacks and Git Branches](/blog/iac-recommended-practices-developer-stacks-git-branches/)
+* **IaC Recommended Practices: Structuring Pulumi Projects** (this post)
+* IaC Recommended Practices: Tying Stacks Together with Stack References
+* IaC Recommended Practices: Local Testing with Pulumi
+* IaC Recommended Practices: Evolving the Application
+* IaC Recommended Practices: Adding Pulumi Deployments
+* IaC Recommended Practices: Refactoring for Reuse
 
 ## Catching up with Zephyr
 


### PR DESCRIPTION
This PR makes the ToC (table of contents) entries for the Zephyr posts consistent. It ensures that the ToC is a bulleted list in all three posts, and updates the hyperlinks accordingly to account for the publication of the third post.