### PR TITLE
fix img links

### DIFF
--- a/themes/default/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
+++ b/themes/default/content/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws/index.md
@@ -47,7 +47,7 @@ traffic-aware ETA calculations, and high-prevision elevation. This data,
 exposed by the API is backed by a high performance database (DynamoDB)
 to enable visualization in realtime on the map client.
 
-![AWS-architecture-iot](./aws-architecture-iot.jpg)
+![AWS-architecture-iot](./aws-architecture-iot.png)
 
 The fun part -- Pulumi Service console helps you map your cloud
 architecture shown above as a connected set of DAG resources so you need

--- a/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
+++ b/themes/default/content/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi/index.md
@@ -80,7 +80,7 @@ will create our API Gateway and Hello World Lambda. In Step 2, we will
 set up the logic for our Lambda authorizer. And finally in Step 3, we
 will bring it all together by telling API Gateway to use our authorizer.
 
-![lambda_authorizer](./lambda-authorizer.jpg)
+![lambda_authorizer](./lambda-authorizer.png)
 
 ### 1 - Define Your Routes
 


### PR DESCRIPTION
## Description
follow on to https://github.com/pulumi/pulumi-hugo/pull/2766
missed 2 img links

`/blog/mapbox-iot-as-code-with-pulumi-crosswalk-for-aws`
`/blog/protecting-your-apis-with-lambda-authorizers-and-pulumi`


## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
