### PR TITLE
fix templates breadcrumbs

### DIFF
--- a/themes/default/layouts/partials/templates/breadcrumb.html
+++ b/themes/default/layouts/partials/templates/breadcrumb.html
@@ -2,7 +2,7 @@
 
 <!-- Don't show the breadcrumb on the main docs landing page. -->
 {{ if ne .RelPermalink "/docs/" }}
-    <ol class="breadcrumb">
+    <ol class="docs-breadcrumb">
         {{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
     </ol>
 {{ end }}


### PR DESCRIPTION
## Description
had no idea these marketing pages were using docs styles
this should fix it up

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
