### PR TITLE
adding swifttype to parent pages in docs

### DIFF
--- a/themes/default/layouts/docs/list.html
+++ b/themes/default/layouts/docs/list.html
@@ -23,7 +23,10 @@
                         <h1>{{ .Title }}</h1>
                     {{ end }}
 
-                    {{ .Content }}
+
+                    <section data-swiftype-index="true">
+                        {{ .Content }}
+                    </section>
                 </div>
             </div>
 


### PR DESCRIPTION
## Description
today i noticed we have a list layout and a single layout for docs. and the list layout is for all parent pages.
the parent pages have content on them, but i think they were previously not being indexed in swifttype
this adds it there

i might be totally wrong, pls tell me if i am

here's the single layout
https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/layouts/docs/single.html#L23-L25

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
