### PR TITLE
fix alias that is missing a slash

### DIFF
--- a/themes/default/content/docs/concepts/secrets.md
+++ b/themes/default/content/docs/concepts/secrets.md
@@ -7,7 +7,7 @@ menu:
   concepts:
     weight: 7
 aliases:
-- docs/intro/concepts/secrets/
+- /docs/intro/concepts/secrets/
 ---
 
 All resource input and output values are recorded as [`state`](/docs/concepts/state), and are stored in the Pulumi Cloud, a file, or a pluggable provider that you choose. These raw values are usually just server names, configuration settings, etc. However, these values sometimes contain sensitive data, such as database passwords or service tokens. **Pulumi never sends authentication secrets or credentials to the Pulumi Cloud**.


### PR DESCRIPTION
## Description

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
