### PR TITLE
Add rss feed for events

### DIFF
--- a/themes/default/content/resources/_index.md
+++ b/themes/default/content/resources/_index.md
@@ -27,4 +27,6 @@ sections:
     - label: Whitepapers
       anchor: whitepapers
       icon: book
+
+outputs: ["html", "rss"]
 ---

--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -8,10 +8,11 @@
         <pubDate>{{ now | time.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
         {{ range (sort .Data.Pages ".Params.main.sortable_date").Reverse }}
             <item>
+                <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
                 <title>{{ .Params.title }}</title>
                 <description>{{ .Params.meta_desc }}</description>
                 <date>{{ .Params.main.sortable_date }}</date>
-                <link>https://pulumi.com/resources/{{ replace .Params.url_slug "/" ""}}</link>
+                <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
             </item>
         {{ end }}
     </channel>

--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -11,7 +11,7 @@
                 <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
                 <title>{{ .Params.title }}</title>
                 <description>{{ .Params.meta_desc }}</description>
-                <date>{{ .Params.main.sortable_date }}</date>
+                <pubDate>{{ .Params.main.sortable_date }}</pubDate>
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
             </item>
         {{ end }}

--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -1,0 +1,18 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\" ?>" | safeHTML }}
+<rss version="2.0">
+    <channel>
+        <title>Pulumi Events</title>
+        <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
+        <description>Feed containing upcoming Pulumi events.</description>
+        <language>{{ .Site.LanguageCode }}</language>
+        <pubDate>{{ now | time.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+        {{ range (sort .Data.Pages ".Params.main.sortable_date").Reverse }}
+            <item>
+                <title>{{ .Params.title }}</title>
+                <description>{{ .Params.meta_desc }}</description>
+                <date>{{ .Params.main.sortable_date }}</date>
+                <link>https://pulumi.com/resources/{{ replace .Params.url_slug "/" ""}}</link>
+            </item>
+        {{ end }}
+    </channel>
+</rss>


### PR DESCRIPTION
Adds the rss feed to surface events sorted by date desc.
![image](https://user-images.githubusercontent.com/16751381/226975808-ef4cfa19-701e-4dd8-8d0e-7ed8a4445eea.png)

