### PR TITLE
Restore the website workflow to the AWS getting-started guide

### DIFF
--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -25,7 +25,7 @@ Previewing update (dev):
 
      Type                    Name            Plan
      pulumi:pulumi:Stack     quickstart-dev
- +   └─ aws:s3:BucketObject  hello.txt       create
+ +   └─ aws:s3:BucketObject  index.html       create
 
 Resources:
     + 1 to create
@@ -37,7 +37,7 @@ Do you want to perform this update?
   details
 ```
 
-Choosing `yes` will proceed with the update and upload your `hello.txt` file to your bucket:
+Choosing `yes` will proceed with the update and upload the `index.html` file to your bucket:
 
 ```
 Do you want to perform this update? yes
@@ -45,7 +45,7 @@ Updating (dev):
 
      Type                    Name            Status
      pulumi:pulumi:Stack     quickstart-dev
- +   └─ aws:s3:BucketObject  hello.txt       created
+ +   └─ aws:s3:BucketObject  index.html       created
 
 Outputs:
     bucketName: "my-bucket-b9c2eaa"
@@ -58,8 +58,6 @@ Duration: 6s
 ```
 
 Once the update has completed, you can verify the object was created in your bucket by checking the AWS Console or by running the following AWS CLI command:
-
-{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language javascript %}}
 
@@ -117,10 +115,426 @@ $ aws s3 ls $(pulumi stack output bucketName)
 
 {{% /choosable %}}
 
-Notice that your `hello.txt` file has been added to the bucket:
+Notice that your `index.html` file has been added to the bucket:
 
 ```bash
-2020-08-27 12:30:24         15 hello.txt
+2020-08-27 12:30:24         70 index.html
+```
+
+Now that `index.html` is in the bucket, modify the program to serve `index.html` as the home page of the website.
+
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+
+{{% choosable language "javascript,typescript" %}}
+
+```typescript
+const bucket = new aws.s3.Bucket("my-bucket", {
+    website: {
+        indexDocument: "index.html",
+    },
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+bucket = s3.Bucket("my-bucket",
+    website=s3.BucketWebsiteArgs(
+        index_document="index.html",
+    ),
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
+    Website: &s3.BucketWebsiteArgs{
+        IndexDocument: pulumi.String("index.html"),
+    },
+})
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var bucket = new Aws.S3.Bucket("my-bucket", new()
+{
+    Website = new Aws.S3.Inputs.BucketWebsiteArgs
+    {
+        IndexDocument = "index.html",
+    },
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+import com.pulumi.aws.s3.BucketArgs;
+import com.pulumi.aws.s3.inputs.BucketWebsiteArgs;
+
+var bucket = new Bucket("bucket", BucketArgs.builder()
+    .website(BucketWebsiteArgs.builder()
+        .indexDocument("index.html")
+        .build())
+    .build());
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+my-bucket:
+  type: aws:s3:Bucket
+  properties:
+    website:
+      indexDocument: index.html
+```
+
+{{% /choosable %}}
+
+Finally, you'll make a few adjustments to allow these resources to be accessed anonymously over the Internet.
+
+For the bucket itself, you'll need two new resources: a `BucketOwnershipControls` resource, which defines the bucket's object-ownership settings, and a `BucketPublicAccessBlock` resource, which allows the bucket to be accessed publicly.
+
+For the `BucketObject`, you'll need an access-control (ACL) setting of `public-read` to allow the page to be accessed publicly, and a content type of `text/html` to tell AWS to serve the file as a web page:
+
+{{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
+
+{{% choosable language "javascript,typescript" %}}
+
+```typescript
+const ownershipControls = new aws.s3.BucketOwnershipControls("ownership-controls", {
+    bucket: bucket.id,
+    rule: {
+        objectOwnership: "ObjectWriter"
+    }
+});
+
+const publicAccessBlock = new aws.s3.BucketPublicAccessBlock("public-access-block", {
+    bucket: bucket.id,
+    blockPublicAcls: false,
+});
+
+const bucketObject = new aws.s3.BucketObject("index.html", {
+    bucket: bucket.id,
+    source: new pulumi.asset.FileAsset("index.html"),
+    contentType: "text/html",
+    acl: "public-read",
+}, { dependsOn: ownershipControls });
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+ownership_controls = aws.s3.BucketOwnershipControls(
+    "ownership-controls",
+    bucket=bucket.id,
+    rule=aws.s3.BucketOwnershipControlsRuleArgs(
+        object_ownership="ObjectWriter",
+    ),
+)
+
+public_access_block = aws.s3.BucketPublicAccessBlock(
+    "public-access-block", bucket=bucket.id, block_public_acls=False
+)
+
+bucket_object = s3.BucketObject(
+    "index.html",
+    bucket=bucket.id,
+    source=homepage,
+    content_type="text/html",
+    acl="public-read",
+    opts=pulumi.ResourceOptions(depends_on=[public_access_block]),
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+_, err = s3.NewBucketOwnershipControls(ctx, "ownership-controls", &s3.BucketOwnershipControlsArgs{
+    Bucket: bucket.ID(),
+    Rule: &s3.BucketOwnershipControlsRuleArgs{
+        ObjectOwnership: pulumi.String("ObjectWriter"),
+    },
+})
+if err != nil {
+    return err
+}
+
+publicAccessBlock, err := s3.NewBucketPublicAccessBlock(ctx, "public-access-block", &s3.BucketPublicAccessBlockArgs{
+    Bucket:          bucket.ID(),
+    BlockPublicAcls: pulumi.Bool(false),
+})
+if err != nil {
+    return err
+}
+
+_, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
+    Bucket:      bucket.ID(),
+    Source:      Asset(homepage),
+    ContentType: pulumi.String("text/html"),
+    Acl:         pulumi.String("public-read"),
+}, pulumi.DependsOn([]pulumi.Resource{
+    publicAccessBlock,
+}))
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var ownershipControls = new Aws.S3.BucketOwnershipControls("ownership-controls", new()
+{
+    Bucket = bucket.Id,
+    Rule = new Aws.S3.Inputs.BucketOwnershipControlsRuleArgs
+    {
+        ObjectOwnership = "ObjectWriter",
+    },
+});
+
+var publicAccessBlock = new Aws.S3.BucketPublicAccessBlock("public-access-block", new()
+{
+    Bucket = bucket.Id,
+    BlockPublicAcls = false,
+});
+
+var indexHtml = new Aws.S3.BucketObject("index.html", new()
+{
+    Bucket = bucket.Id,
+    Source = homepage,
+    ContentType = "text/html",
+    Acl = "public-read",
+}, new CustomResourceOptions
+{
+    DependsOn = new[]
+    {
+        publicAccessBlock,
+    },
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+import com.pulumi.aws.s3.BucketOwnershipControls;
+import com.pulumi.aws.s3.BucketOwnershipControlsArgs;
+import com.pulumi.aws.s3.inputs.BucketOwnershipControlsRuleArgs;
+import com.pulumi.aws.s3.BucketPublicAccessBlock;
+import com.pulumi.aws.s3.BucketPublicAccessBlockArgs;
+
+var ownershipControls = new BucketOwnershipControls("ownershipControls", BucketOwnershipControlsArgs.builder()
+    .bucket(bucket.id())
+    .rule(BucketOwnershipControlsRuleArgs.builder()
+        .objectOwnership("ObjectWriter")
+        .build())
+    .build());
+
+var publicAccessBlock = new BucketPublicAccessBlock("publicAccessBlock", BucketPublicAccessBlockArgs.builder()
+    .bucket(bucket.id())
+    .blockPublicAcls(false)
+    .build());
+
+var indexHtml = new BucketObject("indexHtml", BucketObjectArgs.builder()
+    .bucket(bucket.id())
+    .source(homepage)
+    .contentType("text/html")
+    .acl("public-read")
+    .build(), CustomResourceOptions.builder()
+        .dependsOn(publicAccessBlock)
+        .build());
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+ownership-controls:
+  type: aws:s3:BucketOwnershipControls
+  properties:
+    bucket: ${my-bucket.id}
+    rule:
+      objectOwnership: ObjectWriter
+
+public-access-block:
+  type: aws:s3:BucketPublicAccessBlock
+  properties:
+    bucket: ${my-bucket.id}
+    blockPublicAcls: false
+
+index.html:
+  type: aws:s3:BucketObject
+  properties:
+    bucket: ${my-bucket.id}
+    source: ${homepage}
+    contentType: text/html
+    acl: public-read
+  options:
+    dependsOn:
+      - ${public-access-block}
+```
+
+{{% /choosable %}}
+
+Notice the `BucketObject` also includes a Pulumi resource _option:_ [`dependsOn`](/docs/intro/concepts/resources/options/dependson/). This option tells Pulumi that the `BucketObject` relies indirectly on the `BucketPublicAccessBlock`, which is currently configuring the bucket to permit public access to its objects. If this setting were omitted, the attempt to grant `public-read` access to `index.html` would fail, as all S3 buckets and their objects are blocked from public access by default.
+
+Finally, at the end of the program, export the resulting bucket’s endpoint URL so you can navigate to it easily:
+
+{{% choosable language javascript %}}
+
+```javascript
+exports.bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```typescript
+export const bucketEndpoint = pulumi.interpolate`http://${bucket.websiteEndpoint}`;
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+pulumi.export("bucket_endpoint", pulumi.Output.concat("http://", bucket.website_endpoint))
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+// ...
+ctx.Export("bucketEndpoint", bucket.WebsiteEndpoint.ApplyT(func(websiteEndpoint string) (string, error) {
+    return fmt.Sprintf("http://%v", websiteEndpoint), nil
+}).(pulumi.StringOutput))
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+return new Dictionary<string, object?>
+{
+    // ...
+    ["bucketEndpoint"] = bucket.WebsiteEndpoint.Apply(websiteEndpoint => $"http://{websiteEndpoint}"),
+};
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+// ...
+ctx.export("bucketEndpoint", bucket.websiteEndpoint().applyValue(websiteEndpoint -> String.format("http://%s", websiteEndpoint)));
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+outputs:
+  # ...
+  bucketEndpoint: http://${my-bucket.websiteEndpoint}
+```
+
+{{% /choosable %}}
+
+Finally, you can check out your new static website at the URL in the `Outputs` section of your update or you can make a `curl` request and see the contents of your `index.html` object printed out in your terminal.
+
+{{% choosable language javascript %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language typescript %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```bash
+$ curl $(pulumi stack output bucket_endpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```bash
+$ curl $(pulumi stack output bucketEndpoint)
+```
+
+{{% /choosable %}}
+
+And you should see:
+
+```bash
+<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>
 ```
 
 Next you will destroy the resources.

--- a/themes/default/content/docs/get-started/aws/deploy-changes.md
+++ b/themes/default/content/docs/get-started/aws/deploy-changes.md
@@ -214,7 +214,7 @@ my-bucket:
 
 Lastly, you'll make a few adjustments to make these resources accessible on the Internet.
 
-For the bucket itself, you'll need two new resources: a `BucketOwnershipControls` resource, to define the bucket's file-ownership settings, and a `BucketPublicAccessBlock` resource to allows the bucket to be accessed publicly.
+For the bucket itself, you'll need two new resources: a `BucketOwnershipControls` resource, to define the bucket's file-ownership settings, and a `BucketPublicAccessBlock` resource to allow the bucket to be accessed publicly.
 
 For the `BucketObject`, you'll need an access-control (ACL) setting of `public-read` to allow the page to be accessed anonymously (e.g., in a browser) and a content type of `text/html` to tell AWS to serve the file as a web page. Add the following lines to your program, updating the `BucketObject` in place:
 

--- a/themes/default/content/docs/get-started/aws/deploy-stack.md
+++ b/themes/default/content/docs/get-started/aws/deploy-stack.md
@@ -43,16 +43,16 @@ Do you want to perform this update? yes
 Updating (dev):
 
      Type                 Name            Status
- +   pulumi:pulumi:Stack  quickstart-dev  created
- +   └─ aws:s3:Bucket     my-bucket       created
+ +   pulumi:pulumi:Stack  quickstart-dev  created (4s)
+ +   └─ aws:s3:Bucket     my-bucket       created (2s)
 
 Outputs:
-    bucketName: "my-bucket-b9c2eaa"
+    bucketName: "my-bucket-58ce361"
 
 Resources:
     + 2 created
 
-Duration: 14s
+Duration: 5s
 ```
 
 Remember the output you defined in the previous step? That [stack output](/docs/intro/concepts/stack#outputs) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:

--- a/themes/default/content/docs/get-started/aws/deploy-stack.md
+++ b/themes/default/content/docs/get-started/aws/deploy-stack.md
@@ -119,6 +119,6 @@ Running that command will print out the name of your bucket.
 
 {{< console-note >}}
 
-Now that your bucket has been provisioned, let's make a few modifications to the program.
+Now that the bucket has been provisioned, let's modify the program to host a static website.
 
 {{< get-started-stepper >}}

--- a/themes/default/content/docs/get-started/aws/destroy-stack.md
+++ b/themes/default/content/docs/get-started/aws/destroy-stack.md
@@ -59,7 +59,7 @@ Resources:
 Duration: 4s
 ```
 
-> To delete the stack itself, run [`pulumi stack rm`](/docs/reference/cli/pulumi_stack_rm). Note that this removes the stack entirely from the Pulumi Cloud, along with all of its update history.
+> To delete the stack itself, run [`pulumi stack rm`](/docs/reference/cli/pulumi_stack_rm). Note that this removes the stack entirely from Pulumi Cloud, along with all of its update history.
 
 Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
 

--- a/themes/default/content/docs/get-started/aws/destroy-stack.md
+++ b/themes/default/content/docs/get-started/aws/destroy-stack.md
@@ -27,7 +27,7 @@ Previewing destroy (dev):
 
      Type                    Name            Plan
  -   pulumi:pulumi:Stack     quickstart-dev  delete
- -   ├─ aws:s3:BucketObject  hello.txt       delete
+ -   ├─ aws:s3:BucketObject  index.html      delete
  -   └─ aws:s3:Bucket        my-bucket       delete
 
 
@@ -42,7 +42,7 @@ Destroying (dev):
 
      Type                    Name            Status
  -   pulumi:pulumi:Stack     quickstart-dev  deleted
- -   ├─ aws:s3:BucketObject  hello.txt       deleted
+ -   ├─ aws:s3:BucketObject  index.html      deleted
  -   └─ aws:s3:Bucket        my-bucket       deleted
 
 Outputs:
@@ -60,8 +60,8 @@ Congratulations! You've successfully provisioned some cloud resources using Pulu
 
 - Created a Pulumi new project.
 - Provisioned a new S3 bucket.
-- Added a `hello.txt` file to your bucket.
-- Verified the deployment with AWS CLI.
+- Added a `index.html` file to your bucket.
+- Served the `index.html` as a static website.
 - Destroyed the resources you've provisioned.
 
 On the next page, we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.

--- a/themes/default/content/docs/get-started/aws/destroy-stack.md
+++ b/themes/default/content/docs/get-started/aws/destroy-stack.md
@@ -25,33 +25,38 @@ You'll be prompted to make sure you really want to delete these resources. This 
 ```
 Previewing destroy (dev):
 
-     Type                    Name            Plan
- -   pulumi:pulumi:Stack     quickstart-dev  delete
- -   ├─ aws:s3:BucketObject  index.html      delete
- -   └─ aws:s3:Bucket        my-bucket       delete
-
+     Type                               Name                 Plan
+ -   pulumi:pulumi:Stack                quickstart-dev       delete
+ -   ├─ aws:s3:BucketObject             index.html           delete
+ -   ├─ aws:s3:BucketOwnershipControls  ownership-controls   delete
+ -   ├─ aws:s3:BucketPublicAccessBlock  public-access-block  delete
+ -   └─ aws:s3:Bucket                   my-bucket            delete
 
 Outputs:
-  - bucketName: "my-bucket-b9c2eaa"
+  - bucketEndpoint: "http://my-bucket-dfd6bd0.s3-website-us-east-1.amazonaws.com"
+  - bucketName    : "my-bucket-dfd6bd0"
 
 Resources:
-    - 3 to delete
+    - 5 to delete
 
 Do you want to perform this destroy? yes
 Destroying (dev):
 
-     Type                    Name            Status
- -   pulumi:pulumi:Stack     quickstart-dev  deleted
- -   ├─ aws:s3:BucketObject  index.html      deleted
- -   └─ aws:s3:Bucket        my-bucket       deleted
+     Type                               Name                 Status
+ -   pulumi:pulumi:Stack                quickstart-dev       deleted
+ -   ├─ aws:s3:BucketObject             index.html           deleted (1s)
+ -   ├─ aws:s3:BucketPublicAccessBlock  public-access-block  deleted (0.28s)
+ -   ├─ aws:s3:BucketOwnershipControls  ownership-controls   deleted (0.47s)
+ -   └─ aws:s3:Bucket                   my-bucket            deleted (0.39s)
 
 Outputs:
-  - bucketName: "my-bucket-b9c2eaa"
+  - bucketEndpoint: "http://my-bucket-dfd6bd0.s3-website-us-east-1.amazonaws.com"
+  - bucketName    : "my-bucket-dfd6bd0"
 
 Resources:
-    - 3 deleted
+    - 5 deleted
 
-Duration: 3s
+Duration: 4s
 ```
 
 > To delete the stack itself, run [`pulumi stack rm`](/docs/reference/cli/pulumi_stack_rm). Note that this removes the stack entirely from the Pulumi Cloud, along with all of its update history.
@@ -60,7 +65,7 @@ Congratulations! You've successfully provisioned some cloud resources using Pulu
 
 - Created a Pulumi new project.
 - Provisioned a new S3 bucket.
-- Added a `index.html` file to your bucket.
+- Added an `index.html` file to your bucket.
 - Served the `index.html` as a static website.
 - Destroyed the resources you've provisioned.
 

--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -12,14 +12,18 @@ menu:
 aliases: ["/docs/quickstart/aws/modify-program/"]
 ---
 
-Now that your S3 bucket is provisioned, let's add a file to it. First, from within your project directory, create a new file called `hello.txt` file with some content in it:
+Now that your S3 bucket is provisioned, let's add a file to it. First, from within your project directory, create a new file called `index.html` file along with some content:
 
 {{< chooser os "macos,linux,windows" / >}}
 
 {{% choosable os macos %}}
 
 ```bash
-echo 'Hello, Pulumi!' > hello.txt
+echo '<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>' > index.html
 ```
 
 {{% /choosable %}}
@@ -27,7 +31,11 @@ echo 'Hello, Pulumi!' > hello.txt
 {{% choosable os linux %}}
 
 ```bash
-echo 'Hello, Pulumi!' > hello.txt
+echo '<html>
+    <body>
+        <h1>Hello, Pulumi!</h1>
+    </body>
+</html>' > index.html
 ```
 
 {{% /choosable %}}
@@ -35,15 +43,18 @@ echo 'Hello, Pulumi!' > hello.txt
 {{% choosable os windows %}}
 
 ```powershell
-$hello = "Hello, Pulumi!"
-$hello | Out-File -FilePath hello.txt
+@"
+<html>
+  <body>
+    <h1>Hello, Pulumi!</h1>
+  </body>
+</html>
+"@ | Out-File -FilePath index.html
 ```
 
 {{% /choosable %}}
 
-Now that you have your new `hello.txt` with some content, open your program file and modify it to add the file to your S3 bucket.
-
-To accomplish this, you will use Pulumi's `FileAsset` class to assign the content of the file to a new  `BucketObject`:
+Now, open your program and this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -52,9 +63,9 @@ To accomplish this, you will use Pulumi's `FileAsset` class to assign the conten
 In `index.js`, create the `BucketObject` right after creating the bucket itself:
 
 ```javascript
-const bucketObject = new aws.s3.BucketObject("hello.txt", {
+const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket.id,
-    source: new pulumi.asset.FileAsset("hello.txt")
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -65,9 +76,9 @@ const bucketObject = new aws.s3.BucketObject("hello.txt", {
 In `index.ts`, create the `BucketObject` right after creating the bucket itself:
 
 ```typescript
-const bucketObject = new aws.s3.BucketObject("hello.txt", {
+const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket.id,
-    source: new pulumi.asset.FileAsset("hello.txt")
+    source: new pulumi.asset.FileAsset("index.html")
 });
 ```
 
@@ -79,9 +90,9 @@ In `__main__.py`, create a new bucket object by adding the following right after
 
 ```python
 bucketObject = s3.BucketObject(
-    'hello.txt',
+    'index.html',
     bucket=bucket.id,
-    source=pulumi.FileAsset('hello.txt')
+    source=pulumi.FileAsset('index.html')
 )
 ```
 
@@ -92,9 +103,9 @@ bucketObject = s3.BucketObject(
 In `main.go`, create the `BucketObject` right after creating the bucket itself:
 
 ```go
-_, err = s3.NewBucketObject(ctx, "hello.txt", &s3.BucketObjectArgs{
+_, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket:  bucket.ID(),
-    Source: pulumi.NewFileAsset("hello.txt"),
+    Source: pulumi.NewFileAsset("index.html"),
 })
 if err != nil {
     return err
@@ -108,10 +119,10 @@ if err != nil {
 In `Program.cs`, create a new `BucketObject` right after creating the bucket itself.
 
 ```csharp
-var bucketObject = new BucketObject("hello.txt", new BucketObjectArgs
+var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
-    Source = new FileAsset("./hello.txt")
+    Source = new FileAsset("./index.html")
 });
 ```
 
@@ -133,9 +144,9 @@ public class App {
             // var bucket = ...
 
             // Create an S3 Bucket object
-            new BucketObject("hello.txt", BucketObjectArgs.builder()
+            new BucketObject("index.html", BucketObjectArgs.builder()
                 .bucket(bucket.id())
-                .source(new FileAsset("hello.txt"))
+                .source(new FileAsset("index.html"))
                 .build()
             );
 ```
@@ -149,12 +160,12 @@ In {{< langfile >}}, create the `BucketObject` right below the bucket itself.
 ```yaml
 resources:
   # ...
-  hello.txt:
+  index.html:
     type: aws:s3:BucketObject
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::FileAsset: ./hello.txt
+        Fn::FileAsset: ./index.html
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -54,7 +54,7 @@ echo '<html>
 
 {{% /choosable %}}
 
-Now, open the program and this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
+Now, open the program and add this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -95,7 +95,7 @@ In `__main__.py`, create a new bucket object by adding the following right after
 bucketObject = s3.BucketObject(
     'index.html',
     bucket=bucket.id,
-    source=pulumi.FileAsset('index.html')
+    source=pulumi.FileAsset('./index.html')
 )
 ```
 
@@ -109,7 +109,7 @@ In `main.go`, create the `BucketObject` right after creating the bucket itself:
 // Create an S3 Bucket object
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket:  bucket.ID(),
-    Source: pulumi.NewFileAsset("index.html"),
+    Source: pulumi.NewFileAsset("./index.html"),
 })
 if err != nil {
     return err

--- a/themes/default/content/docs/get-started/aws/modify-program.md
+++ b/themes/default/content/docs/get-started/aws/modify-program.md
@@ -54,7 +54,7 @@ echo '<html>
 
 {{% /choosable %}}
 
-Now, open your program and this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
+Now, open the program and this file to the S3 bucket. To do this, you'll use Pulumi's `FileAsset` resource to assign the content of the file to a new  `BucketObject`:
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
@@ -63,9 +63,10 @@ Now, open your program and this file to the S3 bucket. To do this, you'll use Pu
 In `index.js`, create the `BucketObject` right after creating the bucket itself:
 
 ```javascript
+// Create an S3 Bucket object
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket.id,
-    source: new pulumi.asset.FileAsset("index.html")
+    source: new pulumi.asset.FileAsset("./index.html")
 });
 ```
 
@@ -76,9 +77,10 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 In `index.ts`, create the `BucketObject` right after creating the bucket itself:
 
 ```typescript
+// Create an S3 Bucket object
 const bucketObject = new aws.s3.BucketObject("index.html", {
     bucket: bucket.id,
-    source: new pulumi.asset.FileAsset("index.html")
+    source: new pulumi.asset.FileAsset("./index.html")
 });
 ```
 
@@ -89,6 +91,7 @@ const bucketObject = new aws.s3.BucketObject("index.html", {
 In `__main__.py`, create a new bucket object by adding the following right after creating the bucket itself:
 
 ```python
+# Create an S3 Bucket object
 bucketObject = s3.BucketObject(
     'index.html',
     bucket=bucket.id,
@@ -103,6 +106,7 @@ bucketObject = s3.BucketObject(
 In `main.go`, create the `BucketObject` right after creating the bucket itself:
 
 ```go
+// Create an S3 Bucket object
 _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Bucket:  bucket.ID(),
     Source: pulumi.NewFileAsset("index.html"),
@@ -119,6 +123,7 @@ if err != nil {
 In `Program.cs`, create a new `BucketObject` right after creating the bucket itself.
 
 ```csharp
+// Create an S3 Bucket object
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 {
     Bucket = bucket.BucketName,
@@ -133,22 +138,34 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 In {{< langfile >}}, import the `FileAsset`, `BucketObject`, and `BucketObjectArgs` classes, then create the `BucketObject` right after creating the bucket itself.
 
 ```java
-// ...
-import com.pulumi.asset.FileAsset;
+package myproject;
+
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.aws.s3.Bucket;
 import com.pulumi.aws.s3.BucketObject;
 import com.pulumi.aws.s3.BucketObjectArgs;
+import com.pulumi.asset.FileAsset;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            // var bucket = ...
+
+            // Create an AWS resource (S3 Bucket)
+            var bucket = new Bucket("my-bucket");
 
             // Create an S3 Bucket object
             new BucketObject("index.html", BucketObjectArgs.builder()
                 .bucket(bucket.id())
-                .source(new FileAsset("index.html"))
+                .source(new FileAsset("./index.html"))
                 .build()
             );
+
+            // Export the name of the bucket
+            ctx.export("bucketName", bucket.bucket());
+        });
+    }
+}
 ```
 
 {{% /choosable %}}
@@ -158,14 +175,26 @@ public class App {
 In {{< langfile >}}, create the `BucketObject` right below the bucket itself.
 
 ```yaml
+name: quickstart
+runtime: yaml
+description: A minimal AWS Pulumi YAML program
+
 resources:
-  # ...
+  # Create an AWS resource (S3 Bucket)
+  my-bucket:
+    type: aws:s3:Bucket
+
+  # Create an S3 Bucket object
   index.html:
     type: aws:s3:BucketObject
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::FileAsset: ./index.html
+        fn::fileAsset: ./index.html
+
+outputs:
+  # Export the name of the bucket
+  bucketName: ${my-bucket.id}
 ```
 
 {{% /choosable %}}

--- a/themes/default/content/docs/get-started/aws/review-project.md
+++ b/themes/default/content/docs/get-started/aws/review-project.md
@@ -94,7 +94,7 @@ from pulumi_aws import s3
 bucket = s3.Bucket('my-bucket')
 
 # Export the name of the bucket
-pulumi.export('bucket_name',  bucket.id)
+pulumi.export('bucket_name', bucket.id)
 ```
 
 {{% /choosable %}}
@@ -105,8 +105,8 @@ pulumi.export('bucket_name',  bucket.id)
 package main
 
 import (
-    "github.com/pulumi/pulumi-aws/sdk/v4/go/aws/s3"
-    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
@@ -120,7 +120,7 @@ func main() {
         // Export the name of the bucket
         ctx.Export("bucketName", bucket.ID())
         return nil
-    })
+	  })
 }
 ```
 
@@ -164,7 +164,7 @@ public class App {
             var bucket = new Bucket("my-bucket");
 
             // Export the name of the bucket
-            ctx.export("bucketName", bucket.getId());
+            ctx.export("bucketName", bucket.bucket());
         });
     }
 }
@@ -212,7 +212,7 @@ export const bucketName = bucket.id;
 {{% choosable language python %}}
 
 ```python
-pulumi.export('bucket_name',  bucket.id)
+pulumi.export('bucket_name', bucket.id)
 ```
 
 {{% /choosable %}}
@@ -239,7 +239,7 @@ return new Dictionary<string, object?>
 {{% choosable language java %}}
 
 ```java
-ctx.export("bucketName", bucket.getId());
+ctx.export("bucketName", bucket.bucket());
 ```
 
 {{% /choosable %}}

--- a/themes/default/layouts/shortcodes/cloud-intro.html
+++ b/themes/default/layouts/shortcodes/cloud-intro.html
@@ -12,7 +12,7 @@
         <li>Creating a new Pulumi project.</li>
         {{ if eq $cloud "AWS" }}
             <li>Provisioning a new AWS S3 bucket.</li>
-            <li>Adding a file to the bucket.</li>
+            <li>Adding an <code>index.html</code> file to the bucket and serving it as a static website.</li>
         {{ else if eq $cloud "Microsoft Azure" }}
             <li>Provisioning a new Blob storage container.</li>
             <li>Adding an <code>index.html</code> file to your container and serving it as a static website.</li>


### PR DESCRIPTION
## Description

Fixes #2720.

The code changes here are based on a new repo, [pulumi/getting-started](https://github.com/pulumi/getting-started), that I've set up to test that each step of the guide continues to work as expected.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
