### PR TITLE
adding pulumi ai to practitioner nav

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -46,7 +46,7 @@
                     </a>
                 </li>
                 <li class="mr-8">
-                    <a data-track="header-registry" href="{{ relref . "/ai" }}">
+                    <a data-track="header-ai" href="{{ relref . "/ai" }}">
                         <i class="fas fa-robot mr-0.5"></i>
                         Pulumi AI
                     </a>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -465,7 +465,7 @@
                                 <a href="https://slack.pulumi.com/">Slack</a>
                                 <a href="{{ relref . "/docs" }}">Docs</a>
                                 <a href="{{ relref . "/registry" }}">Registry</a>
-                                <a href="{{ relref . "/registry" }}">Pulumi AI</a>
+                                <a href="{{ relref . "/ai" }}">Pulumi AI</a>
                                 <a href="https://app.pulumi.com/">
                                     {{ partial "top-nav-user-toggle" }}
                                 </a>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -45,6 +45,12 @@
                         Registry
                     </a>
                 </li>
+                <li class="mr-8">
+                    <a data-track="header-registry" href="{{ relref . "/ai" }}">
+                        <i class="fas fa-robot mr-0.5"></i>
+                        Pulumi AI
+                    </a>
+                </li>
                 <li>
                     <a data-track="header-console" href="https://app.pulumi.com/" target="_blank">
                         <i class="fas fa-user-circle"></i>
@@ -459,6 +465,7 @@
                                 <a href="https://slack.pulumi.com/">Slack</a>
                                 <a href="{{ relref . "/docs" }}">Docs</a>
                                 <a href="{{ relref . "/registry" }}">Registry</a>
+                                <a href="{{ relref . "/registry" }}">Pulumi AI</a>
                                 <a href="https://app.pulumi.com/">
                                     {{ partial "top-nav-user-toggle" }}
                                 </a>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -63,7 +63,7 @@
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-github" href="{{ relref . " /ai" }}">
+                <a data-track="header-ai" href="{{ relref . " /ai" }}">
                     <i class="fas fa-robot mr-0.5"></i>
                     Pulumi AI
                 </a>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -21,6 +21,7 @@
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>
                 <li role="none"><a role="menuitem" href="{{ relref . " /registry" }}">Registry</a></li>
+                <li role="none"><a role="menuitem" href="{{ relref . " /ai" }}">Pulumi AI</a></li>
                 <li role="none">
                     <a role="menuitem" href="https://app.pulumi.com">
                         {{ partial "top-nav-user-toggle" }}
@@ -59,6 +60,12 @@
                 <a data-track="header-github" href="{{ relref . " /registry" }}">
                     <i class="fas fa-archive mr-0.5"></i>
                     Registry
+                </a>
+            </li>
+            <li class="mr-8">
+                <a data-track="header-github" href="{{ relref . " /registry" }}">
+                    <i class="fas fa-robot mr-0.5"></i>
+                    Pulumi AI
                 </a>
             </li>
             <li>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -63,7 +63,7 @@
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-github" href="{{ relref . " /registry" }}">
+                <a data-track="header-github" href="{{ relref . " /ai" }}">
                     <i class="fas fa-robot mr-0.5"></i>
                     Pulumi AI
                 </a>


### PR DESCRIPTION
## Description
adding pulumi ai to practitioner nav
to those worried about the amount of space, docs+registry is collapsing into one soon

<img width="681" alt="Screenshot 2023-05-02 at 6 34 47 PM" src="https://user-images.githubusercontent.com/5489125/235818494-014847a7-1c64-4a04-84d2-9ba65736c145.png">
<img width="663" alt="Screenshot 2023-05-02 at 6 34 36 PM" src="https://user-images.githubusercontent.com/5489125/235818496-6f08ee22-e778-4ad4-8e33-b30ac1ebb7e6.png">

related
https://github.com/pulumi/registry/pull/2434
https://github.com/pulumi/pulumi-service/pull/13426


## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
