### PR TITLE
Add MIW videos to blog posts

### DIFF
--- a/themes/default/content/blog/building-a-data-warehouse-on-aws-with-redshift-and-pulumi/index.md
+++ b/themes/default/content/blog/building-a-data-warehouse-on-aws-with-redshift-and-pulumi/index.md
@@ -457,6 +457,10 @@ SELECT *
 
 Huzzah! You've now got yourself a working data warehouse.
 
+Here's a [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video that demonstrates everything you've just read in this blog post:
+
+{{< youtube "2v_53eWGrqE?rel=0" >}}
+
 ## Taking stock, and looking ahead
 
 If you're like me, you're probably happy to be up and running --- but you've also got a few questions:

--- a/themes/default/content/blog/building-a-data-warehouse-on-aws-with-redshift-and-pulumi/index.md
+++ b/themes/default/content/blog/building-a-data-warehouse-on-aws-with-redshift-and-pulumi/index.md
@@ -457,7 +457,9 @@ SELECT *
 
 Huzzah! You've now got yourself a working data warehouse.
 
-Here's a [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video that demonstrates everything you've just read in this blog post:
+## See it in action
+
+To demonstrate the entire process of building a data warehouse with Redshift and Pulumi, we created this [Modern Infrastructure video](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) that shows all of this in action:
 
 {{< youtube "2v_53eWGrqE?rel=0" >}}
 

--- a/themes/default/content/blog/create-manage-confluent-kafka-cluster-with-pulumi/index.md
+++ b/themes/default/content/blog/create-manage-confluent-kafka-cluster-with-pulumi/index.md
@@ -325,7 +325,9 @@ Starting Kafka Consumer. Use Ctrl-C to exit.
 
 The producer is able to write events to your topic, and the consumer is able to read them. Your architecture has been proven to work!
 
-This [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video shows all this in action:
+## See it in action
+
+Want to see this in action? Here is a [Modern Infrastructure video](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) demonstrating everything discussed in this blog post:
 
 {{< youtube "NWm9kAzQGXY?rel=0" >}}
 

--- a/themes/default/content/blog/create-manage-confluent-kafka-cluster-with-pulumi/index.md
+++ b/themes/default/content/blog/create-manage-confluent-kafka-cluster-with-pulumi/index.md
@@ -325,6 +325,10 @@ Starting Kafka Consumer. Use Ctrl-C to exit.
 
 The producer is able to write events to your topic, and the consumer is able to read them. Your architecture has been proven to work!
 
+This [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video shows all this in action:
+
+{{< youtube "NWm9kAzQGXY?rel=0" >}}
+
 ## Conclusion
 
 By combining the operational simplicity and rich functionality of Confluent Cloud with the power of [Pulumi's infrastructure as code](https://www.pulumi.com/product/) platform to manage Confluent resources using real programming languages, organizations can quickly and securely deploy Apache Kafka clusters.

--- a/themes/default/content/blog/how-to-create-and-share-a-pulumi-template/index.md
+++ b/themes/default/content/blog/how-to-create-and-share-a-pulumi-template/index.md
@@ -301,7 +301,9 @@ Embedding these buttons yourself is easy --- just use one of the snippets below,
 
 Project creators who go down this path will be prompted in the browser for the same configuration values as they would with the CLI, and afterward, they'll be able to deploy the project either with the Pulumi CLI or with [Pulumi Deployments](https://www.pulumi.com/docs/intro/deployments/).
 
-Watch this [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video to see another example of creating and sharing your own Pulumi template:
+## See it in action
+
+You can watch this [Modern Infrastructure video](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) to see another example of creating and sharing a Pulumi template:
 
 {{< youtube "-jbZ_LZz31M?rel=0" >}}
 

--- a/themes/default/content/blog/how-to-create-and-share-a-pulumi-template/index.md
+++ b/themes/default/content/blog/how-to-create-and-share-a-pulumi-template/index.md
@@ -301,6 +301,10 @@ Embedding these buttons yourself is easy --- just use one of the snippets below,
 
 Project creators who go down this path will be prompted in the browser for the same configuration values as they would with the CLI, and afterward, they'll be able to deploy the project either with the Pulumi CLI or with [Pulumi Deployments](https://www.pulumi.com/docs/intro/deployments/).
 
+Watch this [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video to see another example of creating and sharing your own Pulumi template:
+
+{{< youtube "-jbZ_LZz31M?rel=0" >}}
+
 ## Wrapping up
 
 As you can see, creating a template is both simple and powerful, and I hope this post encourages you to experiment with a few of your own. Feel free to peruse the following links for inspiration:

--- a/themes/default/content/blog/redshift-etl-with-pulumi-and-aws-glue/index.md
+++ b/themes/default/content/blog/redshift-etl-with-pulumi-and-aws-glue/index.md
@@ -785,9 +785,9 @@ Resources:
     - 16 deleted
 ```
 
-## Seeing a demonstration
+## See it in action
 
-If you'd like to see a demonstration of what you've read in this blog post, then this [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video covers the whole process:
+If you'd like to see a demonstration of what you've read in this blog post, then this [Modern Infrastructure video](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) covers the whole process:
 
 {{< youtube "cbAzk9ovR9s?rel=0" >}}
 

--- a/themes/default/content/blog/redshift-etl-with-pulumi-and-aws-glue/index.md
+++ b/themes/default/content/blog/redshift-etl-with-pulumi-and-aws-glue/index.md
@@ -785,6 +785,12 @@ Resources:
     - 16 deleted
 ```
 
+## Seeing a demonstration
+
+If you'd like to see a demonstration of what you've read in this blog post, then this [Modern Infrastructure](https://www.youtube.com/playlist?list=PLyy8Vx2ZoWloyj3V5gXzPraiKStO2GGZw) video covers the whole process:
+
+{{< youtube "cbAzk9ovR9s?rel=0" >}}
+
 ## What's next?
 
 I hope you learned as much as I did with this post --- we covered a lot, and we've only scratched the surface of what's possible with these tools. Once again, I'd encourage you to spend some time digging into the [Redshift](https://docs.aws.amazon.com/redshift/index.html) and [Glue](https://docs.aws.amazon.com/glue/index.html) documentation to explore both in more depth, as there's lots more to learn than what we've covered so far.


### PR DESCRIPTION
This PR updates four blog posts to add relevant/related Modern Infrastructure Wednesday (MIW) videos via the `youtube` shortcode.

## Description

This blog embeds related MIW videos into four blog posts:

- Building a data warehouse on AWS with Redshift and Pulumi
- Create and Manage Confluent Kafka Cluster with Pulumi
- How to Create and Share a Pulumi Template
- Redshift ETL with Pulumi and AWS Glue

Merging this PR will close https://github.com/pulumi/devrel-team/issues/542

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
