### PR TITLE
Validate choosers and choosables

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default
 
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20220504042409-82f5a4588c0e // indirect
-	github.com/pulumi/registry/themes/default v0.0.0-20230512022046-9489a42f838c // indirect
+	github.com/pulumi/registry/themes/default v0.0.0-20230512213438-69469674fab1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,3 @@
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20220504042409-82f5a4588c0e/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
-github.com/pulumi/registry/themes/default v0.0.0-20230512022046-9489a42f838c h1:gu5DQyH2ZkrQLGuoaTdy/Cb2ovp6vRqwuOXRrQ0scY0=
-github.com/pulumi/registry/themes/default v0.0.0-20230512022046-9489a42f838c/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=
+github.com/pulumi/registry/themes/default v0.0.0-20230512213438-69469674fab1 h1:xP9V8BNkA8HB/wquhIDLieYd0M6zb97GQJbxDchIVYI=
+github.com/pulumi/registry/themes/default v0.0.0-20230512213438-69469674fab1/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=

--- a/themes/default/archetypes/templates/template/index.md
+++ b/themes/default/archetypes/templates/template/index.md
@@ -122,7 +122,7 @@ You can adjust these settings by changing the code in {{< langfile >}}:
 
 {{% chooser language "typescript,python,go,csharp,yaml" / %}}
 
-{{% choosable language typescript %}}
+{{% choosable %}}
 
 ```diff
 const cdn = new aws.cloudfront.Distribution("cdn", {

--- a/themes/default/layouts/shortcodes/choosable.html
+++ b/themes/default/layouts/shortcodes/choosable.html
@@ -4,6 +4,16 @@
 {{ if eq $values "nodejs" }}
     {{ $values = "javascript,typescript" }}
 {{ end }}
+
+{{ if not $type }}
+    {{ errorf "%s Missing required parameter 'type'." .Page }}
+{{ end }}
+
+{{ if not $values }}
+    {{ errorf "%s Missing required parameter 'values." .Page }}
+{{ end }}
+
+
 <div>
     <pulumi-choosable type="{{ $type }}" values="{{ $values }}" mode="{{ $mode }}">{{ .Inner }}</pulumi-choosable>
 </div>

--- a/themes/default/layouts/shortcodes/chooser.html
+++ b/themes/default/layouts/shortcodes/chooser.html
@@ -4,6 +4,16 @@
 {{ if eq $options "nodejs" }}
     {{ $options = "javascript,typescript" }}
 {{ end }}
+
+{{ if not $type }}
+    {{ errorf "%s Missing required parameter 'type'." .Path }}
+{{ end }}
+
+{{ if not $options }}
+    {{ errorf "%s Missing required parameter 'options'." .Path }}
+{{ end }}
+
+
 <div>
     <pulumi-chooser type="{{ $type }}" options="{{ $options }}" mode="{{ $mode }}">{{ .Inner }}</pulumi-chooser>
 </div>


### PR DESCRIPTION
## Description

Adds a bit of validation logic to the `chooser` and `choosable` shortcode to ensure they receive the arguments they need to render choosers properly.

The PR checks here will fail until https://github.com/pulumi/registry/pull/2472 is merged (as that PR corrects the broken shortcode that led to this issue).

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
