### PR TITLE
if external, render external link in rss feed

### DIFF
--- a/themes/default/content/resources/pulumi-up-2023/index.md
+++ b/themes/default/content/resources/pulumi-up-2023/index.md
@@ -33,7 +33,7 @@ block_external_search_index: true
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.
-url_slug: "/pulumi-up"
+url_slug: "https://www.pulumi.com/resources/pulumi-up-2023/"
 
 # Content for the left hand side section of the page.
 main:

--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -12,7 +12,11 @@
                 <title>{{ .Params.title }}</title>
                 <description>{{ .Params.meta_desc }}</description>
                 <pubDate>{{ .Params.main.sortable_date }}</pubDate>
+                {{ if .Params.external }}
+                <link>{{ .Params.url_slug }}</link>
+                {{ else }}
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
+                {{ end }}
             </item>
         {{ end }}
     </channel>

--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -13,6 +13,10 @@
                 <description>{{ .Params.meta_desc }}</description>
                 <pubDate>{{ .Params.main.sortable_date }}</pubDate>
                 {{ if .Params.external }}
+                <!--
+                    When the workshop is external, the `url_slug` property is set to the external link
+                    in the workshop template.
+                -->
                 <link>{{ .Params.url_slug }}</link>
                 {{ else }}
                 <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>


### PR DESCRIPTION
## Description
Render the external link in place of the actual resource page link when the workshop is external. [We set the url_slug property in the workshop templates to that external link when the workshop is external.](https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/content/resources/production-ready-kubernetes-for-python-devs/index.md?plain=1#L35-L37)

https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/content/resources/production-ready-kubernetes-for-python-devs/index.md?plain=1#L35-L37

this is how it looks now for that workshop that was giving issues:
![image](https://github.com/pulumi/pulumi-hugo/assets/16751381/8b77770b-86ba-4f59-9794-7b1915e7e49d)


## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
