### PR TITLE
Update GitHub links for all Zephyr posts

### DIFF
--- a/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
@@ -90,7 +90,7 @@ Zephyr decided to initially start with two stacks: a production stack (named "pr
 
 ## Viewing the first iteration of Zephyr's code
 
-You can view the first iteration of Zephyr's Pulumi and application code---the iteration that corresponds to the decisions described in this blog post---by navigating to [this GitHub repository](https://github.com/pulumi/zephyr-app/). From the branch/tag dropdown, switch from the "main" branch to viewing the "original" tag.
+You can view the first iteration of Zephyr's Pulumi and application code---the iteration that corresponds to the decisions described in this blog post---by navigating to [this GitHub repository](https://github.com/pulumi/zephyr-app/). From the branch/tag dropdown, switch from the `main` branch to viewing the [`blog/original`](https://github.com/pulumi/zephyr-app/tree/blog/original/) branch.
 
 From that GitHub repository, you can also choose to deploy the Pulumi code yourself. Full instructions for deploying the code are found in the repository.
 

--- a/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
@@ -34,7 +34,7 @@ Here are links to all of the posts in the series. Entries below that are not yet
 When we [last met up](/blog/iac-recommended-practices-code-organization-and-stacks/) with the Zephyr team, they were off and running, managing their newly refactored online store, Zephyr Archaeotech Emporium, with a single Pulumi [project](/docs/intro/concepts/project/) and two Pulumi [stacks](/docs/intro/concepts/stack/) --- one for development (`dev`) and another for production (`prod`). The team had chosen to use one Git repository (a monorepo) to manage the code for the online store and its infrastructure after refactoring the store into a set of containerized microservices deployed with Kubernetes on [Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
 
 {{% notes %}}
-For a snapshot of the code as it was at the end of the first post in the series, see the [`original`](https://github.com/pulumi/zephyr-app/tree/original) tag of the [`pulumi/zepyhr-app`](https://github.com/pulumi/zephyr-app) repository on GitHub.
+For a snapshot of the code as it was at the end of the first post in the series, see the [`blog/original`](https://github.com/pulumi/zephyr-app/tree/blog/original) branch of the [`pulumi/zepyhr-app`](https://github.com/pulumi/zephyr-app) repository on GitHub.
 {{% /notes %}}
 
 Up to now, the two-stack approach has worked well for the team. It's allowed them to focus on building new features, integrating those features into the shared `dev` environment by developing and testing locally (which we'll cover in a future post) and merging their [feature branches](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) regularly into the base branch, `main`, using standard GitHub pull-request workflows. Around once a day, as the team's changes are merged into `main`, the team lead (and original author of the Pulumi program) deploys them into the `dev` environment with Pulumi with the following commands:
@@ -193,7 +193,7 @@ pulumi stack rename zephyr/test
 
 ## Viewing the second iteration of Zephyr's code
 
-You can view the second iteration of Zephyr's Pulumi and application code --- the iteration that corresponds to the decisions described in this blog post --- by navigating to [this GitHub repository](https://github.com/pulumi/zephyr-app/). From the branch/tag dropdown, switch from the `main` branch to the [`dev-stacks`](https://github.com/pulumi/zephyr-app/tree/dev-stacks) tag
+You can view the second iteration of Zephyr's Pulumi and application code --- the iteration that corresponds to the decisions described in this blog post --- by navigating to [this GitHub repository](https://github.com/pulumi/zephyr-app/). From the branch/tag dropdown, switch from the `main` branch to the [`blog/dev-stacks`](https://github.com/pulumi/zephyr-app/tree/blog/dev-stacks) branch.
 
 From that GitHub repository, you can also choose to deploy the Pulumi code yourself. Full instructions for deploying the code are found in the repository.
 

--- a/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
@@ -32,7 +32,7 @@ Here are links to all the blog posts in the series (entries below that are not l
 As a result of launching its online presence, Zephyr saw amazing success. The market for arcane artifacts and novel curiosities is booming, and Zephyr is becoming a leader in this market. Funded by this success, Zephyr has grown rapidly. Along with this growth, Zephyr's software engineering and IT teams also grew and expanded. Fortunately, Zephyr's [use of per-developer stacks with short-lived ephemeral Git branches](/blog/iac-recommended-practices-developer-stacks-git-branches/) positioned the development teams well for this growth.
 
 {{% notes %}}
-For a look at the state of Zephyr's Pulumi code as it stood as of the end of the second post in the series, see the [`dev-stacks`](https://github.com/pulumi/zephyr-app/tree/dev-stacks) tag of the [`pulumi/zephyr-app`](https://github.com/pulumi/zephyr-app) repository on GitHub.
+For a look at the state of Zephyr's Pulumi code as it stood as of the end of the second post in the series, see the [`blog/dev-stacks`](https://github.com/pulumi/zephyr-app/tree/blog/dev-stacks) branch of the [`pulumi/zephyr-app`](https://github.com/pulumi/zephyr-app) repository on GitHub.
 {{% /notes %}}
 
 Naturally this growth has resulted in some separation of duties. The IT team now has responsibility for the infrastructure that supports the online retail store. Within that team, some team members are focused on "core" infrastructure, while other team members are focused only on Kubernetes (a natural decision given Zephyr's use of Kubernetes in their architecture). The application team continues to remain responsible for the online store application itself.
@@ -84,7 +84,7 @@ In [the first Zephyr post](/blog/iac-recommended-practices-code-organization-and
 
 Note that relocating code (to a different GitHub repository or different filesystem location within a repository) generally has no impact on Pulumi. As long as the project name and stack name do not change, then changing the filesystem location won't affect anything---keeping in mind, of course, that filesystem paths and such may need to be adjusted in code to account for any such changes.
 
-These repositories are available for you to review on GitHub ([zephyr-infra](https://github.com/pulumi/zephyr-infra), [zephyr-k8s](https://github.com/pulumi/zephyr-k8s), and [zephyr-app](https://github.com/pulumi/zephyr-app)); use the branch/tag selector to find the `multi-project` tab in each repository to see the state of the code as of this blog post. Be aware that the process for standing up the Zephyr online store is now a bit more complex; check the instructions in each repository for more details if you'd like to give these projects a spin.
+These repositories are available for you to review on GitHub ([zephyr-infra](https://github.com/pulumi/zephyr-infra), [zephyr-k8s](https://github.com/pulumi/zephyr-k8s), and [zephyr-app](https://github.com/pulumi/zephyr-app)); use the branch/tag selector to find the `blog/multi-project` branch in each repository to see the state of the code as of this blog post. Be aware that the process for standing up the Zephyr online store is now a bit more complex; check the instructions in each repository for more details if you'd like to give these projects a spin.
 
 ## Summarizing recommended practices
 

--- a/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
@@ -38,7 +38,7 @@ This post continues the previous post in the series. Zephyr's infrastructure foo
 The reasons for this structure are explained in [the third Zephyr blog post](/blog/iac-recommended-practices-structuring-pulumi-projects/). For Zephyr, it came down to supporting multiple teams and allowing the application to evolve independently of the infrastructure that supports it.
 
 {{% notes %}}
-You can continue to use the `multi-project` tag in the GitHub repositories to see the state of Zephyr's code and projects for this blog post.
+You can continue to use the `blog/multi-project` branch in the GitHub repositories to see the state of Zephyr's code and projects for this blog post.
 {{% /notes %}}
 
 It's clear that there are dependencies across projects: The `zephyr-k8s` project needs to know the VPC ID and the subnet IDs from the `zephyr-infra` project. Similarly, the `zephyr-app` project needs to have access to the Kubernetes cluster details from the `zephyr-k8s` project. As the Zephyr team went about building the code that's now in use in their multi-project architecture, they needed to decide how best to handle these cross-project dependencies. The Zephyr team knew that hard-coding output values from one project as configuration values in another stack wasn't the ideal way (and in fact Pulumi **strongly** recommends against hard-coding output values), but what was the best solution to use? The answer to that question is _stack references_.
@@ -74,7 +74,7 @@ One thing not listed above is security---and that's because a later post in the 
 
 With these recommended practices in mind, you can examine the Zephyr team's implementation to see how they put these recommendations into action.
 
-* In the code for the base infrastructure stack, you can see that Zephyr [exported the essential values](https://github.com/pulumi/zephyr-infra/blob/multi-project/index.ts#L14-L17) needed by the Kubernetes platform stack:
+* In the code for the base infrastructure stack, you can see that Zephyr [exported the essential values](https://github.com/pulumi/zephyr-infra/blob/blog/multi-project/index.ts#L14-L17) needed by the Kubernetes platform stack:
 
     ```typescript
     // Export some values for use elsewhere
@@ -83,7 +83,7 @@ With these recommended practices in mind, you can examine the Zephyr team's impl
     export const pubSubnetIds = eksVpc.publicSubnetIds;
     ```
 
-* In the Kubernetes platform stack, the Zephyr team [parameterized the values](https://github.com/pulumi/zephyr-k8s/blob/multi-project/index.ts#L10-L12) needed for the stack reference. This particular approach, by the way, is key to preserving [the per-developer stacks](/blog/iac-recommended-practices-developer-stacks-git-branches/) to which the Zephyr team has grown accustomed (each developer needs to specify the correct organization, project, and stack name):
+* In the Kubernetes platform stack, the Zephyr team [parameterized the values](https://github.com/pulumi/zephyr-k8s/blob/blog/multi-project/index.ts#L10-L12) needed for the stack reference. This particular approach, by the way, is key to preserving [the per-developer stacks](/blog/iac-recommended-practices-developer-stacks-git-branches/) to which the Zephyr team has grown accustomed (each developer needs to specify the correct organization, project, and stack name):
 
     ```typescript
     // Grab some configuration values
@@ -96,14 +96,14 @@ With these recommended practices in mind, you can examine the Zephyr team's impl
     const infraSr = new pulumi.StackReference(`${infraOrgName}/${infraProjName}/${infraStackName}`);
     ```
 
-* As with the base infrastructure stack, [only the key value needed by other stacks](https://github.com/pulumi/zephyr-k8s/blob/multi-project/index.ts#L36-L37) is exported (in this case, the Kubeconfig required to access this cluster):
+* As with the base infrastructure stack, [only the key value needed by other stacks](https://github.com/pulumi/zephyr-k8s/blob/blog/multi-project/index.ts#L36-L37) is exported (in this case, the Kubeconfig required to access this cluster):
 
     ```typescript
     // Export some values for use elsewhere
     export const kubeconfig = eksCluster.kubeconfig;
     ```
 
-* Finally, in the application stack, the [stack reference values are again parameterized](https://github.com/pulumi/zephyr-app/blob/multi-project/infra/index.ts#L7-L9), and the Kubeconfig---necessary for the application stack to deploy onto the provisioned Kubernetes cluster---is [referenced via a stack reference](https://github.com/pulumi/zephyr-app/blob/multi-project/infra/index.ts#L11-L13):
+* Finally, in the application stack, the [stack reference values are again parameterized](https://github.com/pulumi/zephyr-app/blob/blog/multi-project/infra/index.ts#L7-L9), and the Kubeconfig---necessary for the application stack to deploy onto the provisioned Kubernetes cluster---is [referenced via a stack reference](https://github.com/pulumi/zephyr-app/blob/blog/multi-project/infra/index.ts#L11-L13):
 
     ```typescript
     // Grab some configuration values
@@ -117,7 +117,7 @@ With these recommended practices in mind, you can examine the Zephyr team's impl
     ```
 
 {{% notes %}}
-All of the GitHub links in the paragraphs above reference the `multi-project` tag in each repository, which has the code as of this blog post (and the earlier blog post).
+All of the GitHub links in the paragraphs above reference the `blog/multi-project` branch in each repository, which has the code as of this blog post (and the earlier blog post).
 {{% /notes %}}
 
 ## Summarizing recommended practices

--- a/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
@@ -58,7 +58,7 @@ You can see how the Zephyr team did this for their projects, including code samp
 
 It's worthwhile to note that any information that needs to be accessible from another stack via a stack reference must be exported as a stack output in the source stack. If you don't mark it as a stack output, then it can't be used in a stack reference. Adding stack outputs after the fact requires little effort and has no impact on existing infrastructure.
 
-Also, any value retrieved via a stack reference is treated as [a Pulumi Output](/docs/intro/concepts/inputs-outputs/), and therefore may require some extra work to transform values (such as the use of `Output.apply`). The recent addition of `OutputDetails` support in Pulumi---you can read more about `OutputDetails` [in this blog post announcing the functionality](/blog/stack-reference-output-details/)---helps considerably in this situation. Some SDKs also have language-specific mechanisms that can help; for example, using Go's `.AsStringArrayOutput()` method on a `StackReference.GetOutput` statement makes referencing subnet IDs from other project much easier.
+Also, any value retrieved via a stack reference is treated as [a Pulumi Output](/docs/intro/concepts/inputs-outputs/), and therefore may require some extra work to transform values (such as the use of `Output.apply`). The recent addition of `OutputDetails` support in Pulumi---you can read more about `OutputDetails` [in this blog post announcing the functionality](/blog/stack-reference-output-details/)---helps considerably in this situation. Some SDKs also have language-specific mechanisms that can help; for example, using Go's `.AsStringArrayOutput()` method on a `StackReference.GetOutput` statement makes referencing subnet IDs from another project much easier.
 
 While stack references are conceptually straightforward and not difficult to implement, there are some recommended practices to be mindful of regarding the use of stack outputs and stack references:
 
@@ -117,7 +117,7 @@ With these recommended practices in mind, you can examine the Zephyr team's impl
     ```
 
 {{% notes %}}
-All of the GitHub links in the paragraphs above reference the `blog/multi-project` branch in each repository, which has the code as of this blog post (and the earlier blog post).
+All of the GitHub links in the paragraphs above reference the `blog/multi-project` branch in each repository, which has the code as of this blog post (and the earlier blog posts).
 {{% /notes %}}
 
 ## Summarizing recommended practices

--- a/themes/default/content/blog/local-testing-with-pulumi/index.md
+++ b/themes/default/content/blog/local-testing-with-pulumi/index.md
@@ -47,7 +47,7 @@ Alice smiled. "I have an idea."
 A couple days later, Alice contacted Bob and said, "I want to show you what I've come up with."
 
 {{% notes %}}
-To see the code that Alice created for local testing of the Zephyr online store with Pulumi, visit [the zephyr-app repository](https://github.com/pulumi/zephyr-app/) and look at the `inner-dev-loop` tag.
+To see the code that Alice created for local testing of the Zephyr online store with Pulumi, visit [the zephyr-app repository](https://github.com/pulumi/zephyr-app/) and look at the [`blog/inner-dev-loop`](https://github.com/pulumi/zephyr-app/tree/blog/inner-dev-loop/) branch.
 {{% /notes %}}
 
 When Bob met up with Alice, Alice showed him a TypeScript program she'd written with Pulumi's Docker provider that automates building and deploying the Zephyr online store to a local Docker daemon.
@@ -170,4 +170,4 @@ Bob watches as the operation completes in about 17 seconds.
 
 ## Try this out yourself
 
-Now that you've seen how Alice uses Pulumi to streamline testing the Zephyr online store's application code locally, feel free to try this out yourself! The code that you saw in this blog post is available [in the `zephyr-app` repository on GitHub](https://github.com/pulumi/zephyr-app/). Just select the `inner-dev-loop` branch and go to the `develop/pulumi` folder.
+Now that you've seen how Alice uses Pulumi to streamline testing the Zephyr online store's application code locally, feel free to try this out yourself! The code that you saw in this blog post is available [in the `zephyr-app` repository on GitHub](https://github.com/pulumi/zephyr-app/). Just select the [`blog/inner-dev-loop`](https://github.com/pulumi/zephyr-app/tree/blog/inner-dev-loop/) branch and go to the `develop/pulumi` folder.


### PR DESCRIPTION
Update all GitHub links in all Zephyr posts to reflect switch from tags to branches

## Description

To make it possible to update the code at "older" points in time that correspond to previous blog posts, we needed to switch from using git tags to git branches. That change has been made, and this PR updates all Github links and references for all Zephyr posts to properly reference the correct git branch instead of the old git tag.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
