### PR TITLE
Update github handle reference in release notes 80

### DIFF
--- a/themes/default/content/blog/pulumi-release-notes-80/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-80/index.md
@@ -143,7 +143,7 @@ We have added a new experimental flag to improve performance for certain use cas
 
 ### Token Authentication in Go Providers
 
-Thank you to community member [@avlllo](https://github.com/avlllo) for adding support for token authentication in the Go providers that use git. You can now authenticated requests by tokens such as `https://auth:token@gitlab.example.com/group/proj.git/tree/v0.0.0/path`.
+Thank you to community member [@aohoy](https://github.com/aohoy) for adding support for token authentication in the Go providers that use git. You can now authenticated requests by tokens such as `https://auth:token@gitlab.example.com/group/proj.git/tree/v0.0.0/path`.
 
 👉 Learn more by reviewing the [Add token to git Go module pull request](https://github.com/pulumi/pulumi/pull/10628).
 


### PR DESCRIPTION
## Description
Update github handle reference in release notes 80. User has updated their handle.
## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
