### PR TITLE
update broken links

### DIFF
--- a/themes/default/content/blog/pulumi-release-notes-85/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-85/index.md
@@ -231,7 +231,7 @@ We implemented a workaround to support Azure DevOps repositories when driving Pu
 
 Every week we keep shipping provider updates. Two highlights on our native providers:
 
-- Azure Native shipped 20 new resources, including support for `networkcloud` and `voiceservices` ([changelog](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md))
+- Azure Native shipped 20 new resources, including support for `networkcloud` and `voiceservices` ([changelog](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md))
 - AWS Native shipped 30 new resources in `apigatewayv2`, `appflow`, `applicationautoscaling`, `cloudtrail`, `connect`, `directoryservice`, `ec2`, `fms`, `gamecast`, `gamelift`, `kendraranking`, `networkmanager`, `omics`, `organizations`, `sagemaker`, `secretsmanager`, `simspaceweaver`, and `systemsmanagersap` modules ([changelog](https://github.com/pulumi/pulumi-aws-native/blob/master/CHANGELOG.md))
 
 Five new community packages were added to the Registry: [Vultr](https://www.pulumi.com/registry/packages/vultr/), [Zscaler Private Access (ZPA)](https://www.pulumi.com/registry/packages/zpa/), [Zscaler Internet Access (ZIA)](https://www.pulumi.com/registry/packages/zia/), [Statuscake](https://www.pulumi.com/registry/packages/statuscake/), and [Nuage](https://www.pulumi.com/registry/packages/nuage/).

--- a/themes/default/content/blog/pulumi-release-notes-m58/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m58/index.md
@@ -255,7 +255,7 @@ Learn more at [pulumi/pulumi-kubernetes#1421](https://github.com/pulumi/pulumi-k
 
 We shipped 5 new versions of the Azure Native provider (1.11.0 through 1.15.0) that collectively added 10 new resources that you can manage with the Azure Native provider, including Azure Arc data services and Azure Event Grid resources.
 
-[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1150-2020-07-01)
+[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1150-2020-07-01)
 
 ### Google Native provider adds support for enums and more
 

--- a/themes/default/content/blog/pulumi-release-notes-m59/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m59/index.md
@@ -50,7 +50,7 @@ spec:
 
 We shipped 4 new versions of the Azure Native provider (1.16.0 through 1.19.0) that collectively added 12 new resources that you can manage with the Azure Native provider, including Fast Healthcare Interoperability Resources (FHIR) and Azure Relay resources.
 
-[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1190-2021-07-22)
+[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1190-2021-07-22)
 
 ### Google Native: autonaming; easier management of project and region settings
 

--- a/themes/default/content/blog/pulumi-release-notes-m60/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m60/index.md
@@ -37,7 +37,7 @@ Learn more in these GitHub issues [1](https://github.com/pulumi/pulumi-eks/issue
 
 We shipped 2 new versions of the Azure Native provider (1.20.0 through 1.21.0) that collectively added 8 new resources that you can manage with the Azure Native provider, including core networking and IoT security resources.
 
-[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1210-2021-08-12)
+[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1210-2021-08-12)
 
 ## Pulumi CLI and core technologies
 

--- a/themes/default/content/blog/pulumi-release-notes-m61/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m61/index.md
@@ -369,7 +369,7 @@ Learn more in the [MinIO](/registry/packages/minio/) and [Snowflake](/registry/p
 
 We shipped new versions of the Azure Native provider (1.22.0 through 1.28.0) that collectively added 15 new resources across services like SQL Server, Kusto, DocumentDB, and Power BI that you can now manage with the Azure Native provider.
 
-[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1280-2021-09-13)
+[See the full list](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1280-2021-09-13)
 
 ## Pulumi CLI and core technologies
 

--- a/themes/default/content/blog/pulumi-release-notes-m62/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m62/index.md
@@ -40,7 +40,7 @@ Learn more in the [AWS Lambda functions blog post](/blog/aws-lambda-functions-po
 
 ### New resources in the Azure Native provider
 
-We shipped new versions of the Azure Native provider (1.29.0 through 1.34.0) that collectively added [14 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1340-2021-09-30) across services like Azure SQL, Azure API Management, and more that you can now manage with the Azure Native provider.
+We shipped new versions of the Azure Native provider (1.29.0 through 1.34.0) that collectively added [14 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1340-2021-09-30) across services like Azure SQL, Azure API Management, and more that you can now manage with the Azure Native provider.
 
 ## Pulumi CLI and core technologies
 

--- a/themes/default/content/blog/pulumi-release-notes-m63/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m63/index.md
@@ -79,7 +79,7 @@ We shipped a new version of the AWS Native provider (0.2.0) that added [19 new r
 
 ### New resources in the Azure Native provider
 
-We shipped new versions of the Azure Native provider (1.35.0 through 1.42.0) that collectively added [31 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1420-2021-10-25) giving you access to new Azure offerings like vSphere integration, Chaos engineering, and more.
+We shipped new versions of the Azure Native provider (1.35.0 through 1.42.0) that collectively added [31 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1420-2021-10-25) giving you access to new Azure offerings like vSphere integration, Chaos engineering, and more.
 
 ## Pulumi CLI and core technologies
 

--- a/themes/default/content/blog/pulumi-release-notes-m64/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m64/index.md
@@ -204,7 +204,7 @@ We shipped new versions of the AWS Native provider (0.3.0 through 0.4.0) that ad
 
 ### New resources in the Azure Native provider
 
-We shipped new versions of the Azure Native provider (1.43.0 through 1.45.0) that collectively added [4 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1450-2021-11-05) giving you access to resources like Cognitive Services.
+We shipped new versions of the Azure Native provider (1.43.0 through 1.45.0) that collectively added [4 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1450-2021-11-05) giving you access to resources like Cognitive Services.
 
 ## Pulumi CLI and core technologies
 

--- a/themes/default/content/blog/pulumi-release-notes-m65/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-m65/index.md
@@ -173,10 +173,10 @@ We shipped new versions of the AWS Native provider (0.5.0 through 0.8.0) that ad
 
 ### New resources in the Azure Native provider
 
-We shipped new versions of the Azure Native provider (1.46.0 through 1.49.0) that collectively added [8 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1450-2021-11-05).
+We shipped new versions of the Azure Native provider (1.46.0 through 1.49.0) that collectively added [8 new resources](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1450-2021-11-05).
 
 {{% notes type="warning" %}}
-Azure Native version 1.47.0 fixes a security issue that could result in your Azure credentials being stored in your state in cleartext. Read the [description of the issue](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG.md#1470-2021-11-19) to see if you're affected and how to remediate any cleartext secrets.
+Azure Native version 1.47.0 fixes a security issue that could result in your Azure credentials being stored in your state in cleartext. Read the [description of the issue](https://github.com/pulumi/pulumi-azure-native/blob/master/CHANGELOG_OLD.md#1470-2021-11-19) to see if you're affected and how to remediate any cleartext secrets.
 
 As a precaution, we recommend updating to the latest version of the Azure Native provider.
 {{% /notes %}}


### PR DESCRIPTION
the changelog file in the azure-native provider repo was renamed from CHANGELOD.md to CHANGELOG_OLD.md. This caused links to break where the file was being referenced. I see it says it is now deprecated, since we are moving it to github releases, but this will fix up the links so they don't 404.