### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# docs
+/themes/default/content/docs @susanev @sean1588 @anita-trimbur
+
+# blog
+/themes/default/content/blog @cnunciato @scottslowe 


### PR DESCRIPTION
## Description
adding a codeowners file for both docs and blog
so we automatically get added as reviewers
i did not change anything to require our review to merge
so its only gonna add us as reviewers

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
