### PR TITLE
make guid match link in rss feed

### DIFF
--- a/themes/default/layouts/resources/rss.xml
+++ b/themes/default/layouts/resources/rss.xml
@@ -8,19 +8,19 @@
         <pubDate>{{ now | time.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
         {{ range (sort .Data.Pages ".Params.main.sortable_date").Reverse }}
             <item>
-                <guid>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</guid>
-                <title>{{ .Params.title }}</title>
-                <description>{{ .Params.meta_desc }}</description>
-                <pubDate>{{ .Params.main.sortable_date }}</pubDate>
-                {{ if .Params.external }}
+                {{ $eventLink := printf "%s%s" .Site.Params.canonicalURL .RelPermalink }}
                 <!--
                     When the workshop is external, the `url_slug` property is set to the external link
                     in the workshop template.
                 -->
-                <link>{{ .Params.url_slug }}</link>
-                {{ else }}
-                <link>{{ .Site.Params.canonicalURL }}{{ .RelPermalink }}</link>
+                {{ if .Params.external }}
+                    {{ $eventLink = .Params.url_slug }}
                 {{ end }}
+                <guid>{{ $eventLink }}</guid>
+                <title>{{ .Params.title }}</title>
+                <description>{{ .Params.meta_desc }}</description>
+                <pubDate>{{ .Params.main.sortable_date }}</pubDate>
+                <link>{{ $eventLink }}</link>
             </item>
         {{ end }}
     </channel>


### PR DESCRIPTION
## Description

apparently the rss parsing library we are using in the service has some weird parsing logic where it is returning the guid as the link in some cases.... this will make the guid match the link for external resources as we are doing for the other events

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
