### PR TITLE
fix deploy relrefs on pricing page

### DIFF
--- a/themes/default/layouts/page/pricing.html
+++ b/themes/default/layouts/page/pricing.html
@@ -63,7 +63,7 @@
                                         <span>
                                             <i class="fa fa-check pricing-checkmark mr-2"></i>
                                             <span
-                                                ><a href="{{ relref . " /docs/intro/pulumi-service/deployments" }}" class="underline">Hosted deployments</a>
+                                                ><a href="{{ relref . " /docs/intro/deployments" }}" class="underline">Hosted deployments</a>
                                                 <pulumi-tooltip>
                                                     <i class="w-8 fas fa-info-circle text-blue-600"></i>
                                                     <span slot="content"> This feature is in preview.</span>
@@ -119,7 +119,7 @@
                                                 <span>
                                                     <i class="fa fa-check pricing-checkmark mr-2"></i>
                                                     <span
-                                                        ><a href="{{ relref . " /docs/intro/pulumi-service/deployments" }}" class="underline">Hosted deployments</a>
+                                                        ><a href="{{ relref . " /docs/intro/deployments" }}" class="underline">Hosted deployments</a>
                                                         <pulumi-tooltip>
                                                             <i class="w-8 fas fa-info-circle text-blue-600"></i>
                                                             <span slot="content"> This feature is in preview and is available at no additional cost during the preview.</span>
@@ -1039,7 +1039,7 @@
                 <div class="compare-plans-table-row-container">
                     <div class="compare-plans-table-row-item">
                         <span>
-                            <a class="compare-table-link" href="{{ relref . " /docs/intro/pulumi-service/deployments" }}">Hosted deployments</a>
+                            <a class="compare-table-link" href="{{ relref . " /docs/intro/deployments" }}">Hosted deployments</a>
                             <pulumi-tooltip>
                                 <i class="w-8 fas fa-info-circle text-blue-600"></i>
                                 <span slot="content"> This feature is in preview and is available at no additional cost during the preview.</span>


### PR DESCRIPTION
The rest of the links redirect with the alias, but these three appear to fail the docs build