### PR TITLE
fix pulumi up timezone

### DIFF
--- a/themes/default/content/resources/pulumi-up-2023/index.md
+++ b/themes/default/content/resources/pulumi-up-2023/index.md
@@ -38,5 +38,5 @@ url_slug: "/pulumi-up"
 # Content for the left hand side section of the page.
 main:
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
-    sortable_date: 2023-06-15T08:00:00+02:00
+    sortable_date: 2023-06-15T08:00:00-07:00
 ---


### PR DESCRIPTION
I think the timezone on this is wrong and it is affecting the date that will get displayed on the dashboard card we want to show in the console since it is compensating for the timezone which was enough to make it show the day before. So it is showing June 14 instead of June 15. It should be 8:00am pacific time (-7:00) from what I understand.

![image](https://user-images.githubusercontent.com/16751381/230479439-56b7c6a7-d9de-4956-a693-33cadae49aee.png)


