### PR TITLE
fix blog search results

### DIFF
--- a/themes/default/theme/src/scss/_search.scss
+++ b/themes/default/theme/src/scss/_search.scss
@@ -51,12 +51,6 @@
     top: auto !important;
     left: auto !important;
 
-    @screen md {
-        top: 16px !important;
-        left: -650px !important;
-        width: 650px !important;
-    }
-
     .st-query-present {
         .st-ui-result {
             .st-ui-type-heading {
@@ -68,6 +62,14 @@
                 color: #4a5568 !important; /* text-gray-600 */
             }
         }
+    }
+}
+
+div.search-header-container div.st-default-autocomplete {
+    @screen md {
+        top: 16px !important;
+        left: -650px !important;
+        width: 650px !important;
     }
 }
 


### PR DESCRIPTION
## Description
i think we overlooked blog search when we updated the docs search
this should fix it up quickly
but we may want to revisit this

it seems for blog you have to type 2 letters to get results

### before
<img width="612" alt="Screenshot 2023-05-18 at 6 43 48 AM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/93aff4d5-1418-4f31-ba24-182156be6dd2">

### after
<img width="406" alt="Screenshot 2023-05-18 at 6 43 25 AM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/6dbe40f5-91ee-4613-9cc7-8d8fb676f320">

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
