### PR TITLE
Node: Add description of support package managers

### DIFF
--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -211,7 +211,7 @@ runtime:
 ## Package Management
 
 Pulumi has official support for NPM and Yarn Classic. Pulumi does
-not currently support Yarn Plug'n'Play.
+not support Yarn Plug'n'Play.
 
 Pulumi defaults to using NPM. However, if Pulumi detects a `yarn.lock` file
 in the project root, or the environment variable `PULUMI_PREFER_YARN=true`,

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -216,7 +216,7 @@ not support Yarn Plug'n'Play.
 Pulumi defaults to using NPM. However, if Pulumi detects a `yarn.lock` file
 in the project root, or the environment variable `PULUMI_PREFER_YARN=true`,
 then Pulumi will use Yarn instead of NPM if the executable is available in the
-user's path.
+path.
 
 ## Package Documentation
 

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -208,6 +208,16 @@ runtime:
     typescript: false
 ```
 
+## Package Management
+
+Pulumi has official support for NPM and Yarn Classic. Pulumi does
+not currently support Yarn Plug'n'Play.
+
+Pulumi defaults to using NPM. However, if Pulumi detects a `yarn.lock` file
+in the project root, or the environment variable `PULUMI_PREFER_YARN=true`,
+then Pulumi will use Yarn instead of NPM if the executable available in the
+user's path.
+
 ## Package Documentation
 
 In addition to the standard and cloud-agnostic packages the [Pulumi Registry](/registry/) houses 100+ Node.js packages.

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -215,7 +215,7 @@ not support Yarn Plug'n'Play.
 
 Pulumi defaults to using NPM. However, if Pulumi detects a `yarn.lock` file
 in the project root, or the environment variable `PULUMI_PREFER_YARN=true`,
-then Pulumi will use Yarn instead of NPM if the executable available in the
+then Pulumi will use Yarn instead of NPM if the executable is available in the
 user's path.
 
 ## Package Documentation


### PR DESCRIPTION
## Description

The Platform team is often asked about support for different Node package managers. We're working on an epic to support PNPM, Yarn Berry, and NX, but for now our support is limited to Yarn Classic (without P'n'P) and NPM. 

This commit adds a short section explaining which managers are supported and how to use Yarn over NPM.

In the interest of "documenting what is, not what isn't", I've kept this section super narrow, not mentioning that some users have success with Yarn Berry and PNPM. As we advance through the monorepo epic, we're likely to add official support for PNPM; at that point, this section will fill out a bit more. 

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
