### PR TITLE
ci: Use ubuntu-latest

### DIFF
--- a/.github/workflows/pull-request-closed.yml
+++ b/.github/workflows/pull-request-closed.yml
@@ -8,7 +8,7 @@ jobs:
     # Only run this job for events that originate on this repository.
     if: github.event.pull_request.head.repo.full_name == github.repository
     name: Find and remove buckets
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out branch
         uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build
     # Only run this step on the upstream repo.
     if: github.repository == 'pulumi/pulumi-hugo'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Node
         uses: actions/setup-node@v1

--- a/.github/workflows/scheduled-cleanup.yml
+++ b/.github/workflows/scheduled-cleanup.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   cleanup:
     name: Find and remove buckets
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out branch
         uses: actions/checkout@v2


### PR DESCRIPTION
CI jobs appear to be failing with the message:

    The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead.
    For more details see https://github.com/actions/virtual-environments/issues/6002

Switch them all to ubuntu-latest.
