### PR TITLE
delete parameter for bucket on closed PRs

### DIFF
--- a/scripts/ci/common.sh
+++ b/scripts/ci/common.sh
@@ -133,6 +133,13 @@ set_bucket_for_commit() {
         --tags "$(aws_owner_tag)"
 }
 
+# Remove the parameter key associated with a specific commit.
+remove_param_for_commit() {
+    aws ssm delete-parameter \
+        --name "$(ssm_parameter_key_for_commit $1)" \
+        --region $2
+}
+
 # List the 100 most recent bucket in the current account, sorted descendingly by
 # CreationDate, matching the prefix we use to name website buckets. Supports an optional
 # suffix to filter by (e.g., "pr" or "push").

--- a/scripts/ci/pull-request-closed.sh
+++ b/scripts/ci/pull-request-closed.sh
@@ -40,6 +40,7 @@ if [[ "$GITHUB_EVENT_NAME" == "pull_request" && ! -z "$GITHUB_EVENT_PATH" ]]; th
                 # and we have access to it.
                 if aws s3api head-bucket --bucket "$pr_bucket_name" 2>/dev/null; then
                     aws s3 rb "s3://${pr_bucket_name}" --force
+                    remove_param_for_commit "$(git_sha)" "$(aws_region)"
                 else
                     echo "Unable to delete ${pr_bucket_name}. Skipping."
                 fi


### PR DESCRIPTION
part of: https://github.com/pulumi/home/issues/2779

This PR removes the parameters used to track the preview buckets associated with PR commits once the PR. We have a limit for how many parameters we can store, so this will clean up the parameter used to track that particular bucket once the bucket gets deleted, since it is no longer needed at that point. We also need to do this in docs and registry repos as well, but will start here and verify this works since this repo does not run against the prod account.