### PR TITLE
remove how-to guide buttons for aws-native and google cloud native cause they have no guides

### DIFF
--- a/themes/default/content/docs/clouds/aws/_index.md
+++ b/themes/default/content/docs/clouds/aws/_index.md
@@ -45,9 +45,6 @@ providers:
     - display_name: API docs
       icon: book-small-black
       url: aws-native/api-docs/
-    - display_name: How-to guides
-      icon: question-small-black
-      url: aws-native/how-to-guides/
 components:
 - display_name: AWSx
   url: awsx/

--- a/themes/default/content/docs/clouds/gcp/_index.md
+++ b/themes/default/content/docs/clouds/gcp/_index.md
@@ -46,9 +46,6 @@ providers:
     - display_name: API docs
       icon: book-small-black
       url: google-native/api-docs/
-    - display_name: How-to guides
-      icon: question-small-black
-      url: google-native/how-to-guides/
 components:
 - display_name: Google Cloud Global CloudRun
   url: gcp-global-cloudrun/


### PR DESCRIPTION
## Description
<img width="1011" alt="Screenshot 2023-05-16 at 11 15 33 AM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/e2af580c-e534-4b02-a2da-26641f62a844">

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
