### PR TITLE
adjust pricing meta description to appease google

### DIFF
--- a/themes/default/content/pricing/_index.md
+++ b/themes/default/content/pricing/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Pricing
-meta_desc: Pulumi's open source infrastructure as code SDK and enterprise SaaS products together provide editions for teams of all sizes.
+meta_desc: Pulumi's open source infrastructure as code SDK and enterprise SaaS is available in various editions with a starting cost of free.
 type: page
 layout: pricing
 menu:


### PR DESCRIPTION
i believe google is scanning our pricing page for the word `cost` or an actual dollar amount
to inform the meta description, as its not currently displaying the actual meta description and instead is displaying...
>Estimated resources: 24 · Estimated monthly cost without applying free credits: $8.76 USD / 17,520 credits ...

[internal slack convo](https://pulumi.slack.com/archives/C0331801TGE/p1679864803005889)


very open to feedback on this, pls share your ideas if you have a better one!!!