### PR TITLE
Add docs on configuring SAML session lifetime

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/access-management/saml/okta.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/saml/okta.md
@@ -105,6 +105,30 @@ titled **SAML SSO Settings**. Then select **Save** at the bottom of the card.
 
 Once the IDP metadata descriptor has been saved, you are all set to log into Pulumi.
 
+## Configuring Session Lifetime
+
+The Pulumi Cloud uses the `SessionNotOnOrAfter` attribute in the `AuthnStatement` element to configure the session lifetime. In order to configure this in Okta, you will need to use a [SAML assertion inline hook](https://developer.okta.com/docs/guides/saml-inline-hook/main/).
+
+The JSON payload the inline hook sends to Okta should contain the following:
+
+```json
+{
+  "commands": [
+    {
+      "type": "com.okta.assertion.patch",
+      "value": [
+        {
+          "op": "add",
+          "path": "/authentication/sessionLifetime",
+          "value": 21600 // lifetime in seconds
+        }
+      ]
+    }
+  ]
+}
+
+```
+
 ### Signing into Pulumi using Okta
 
 Members of your Okta application can now sign into Pulumi. Navigate to

--- a/themes/default/content/docs/pulumi-cloud/access-management/saml/okta.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/saml/okta.md
@@ -107,7 +107,7 @@ Once the IDP metadata descriptor has been saved, you are all set to log into Pul
 
 ## Configuring Session Lifetime
 
-The Pulumi Cloud uses the `SessionNotOnOrAfter` attribute in the `AuthnStatement` element to configure the session lifetime. In order to configure this in Okta, you will need to use a [SAML assertion inline hook](https://developer.okta.com/docs/guides/saml-inline-hook/main/).
+The Pulumi Cloud uses the `SessionNotOnOrAfter` attribute in the `AuthnStatement` element to configure the session lifetime. To configure this in Okta, you must use a [SAML assertion inline hook](https://developer.okta.com/docs/guides/saml-inline-hook/main/).
 
 The JSON payload the inline hook sends to Okta should contain the following:
 

--- a/themes/default/content/docs/pulumi-cloud/access-management/saml/sso.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/saml/sso.md
@@ -77,9 +77,9 @@ The name ID format is one of the most important aspects of your SAML SSO configu
 
 ## Session Lifetime
 
-Most identity providers support configuring the lifetime of the SAML session by passing the optional `SessionNotOnAfter` attribute in the `AuthnStatement` element in the SAML assertion. Please refer to your identity provider for guidance on how to set this attribute.
+Most identity providers support configuring the lifetime of the SAML session by passing the optional `SessionNotOnAfter` attribute in the `AuthnStatement` element in the SAML assertion. Refer to your identity provider for guidance on how to set this attribute.
 
-Here's an example of the `AuthnStatement` element with session lifetime configured:
+Example of the `AuthnStatement` element with session lifetime configured:
 
 ```xml
 <saml:AuthnStatement AuthnInstant="2023-05-23T00:49:39Z" SessionNotOnOrAfter="2023-05-23T10:49:39Z" SessionIndex="...">

--- a/themes/default/content/docs/pulumi-cloud/access-management/saml/sso.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/saml/sso.md
@@ -75,6 +75,18 @@ The name ID format is one of the most important aspects of your SAML SSO configu
 > **Note:** Pulumi only accepts stable and persistent identifiers for users. Identity providers must be able to set either a persistent randomly unique identifier (`urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`) or the user's email address (`urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`) as the user's `Subject` value.
 > <br /> > **Important:** Once your name ID format is configured and your users have started to use SSO, **DO NOT** change the name identifier. That will prevent your users from being able to sign in.
 
+## Session Lifetime
+
+Most identity providers support configuring the lifetime of the SAML session by passing the optional `SessionNotOnAfter` attribute in the `AuthnStatement` element in the SAML assertion. Please refer to your identity provider for guidance on how to set this attribute.
+
+Here's an example of the `AuthnStatement` element with session lifetime configured:
+
+```xml
+<saml:AuthnStatement AuthnInstant="2023-05-23T00:49:39Z" SessionNotOnOrAfter="2023-05-23T10:49:39Z" SessionIndex="...">
+```
+
+If `SessionNotOnAfter` isn't specified, then the Pulumi Cloud will use the default session lifetime of 12 hours.
+
 ## Troubleshooting
 
 ### Validation error while trying to save an IdP-provided metadata XML in the Pulumi Cloud


### PR DESCRIPTION
## Description
If we're going to improve the way we handle SAML expirations, we should also have this info in our docs. Most of our SAML users are using Okta as their IdP, so this also adds some instructions for setting that up with Okta specifically since it's not super straightforward.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
