### PR TITLE
block external search indexing on unlisted resources

### DIFF
--- a/themes/default/content/resources/advanced-infrastructure-as-code-2020-04-08/index.md
+++ b/themes/default/content/resources/advanced-infrastructure-as-code-2020-04-08/index.md
@@ -20,6 +20,8 @@ preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+# block indexing on unlisted pages
+block_external_search_index: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/advanced-infrastructure-as-code-2020-04-16/index.md
+++ b/themes/default/content/resources/advanced-infrastructure-as-code-2020-04-16/index.md
@@ -20,6 +20,7 @@ preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+block_external_search_index: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/armory-continuous-delivery-for-infrastructure/index.md
+++ b/themes/default/content/resources/armory-continuous-delivery-for-infrastructure/index.md
@@ -34,7 +34,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true 
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/ask-the-expert/index.md
+++ b/themes/default/content/resources/ask-the-expert/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/automating-infrastructure-as-code-workflows/index.md
+++ b/themes/default/content/resources/automating-infrastructure-as-code-workflows/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/aws-howdy-partner-twitch/index.md
+++ b/themes/default/content/resources/aws-howdy-partner-twitch/index.md
@@ -31,7 +31,7 @@ type: webinars
 # External webinars will link to an external page instead of a webinar
 # landing/registration page.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/azure-infrastructure-as-code-workshop-2020-07-23/index.md
+++ b/themes/default/content/resources/azure-infrastructure-as-code-workshop-2020-07-23/index.md
@@ -20,6 +20,7 @@ preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+block_external_search_index: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/azure-infrastructure-as-code-workshop-2020-10-19/index.md
+++ b/themes/default/content/resources/azure-infrastructure-as-code-workshop-2020-10-19/index.md
@@ -11,6 +11,7 @@ pre_recorded: false
 pulumi_tv: false
 preview_image: /images/webinar/pulumi_workshop.jpg
 unlisted: true
+block_external_search_index: true
 gated: true
 type: webinars
 external: false

--- a/themes/default/content/resources/cloud-engineering-in-aws-with-python/index.md
+++ b/themes/default/content/resources/cloud-engineering-in-aws-with-python/index.md
@@ -31,7 +31,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/docker-show-multi-language-components/index.md
+++ b/themes/default/content/resources/docker-show-multi-language-components/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/end-to-end-infrastructure-apps-and-auth-with-pulumi-and-auth0/index.md
+++ b/themes/default/content/resources/end-to-end-infrastructure-apps-and-auth-with-pulumi-and-auth0/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/getting-started-infrastructure-as-code-2020-03-30/index.md
+++ b/themes/default/content/resources/getting-started-infrastructure-as-code-2020-03-30/index.md
@@ -22,6 +22,8 @@ preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/hacktoberfest-2020/index.md
+++ b/themes/default/content/resources/hacktoberfest-2020/index.md
@@ -24,7 +24,7 @@ event:
     integrations, automation, and infrastructure libraries!
 type: events
 url_slug: hacktoberfest-2020
-block_external_search_index: false
+block_external_search_index: true
 ---
 ## About Hacktoberfest
 

--- a/themes/default/content/resources/how-to-test-cloud-infrastructure/index.md
+++ b/themes/default/content/resources/how-to-test-cloud-infrastructure/index.md
@@ -21,6 +21,8 @@ preview_image: "/images/webinar/pulumi_tech_talk.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/infrastructure-as-code-workshop-2020-04-09/index.md
+++ b/themes/default/content/resources/infrastructure-as-code-workshop-2020-04-09/index.md
@@ -23,6 +23,9 @@ preview_image: "/images/webinar/pulumi_workshop.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
+
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/intro-to-aws-crosswalk/index.md
+++ b/themes/default/content/resources/intro-to-aws-crosswalk/index.md
@@ -20,6 +20,9 @@ preview_image: "https://img.youtube.com/vi/PQNfLqUHu64/hqdefault.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
+
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/intro-to-aws-crosswalk/index.md
+++ b/themes/default/content/resources/intro-to-aws-crosswalk/index.md
@@ -19,9 +19,9 @@ pulumi_tv: true
 preview_image: "https://img.youtube.com/vi/PQNfLqUHu64/hqdefault.jpg"
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: true
+unlisted: false
 # don't index on unlisted resources
-block_external_search_index: true
+block_external_search_index: false
 
 
 # Gated webinars will have a registration form and the user will need

--- a/themes/default/content/resources/introduction-to-infrastructure-as-code/index.md
+++ b/themes/default/content/resources/introduction-to-infrastructure-as-code/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/multicloud-oss-database-deployments-with-aiven/index.md
+++ b/themes/default/content/resources/multicloud-oss-database-deployments-with-aiven/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/sharing-and-reusing-infrastructure-best-practices/index.md
+++ b/themes/default/content/resources/sharing-and-reusing-infrastructure-best-practices/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/using-pulumi-to-supercharge-your-deployments/index.md
+++ b/themes/default/content/resources/using-pulumi-to-supercharge-your-deployments/index.md
@@ -30,7 +30,7 @@ type: webinars
 # set the 'block_external_search_index' flag to true so Google does not index
 # the webinar page created.
 external: false
-block_external_search_index: false
+block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.

--- a/themes/default/content/resources/workshop-london-2020-09-23/index.md
+++ b/themes/default/content/resources/workshop-london-2020-09-23/index.md
@@ -11,6 +11,8 @@ aliases:
 type: events
 
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
 
 # The url slug for the even landing page.
 url_slug: "workshop-london-2020-09-23"

--- a/themes/default/content/resources/workshop-nyc-2020-07-08/index.md
+++ b/themes/default/content/resources/workshop-nyc-2020-07-08/index.md
@@ -11,6 +11,8 @@ aliases:
 type: events
 
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
 
 # The url slug for the even landing page.
 url_slug: "workshop-nyc-2020-07-08"

--- a/themes/default/content/resources/workshop-redmond-2020-03-12/index.md
+++ b/themes/default/content/resources/workshop-redmond-2020-03-12/index.md
@@ -9,6 +9,8 @@ aliases:
 
 # Events with unlisted as true will not be shown on the event list
 unlisted: true
+# don't index on unlisted resources
+block_external_search_index: true
 
 # The layout of the landing page.
 type: events


### PR DESCRIPTION
List of changed resources (in case you don't want to crawl through a ton of files to figure this out)

https://www.pulumi.com/resources/advanced-infrastructure-as-code-2020-04-08/
https://www.pulumi.com/resources/advanced-infrastructure-as-code-2020-04-16/
https://www.pulumi.com/resources/armory-continuous-delivery-for-infrastructure/
https://www.pulumi.com/resources/ask-the-expert/
https://www.pulumi.com/resources/automating-infrastructure-as-code-workflows/
https://www.pulumi.com/resources/aws-howdy-partner-twitch/
https://www.pulumi.com/resources/azure-infrastructure-as-code-workshop-2020-07-23/
https://www.pulumi.com/resources/azure-infrastructure-as-code-workshop-2020-10-19/
cloud-engineering-in-aws-with-python (aliased)
https://www.pulumi.com/resources/docker-show-multi-language-components/
https://www.pulumi.com/resources/end-to-end-infrastructure-apps-and-auth-with-pulumi-and-auth0/
https://www.pulumi.com/resources/getting-started-with-infrastructure-as-code/
https://www.pulumi.com/resources/hacktoberfest-2020/
https://www.pulumi.com/resources/how-to-test-cloud-infrastructure/
https://www.pulumi.com/resources/getting-started-with-infrastructure-as-code/
https://www.pulumi.com/resources/intro-to-aws-crosswalk/
https://www.pulumi.com/resources/introduction-to-infrastructure-as-code/
https://www.pulumi.com/resources/multicloud-oss-database-deployments-with-aiven/
https://www.pulumi.com/resources/sharing-and-reusing-infrastructure-best-practices/
https://www.pulumi.com/resources/using-pulumi-to-supercharge-your-deployments/
https://www.pulumi.com/resources/workshop-london-2020-09-23/
https://www.pulumi.com/resources/workshop-nyc-2020-07-08/
https://www.pulumi.com/resources/workshop-redmond-2020-03-12/

not entirely sure about [this one](https://www.pulumi.com/resources/intro-to-aws-crosswalk/) since it's unlisted but has a video. @SaraDPH let me know if I should do something else with it, but it's pretty old (2019)
