### PR TITLE
change "registry" tab in docs to "packages"

### DIFF
--- a/themes/default/layouts/partials/docs/search.html
+++ b/themes/default/layouts/partials/docs/search.html
@@ -10,7 +10,7 @@
                     </a>
                     <a class="tab" href="/registry">
                         <img class="tab-icon" src="/icons/registry-light.svg" />
-                        Registry
+                        Packages
                     </a>
                 {{ else }}
                     <a class="tab" href="/docs">
@@ -19,7 +19,7 @@
                     </a>
                     <a class="tab-selected" href="/registry">
                         <img class="tab-icon" src="/icons/registry.svg" />
-                        Registry
+                        Packages
                     </a>
                 {{ end }}
             </div>


### PR DESCRIPTION
## Description
changing the tab label
not planning any other changes quiet yet
if we get negative feedback we can revert this

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
