### PR TITLE
archetypes: Use Semantic Line Breaks per Style Guide

### DIFF
--- a/themes/default/archetypes/blog-post/index.md
+++ b/themes/default/archetypes/blog-post/index.md
@@ -1,48 +1,62 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 
-# The date represents the post's publish date, and by default corresponds with
-# the date this file was generated. Posts with future dates are visible in development,
-# but excluded from production builds. Use the time and timezone-offset portions of
-# of this value to schedule posts for publishing later.
+# The date represents the post's publish date,
+# and by default corresponds with the date this file was generated.
+# Posts with future dates are visible in development,
+# but excluded from production builds.
+# Use the time and timezone-offset portions of of this value
+# to schedule posts for publishing later.
 date: {{ .Date }}
 
-# Use the meta_desc property to provide a brief summary (one or two sentences)
-# of the content of the post, which is useful for targeting search results or social-media
-# previews. This field is required or the build will fail the linter test.
+# Use the meta_desc property to provide a brief summary
+# (one or two sentences) of the content of the post,
+# which is useful for targeting search results or social-media previews.
+# This field is required or the build will fail the linter test.
 # Max length is 160 characters.
 meta_desc:
 
 # The meta_image appears in social-media previews and on the blog home page.
-# A placeholder image representing the recommended format, dimensions and aspect
-# ratio has been provided for you.
+# A placeholder image representing the recommended format, dimensions and aspect ratio
+# has been provided for you.
 meta_image: meta.png
 
-# At least one author is required. The values in this list correspond with the `id`
-# properties of the team member files at /data/team/team. Create a file for yourself
-# if you don't already have one.
+# At least one author is required.
+# The values in this list correspond with the `id` properties
+# of the team member files at /data/team/team.
+# Create a file for yourself if you don't already have one.
 authors:
     - joe-duffy
 
-# At least one tag is required. Lowercase, hyphen-delimited is recommended.
+# At least one tag is required.
+# Lowercase, hyphen-delimited is recommended.
 tags:
     - change-me
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md.
-# for additional details, and please remove these comments before submitting for review.
+# for additional details,
+# and please remove these comments before submitting for review.
 ---
 
-What you put here will appear on the index page. In most cases, you'll also want to add a Read More link after this paragraph (though technically, that's optional). To do that, just add an HTML comment like the one below.
+What you put here will appear on the index page.
+In most cases, you'll also want to add a Read More link after this paragraph
+(though technically, that's optional).
+To do that, just add an HTML comment like the one below.
 
 <!--more-->
 
 And then everything _after_ that comment will appear on the post page itself.
 
-Either way, avoid using images or code samples [in the first 70 words](https://gohugo.io/content-management/summaries/#automatic-summary-splitting) of your post, as these may not render properly in summary contexts (e.g., on the blog home page or in social-media previews).
+Either way, avoid using images or code samples
+[in the first 70 words](https://gohugo.io/content-management/summaries/#automatic-summary-splitting) of your post,
+as these may not render properly in summary contexts (e.g., on the blog home page or in social-media previews).
 
 ## Writing the Post
 
-For help assembling the content of your post, see [BLOGGING.md](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md). For general formatting guidelines, see the [Style Guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
+For help assembling the content of your post,
+see [BLOGGING.md](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
+For general formatting guidelines,
+see the [Style Guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
 
 ## Code Samples
 

--- a/themes/default/archetypes/learn/module/_index.md
+++ b/themes/default/archetypes/learn/module/_index.md
@@ -2,16 +2,20 @@
 title: "{{ replace .Name "-" " " | title }}"
 layout: module
 
-# The date represents the date the course was created. Posts with future dates are visible
-# in development, but excluded from production builds. Use the time and timezone-offset
-# portions of of this value to schedule posts for publishing later.
+# The date represents the date the course was created.
+# Posts with future dates are visible in development,
+# but excluded from production builds.
+# Use the time and timezone-offset portions of this value
+# to schedule posts for publishing later.
 date: {{ .Date }}
 
-# Draft posts are visible in development, but excluded from production builds.
+# Draft posts are visible in development,
+# but excluded from production builds.
 # Set this property to `false` before submitting the module for review.
 draft: true
 
-# The description summarizes the course. It appears on the Learn home and module index pages.
+# The description summarizes the course.
+# It appears on the Learn home and module index pages.
 description: Here is a brief description of what this module's all about.
 
 # The meta_desc property is used for targeting search results or social-media previews.
@@ -21,8 +25,8 @@ meta_desc: Here is a brief description of what this module's all about.
 index: 0
 
 # The meta_image appears in social-media previews and on the Learn Pulumi home page.
-# A placeholder image representing the recommended format, dimensions and aspect
-# ratio has been provided for reference.
+# A placeholder image representing the recommended format, dimensions and aspect ratio
+# has been provided for reference.
 meta_image: meta.png
 
 youll_learn:
@@ -39,6 +43,6 @@ providers:
     - aws
 ---
 
-This is the content that will appear at the top of the module index page. It should
-describe the overall goal of the module and briefly summarize what the reader will know
-how to do by the end of it.
+This is the content that will appear at the top of the module index page.
+It should describe the overall goal of the module
+and briefly summarize what the reader will know how to do by the end of it.

--- a/themes/default/archetypes/learn/topic/index.md
+++ b/themes/default/archetypes/learn/topic/index.md
@@ -2,16 +2,20 @@
 title: "{{ replace .Name "-" " " | title }}"
 layout: topic
 
-# The date represents the date the course was created. Posts with future dates are visible
-# in development, but excluded from production builds. Use the time and timezone-offset
-# portions of of this value to schedule posts for publishing later.
+# The date represents the date the course was created.
+# Posts with future dates are visible # in development,
+# but excluded from production builds.
+# Use the time and timezone-offset portions of of this value
+# to schedule posts for publishing later.
 date: {{ .Date }}
 
-# Draft posts are visible in development, but excluded from production builds.
+# Draft posts are visible in development,
+# but excluded from production builds.
 # Set this property to `false` before submitting the topic for review.
 draft: true
 
-# The description summarizes the course. It appears on the Learn home and module index pages.
+# The description summarizes the course.
+# It appears on the Learn home and module index pages.
 description: Here is a brief description of what this topic will cover.
 
 # The meta_desc property is used for targeting search results or social-media previews.
@@ -24,26 +28,29 @@ index: 0
 estimated_time: 10
 
 # The meta_image appears in social-media previews and on the Learn Pulumi home page.
-# A placeholder image representing the recommended format, dimensions and aspect
-# ratio has been provided for reference.
+# A placeholder image representing the recommended format, dimensions and aspect ratio
+# has been provided for reference.
 meta_image: meta.png
 
-# The optional meta_video also appears in social-media previews (taking precedence
-# over the image) and on the module's index page. A placeholder video representing
-# the recommended format, dimensions and aspect ratio has been provided for reference.
+# The optional meta_video also appears in social-media previews
+# (taking precedence over the image) and on the module's index page.
+# A placeholder video representing # the recommended format, dimensions and aspect ratio
+# has been provided for reference.
 # meta_video:
 #     url: 'http://destination-bucket-568cee2.s3-website-us-west-2.amazonaws.com/video/2020-09-03-16-46-41.mp4'
 #     thumb: 'http://destination-bucket-568cee2.s3-website-us-west-2.amazonaws.com/thumbs/2020-09-03-16-46-41.jpg'
 #     preview: 'http://destination-bucket-568cee2.s3-website-us-west-2.amazonaws.com/previews/2020-09-03-16-46-41.jpg'
 #     poster: 'http://destination-bucket-568cee2.s3-website-us-west-2.amazonaws.com/posters/2020-09-03-16-46-41.jpg'
 
-# At least one author is required. The values in this list correspond with the `id`
-# properties of the team member files at /data/team/team. Create a file for yourself
-# if you don't already have one.
+# At least one author is required.
+# The values in this list correspond with the `id` properties
+# of the team member files at /data/team/team.
+# Create a file for yourself if you don't already have one.
 authors:
     - christian-nunciato
 
-# At least one tag is required. Lowercase, hyphen-delimited is recommended.
+# At least one tag is required.
+# Lowercase, hyphen-delimited is recommended.
 tags:
     - change-me
 

--- a/themes/default/archetypes/templates/template/index.md
+++ b/themes/default/archetypes/templates/template/index.md
@@ -5,14 +5,16 @@ layout: template
 # Make sure this is description accurate for this template.
 meta_desc: The {{ replace .Name "-" " " | title }} template makes it easy to deploy a static website on $CLOUD with Pulumi, some service, and some other cloud service.
 
-# Be sure to replace this image. Figma source file:
+# Be sure to replace this image.
+# Figma source file:
 # https://www.figma.com/file/lGrSpwbGGmbixEuewMbtkh/Template-Architecture-Diagrams?node-id=15%3A196
 meta_image: meta.png
 
 # Appears on the cards on template-overview pages.
 card_desc: Deploy a $THING on $CLOUD with Pulumi, some cloud service, and some other cloud service.
 
-# Used for generating language-specific CLI commands and links to the templates repo on GitHub.
+# Used for generating language-specific CLI commands
+# and links to the templates repo on GitHub.
 template:
   prefix: architecture-cloud
   dirname: my-project
@@ -23,35 +25,53 @@ template:
     - csharp
     - yaml
 
-# Used for generating links to sibling templates in the right-hand nav. Slug is this template's parent directory.
+# Used for generating links to sibling templates in the right-hand nav.
+# Slug is this template's parent directory.
 cloud:
   name: Amazon Web Services
   slug: aws
 
-# The content below is meant help you get started and to serve as a guide to work by. Feel free to adjust it needed for your template.
+# The content below is meant help you get started
+# and to serve as a guide to work by.
+# Feel free to adjust it needed for your template.
 ---
 
-The $CLOUD $ARCHITECTURE template creates an infrastructure as code project in your favorite language that deploys a $THING to $CLOUD with Pulumi. It uses this resource, this other resource, and probably some other awesome resource to accomplish some particular desirable outcome. The template generates a complete Pulumi program, including $INCLUDED_STUFF, to give you a working project out of the box that you can customize easily and extend to suit your needs.
+The $CLOUD $ARCHITECTURE template creates an infrastructure as code project
+in your favorite language that deploys a $THING to $CLOUD with Pulumi.
+It uses this resource, this other resource, and probably some other awesome resource
+to accomplish some particular desirable outcome.
+The template generates a complete Pulumi program, including $INCLUDED_STUFF,
+to give you a working project out of the box that you can customize easily
+and extend to suit your needs.
 
 ![An architecture diagram of the Pulumi $CLOUD $ARCHITECTURE template](./architecture.png)
 
 ## Using this template
 
-To use this template to deploy your own $THING, make sure you've [installed Pulumi](/docs/get-started/install/) and [configured your $CLOUD credentials](/registry/packages/$CLOUD/installation-configuration/#credentials), then create a new [project](/docs/intro/concepts/project/) using the template in your language of choice:
+To use this template to deploy your own $THING,
+make sure you've [installed Pulumi](/docs/get-started/install/)
+and [configured your $CLOUD credentials](/registry/packages/$CLOUD/installation-configuration/#credentials),
+then create a new [project](/docs/intro/concepts/project/) using the template in your language of choice:
 
 {{< templates/pulumi-new >}}
 
-Follow the prompts to complete the new-project wizard. When it's done, you'll have a complete Pulumi project that's ready to deploy and configured with the most common settings. Feel free to inspect the code in {{< langfile >}} for a closer look.
+Follow the prompts to complete the new-project wizard.
+When it's done, you'll have a complete Pulumi project
+that's ready to deploy and configured with the most common settings.
+Feel free to inspect the code in {{< langfile >}} for a closer look.
 
 ## Deploying the project
 
-The template requires no additional configuration. Once the new project is created, you can deploy it immediately with [`pulumi up`](/docs/reference/cli/pulumi_up/):
+The template requires no additional configuration.
+Once the new project is created,
+you can deploy it immediately with [`pulumi up`](/docs/reference/cli/pulumi_up/):
 
 ```bash
 $ pulumi up
 ```
 
-When the deployment completes, Pulumi exports the following [stack output](/docs/intro/concepts/stack/#outputs) values:
+When the deployment completes,
+Pulumi exports the following [stack output](/docs/intro/concepts/stack/#outputs) values:
 
 someOutput
 : The provider-assigned property of the widget resource.
@@ -59,7 +79,10 @@ someOutput
 someOtherOutput
 : The fully-qualified HTTP URL of the widget resource.
 
-Output values like these are useful in many ways, most commonly as inputs for other stacks or related cloud resources. The computed `someOutput`, for example, can be used from the command line to open the newly deployed website in your favorite web browser:
+Output values like these are useful in many ways,
+most commonly as inputs for other stacks or related cloud resources.
+The computed `someOutput`, for example, can be used from the command line
+to open the newly deployed website in your favorite web browser:
 
 ```bash
 $ open $(pulumi stack output cdnURL)
@@ -67,7 +90,8 @@ $ open $(pulumi stack output cdnURL)
 
 ## Customizing the project
 
-Projects created with the $ARCHITECTURE template expose the following [configuration](/docs/intro/concepts/config/) settings:
+Projects created with the $ARCHITECTURE template expose
+the following [configuration](/docs/intro/concepts/config/) settings:
 
 someProp
 : The description of the property. Defaults to `someValue`.
@@ -75,11 +99,15 @@ someProp
 otherProp
 : The file to use for top-level pages. Defaults to `otherValue`.
 
-All of these settings are optional and may be adjusted either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`) or by changing their values with [`pulumi config set`](/docs/reference/cli/pulumi_config_set/) as shown below.
+All of these settings are optional and may be adjusted
+either by editing the stack configuration file directly (by default, `Pulumi.dev.yaml`)
+or by changing their values with [`pulumi config set`](/docs/reference/cli/pulumi_config_set/) as shown below.
 
 ### Changing a config value
 
-If you already have a $THING you'd like to deploy on $CLOUD with Pulumi, you can do so either by replacing placeholder content in the `foo` folder or by configuring the stack to point to another folder on your computer with the `someProp` setting:
+If you already have a $THING you'd like to deploy on $CLOUD with Pulumi,
+you can do so either by replacing placeholder content in the `foo` folder
+or by configuring the stack to point to another folder on your computer with the `someProp` setting:
 
 ```bash
 $ pulumi config set someProp ../some/value
@@ -88,7 +116,9 @@ $ pulumi up
 
 ### Adjusting the code somehow
 
-By default, the generated program configures some resource in a particular way, which may or may not be the best fit for your project. You can adjust these settings by changing the code in {{< langfile >}}:
+By default, the generated program configures some resource in a particular way,
+which may or may not be the best fit for your project.
+You can adjust these settings by changing the code in {{< langfile >}}:
 
 {{% chooser language "typescript,python,go,csharp,yaml" / %}}
 
@@ -151,7 +181,8 @@ cdn:
 
 {{% /choosable %}}
 
-Alternatively, you could make these settings configurable as well, which would allow them to vary between other stacks in your project.
+Alternatively, you could make these settings configurable as well,
+which would allow them to vary between other stacks in your project.
 
 ## Next steps
 
@@ -175,7 +206,8 @@ $ pulumi destroy
 
 ## Learn more
 
-Congratulations! You're now well on your way to managing a production-grade $THING on $CLOUD with Pulumi --- and there's lots more you can do from here:
+Congratulations!
+You're now well on your way to managing a production-grade $THING on $CLOUD with Pulumi --- and there's lots more you can do from here:
 
 * Discover more architecture templates in [Templates &rarr;](/templates/)
 * Dive into the $CLOUD package by exploring the [API docs in the Registry &rarr;](/registry/packages/$CLOUD/)

--- a/themes/default/archetypes/templates/type/_index.md
+++ b/themes/default/archetypes/templates/type/_index.md
@@ -3,7 +3,8 @@ title: "{{ replace .Name "-" " " | title }} Templates"
 layout: overview
 meta_desc: Pulumi program templates that make it easy to deploy {{ replace .Name "-" " " }}s on AWS, Azure, or Google Cloud Platform.
 
-# Be sure to replace this image. Figma source file:
+# Be sure to replace this image.
+# Figma source file:
 # https://www.figma.com/file/lGrSpwbGGmbixEuewMbtkh/Template-Architecture-Diagrams?node-id=15%3A196
 meta_image: meta.png
 

--- a/themes/default/archetypes/video-transcript/index.md
+++ b/themes/default/archetypes/video-transcript/index.md
@@ -10,8 +10,8 @@ pre_recorded: true
 pulumi_tv: true
 unlisted: false
 
-# Gated videos will have a registration form and the user will need
-# to fill out the form before viewing.
+# Gated videos will have a registration form
+# and the user will need to fill out the form before viewing.
 gated: false
 
 # The layout of the landing page.
@@ -20,13 +20,14 @@ type: webinars
 external: false
 block_external_search_index: false
 
-# The url slug for the video landing page. If this is an external
-# video, use the external URL as the value here.
+# The url slug for the video landing page.
+# If this is an external video, use the external URL as the value here.
 url_slug: "{{ .Name }}"
 
 # The content of the hero section.
 hero:
-    # The title text in the hero. This also serves as the pages H1.
+    # The title text in the hero.
+    # This also serves as the pages H1.
     title: ""
 
 # Content for the left hand side section of the page.
@@ -35,7 +36,8 @@ main:
     title: ""
     # URL for embedding a URL for ungated videos.
     youtube_url: ""
-    # Sortable date. The datetime Hugo will use to sort the videos in date order.
+    # Sortable date.
+    # The datetime Hugo will use to sort the videos in date order.
     sortable_date: 2021-02-05T10:00:00-07:00
     # Duration of the video.
     duration: "2 hours"
@@ -47,7 +49,8 @@ main:
         - name: ""
           role: ""
 
-# This section contains the transcript for a video. It is optional.
+# This section contains the transcript for a video.
+# It is optional.
 transcript: |
     Here is where you would put the transcript for a recorded video.
 ---

--- a/themes/default/archetypes/webinar/index.md
+++ b/themes/default/archetypes/webinar/index.md
@@ -9,36 +9,39 @@ featured: false
 # If the video is pre-recorded or live.
 pre_recorded: false
 
-# If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
+# If the video is part of the PulumiTV series.
+# Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
 
 # The preview image will be shown on the list page.
 preview_image: ""
 
-# Webinars with unlisted as true will not be shown on the webinar list
+# Webinars with unlisted as true will not be shown on the webinar list.
 unlisted: false
 
-# Gated webinars will have a registration form and the user will need
-# to fill out the form before viewing.
+# Gated webinars will have a registration form
+# and the user will need to fill out the form before viewing.
 gated: false
 
 # The layout of the landing page.
 type: webinars
 
-# External webinars will link to an external page instead of a webinar
-# landing/registration page. If the webinar is external you will need
-# set the 'block_external_search_index' flag to true so Google does not index
-# the webinar page created.
+# External webinars will link to an external page
+# instead of a webinar landing/registration page.
+# If the webinar is external
+# you will need set the 'block_external_search_index' flag to true
+# so Google does not index the webinar page created.
 external: false
 block_external_search_index: false
 
-# The url slug for the webinar landing page. If this is an external
-# webinar, use the external URL as the value here.
+# The url slug for the webinar landing page.
+# If this is an external webinar, use the external URL as the value here.
 url_slug: "{{ .Name }}"
 
 # The content of the hero section.
 hero:
-    # The title text in the hero. This also serves as the pages H1.
+    # The title text in the hero.
+    # This also serves as the pages H1.
     title: ""
     # The image the appears on the right hand side of the hero.
     image: "/icons/containers.svg"
@@ -55,7 +58,8 @@ main:
     title: ""
     # URL for embedding a URL for ungated webinars.
     youtube_url: ""
-    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    # Sortable date.
+    # The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2020-02-05T10:00:00-07:00
     # Duration of the webinar.
     duration: "2 hours"
@@ -73,7 +77,8 @@ main:
     learn:
         - ""
 
-# This section contains the transcript for a video. It is optional.
+# This section contains the transcript for a video.
+# It is optional.
 transcript: |
     Here is where you would put the transcript for a recorded video.
 

--- a/themes/default/archetypes/whitepaper/index.md
+++ b/themes/default/archetypes/whitepaper/index.md
@@ -12,22 +12,24 @@ featured: false
 # Resources with unlisted as true will not be shown on the webinar list
 unlisted: false
 
-# Gated resources will have a registration form and the user will need
-# to fill out the form before viewing.
+# Gated resources will have a registration form
+# and the user will need to fill out the form before viewing.
 gated: false
 
 # The layout of the landing page.
 type: webinars
 
-# External resources will link to an external page instead of a resource
-# landing/registration page. If the resource is external you will need
-# set the 'block_external_search_index' flag to true so Google does not index
-# the resource page created.
+# External resources will link to an external page
+# instead of a resource landing/registration page.
+# If the resource is external
+# you will need set the 'block_external_search_index' flag to true
+# so Google does not index the resource page created.
 external: false
 block_external_search_index: false
 
-# The url slug for the resource landing page. If this is an external
-# resource, use the external URL as the value here.
+# The url slug for the resource landing page.
+# If this is an external resource,
+# use the external URL as the value here.
 url_slug: "{{ .Name }}"
 
 # The content of the hero section.


### PR DESCRIPTION
We changed the style guide in #2474
to recommend Semantic Line Breaks for new content
while leaving old content as-is.

This had less of an effect
because our generated sample content does not comply with the guidance.

This updates all archetypes (templates for generated files)
to use semantic line breaks in both content and comments,
so that future content is more likely to match the guidance.
