### PR TITLE
make the newsletter input look more like an input

### DIFF
--- a/themes/default/layouts/blog/single.html
+++ b/themes/default/layouts/blog/single.html
@@ -40,7 +40,7 @@
                             {{ end }}
                         </div>
 
-                        <section class="py-8">
+                        <section class="py-8 newsletter-input">
                             <div class="container mx-auto">
                                 <div class="text-center">
                                     <h4 class="">Subscribe to the Pulumi Monthly Newsletter</h4>

--- a/themes/default/theme/src/scss/main.scss
+++ b/themes/default/theme/src/scss/main.scss
@@ -351,4 +351,8 @@ pulumi-tree-item {
     }
 }
 
+section.newsletter-input pulumi-hubspot-form input.hs-input {
+    border-radius: 4px;
+}
+
 @tailwind utilities;

--- a/themes/default/theme/src/scss/main.scss
+++ b/themes/default/theme/src/scss/main.scss
@@ -352,7 +352,7 @@ pulumi-tree-item {
 }
 
 section.newsletter-input pulumi-hubspot-form input.hs-input {
-    border-radius: 4px;
+    @apply rounded;
 }
 
 @tailwind utilities;


### PR DESCRIPTION
## Description
the newsletter input looks like a button without a label making a small change to make this look a bit more like an input
i don't think its possible to add a label cause this is hubspot
but this should make it a bit better
fixes https://github.com/pulumi/pulumi-hugo/issues/1707

### before
<img width="469" alt="Screenshot 2023-04-28 at 3 40 38 PM" src="https://user-images.githubusercontent.com/5489125/235265394-f94bd85e-822b-4893-bb1e-d8c11ba4c9a0.png">

### after
<img width="484" alt="Screenshot 2023-04-28 at 3 40 29 PM" src="https://user-images.githubusercontent.com/5489125/235265387-49854cb1-1d80-4a37-b75d-529ebfe9aa0d.png">

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
