### PR TITLE
remove get started content from language pages

### DIFF
--- a/themes/default/content/docs/languages-sdks/_index.md
+++ b/themes/default/content/docs/languages-sdks/_index.md
@@ -14,8 +14,6 @@ aliases:
 - /docs/reference/pulumi-sdk/
 ---
 
-{{< get-started-note >}}
-
 Pulumi is a multi-language infrastructure as code tool. Each language is as capable as the
 other and supports the entire surface area of all of the clouds available in [Pulumi Registry](
 /registry).

--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -20,37 +20,6 @@ You can use your favorite .NET tools &mdash; such as editors, package managers, 
 
 <a class="btn btn-secondary" href="https://dotnet.microsoft.com/download" target="_blank" title="Install .NET">Install .NET</a>
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=csharp">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=csharp">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=csharp">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=csharp">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
-{{% notes "info" %}}
-The Getting Started guides only demonstrate C#, but will also work for F# and Visual Basic.
-{{% /notes %}}
-
 ## Prerequisites
 
 Before using Pulumi for .NET, you will need to install both Pulumi and .NET Core SDK 3.1, .NET 5, or .NET 6 (recommended). If you follow the Getting Started guides above, they will walk you through doing this.

--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -143,7 +143,7 @@ End Module
 
 ## C\#, F\#, and VB Templates
 
-You can write Pulumi programs in your favorite .NET language to get additional verification and tooling benefits. The fastest way to get started is to use a template. The template will autogenerate a set of files and initialize a Pulumi project. The getting started guides shown above will help do this on your cloud of choice, but this section describes doing so independently.
+You can write Pulumi programs in your favorite .NET language to get additional verification and tooling benefits. The fastest way to get started is to use a template. The template will autogenerate a set of files and initialize a Pulumi project.
 
 {{< chooser language "csharp,fsharp,visualbasic" >}}
 

--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -29,6 +29,8 @@ Before using Pulumi for .NET, you will need to install both Pulumi and .NET Core
 
 ## Example
 
+{{% chooser language "csharp,fsharp,visualbasic" %}}
+
 {{% choosable language csharp %}}
 For example, this C# program provisions an Azure resource group and storage account:
 
@@ -136,6 +138,8 @@ End Module
 ```
 
 {{% /choosable %}}
+
+{{% /chooser %}}
 
 ## C\#, F\#, and VB Templates
 

--- a/themes/default/content/docs/languages-sdks/go/_index.md
+++ b/themes/default/content/docs/languages-sdks/go/_index.md
@@ -19,7 +19,7 @@ Pulumi supports writing your infrastructure as code in the Go language built for
 
 ## Templates
 
-The fastest way to get started is to use a template. The template will initialize a Pulumi project. The getting started guides shown above will help do this on your cloud of choice, but this section describes doing so independently.
+The fastest way to get started is to use a template. The template will initialize a Pulumi project.
 
 From an empty directory, create a new project:
 

--- a/themes/default/content/docs/languages-sdks/go/_index.md
+++ b/themes/default/content/docs/languages-sdks/go/_index.md
@@ -17,33 +17,6 @@ Pulumi supports writing your infrastructure as code in the Go language built for
 
 <a class="btn btn-secondary" href="https://golang.org/doc/install" target="_blank" title="Install Go">Install Go</a>
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=go">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=go">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=go">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=go">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
 ## Templates
 
 The fastest way to get started is to use a template. The template will initialize a Pulumi project. The getting started guides shown above will help do this on your cloud of choice, but this section describes doing so independently.

--- a/themes/default/content/docs/languages-sdks/java/_index.md
+++ b/themes/default/content/docs/languages-sdks/java/_index.md
@@ -29,7 +29,7 @@ Please post any Bug Reports or Feature Requests in [GitHub Issues](https://githu
 
 ## Templates
 
-The getting started guides shown above will help you write a Pulumi Java program via tutorial, but this section describes starting a basic project that you can start to explore with.
+This section describes starting a basic project that you can start to explore with.
 
 From an empty directory, create a new project:
 

--- a/themes/default/content/docs/languages-sdks/java/_index.md
+++ b/themes/default/content/docs/languages-sdks/java/_index.md
@@ -27,33 +27,6 @@ Please post any Bug Reports or Feature Requests in [GitHub Issues](https://githu
 
 {{< install-java >}}
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=java">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=java">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=java">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=java">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
 ## Templates
 
 The getting started guides shown above will help you write a Pulumi Java program via tutorial, but this section describes starting a basic project that you can start to explore with.

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -22,33 +22,6 @@ test frameworks.
 
 <a class="btn btn-secondary" href="https://nodejs.org/en/download/" target="_blank" title="Install Node.js">Install Node.js</a>
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=nodejs">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=nodejs">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=nodejs">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=nodejs">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
 ## Pulumi Programming Model
 
 The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using

--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -18,33 +18,6 @@ Pulumi supports writing your infrastructure as code in the Python language runni
 
 {{< install-python >}}
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=python">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=python">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=python">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=python">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
 ## Pulumi Programming Model
 
 The Pulumi programming model defines the core concepts you will use when creating infrastructure as code programs using

--- a/themes/default/content/docs/languages-sdks/yaml/_index.md
+++ b/themes/default/content/docs/languages-sdks/yaml/_index.md
@@ -19,33 +19,6 @@ Pulumi supports writing your infrastructure as code using Pulumi YAML. Pulumi YA
 configuration language designed to make describing infrastructure as simple as possible. It supports
 managing infrastructure on any cloud, including Azure, AWS, and Google Cloud.
 
-## Getting Started
-
-The fastest way to get up and running is to choose from one of the following Getting Started guides:
-
-<div class="tiles mt-4">
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/aws/get-started/?language=yaml">
-            <img class="h-8 mx-auto" src="/logos/tech/aws.svg" alt="AWS">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/azure/get-started/?language=yaml">
-            <img class="h-8 mx-auto" src="/logos/tech/azure.svg" alt="Azure">
-        </a>
-    </div>
-    <div class="flex-1 pb-4 md:mr-4">
-        <a class="tile p-4" href="/docs/clouds/gcp/get-started/?language=yaml">
-            <img class="h-8 mx-auto" src="/logos/tech/gcp.svg" alt="Google Cloud">
-        </a>
-    </div>
-    <div class="flex-1 pb-4">
-        <a class="tile p-4" href="/docs/clouds/kubernetes/get-started/?language=yaml">
-            <img class="h-8 mx-auto" src="/logos/tech/k8s.svg" alt="Kubernetes">
-        </a>
-    </div>
-</div>
-
 ## Prerequisites
 
 All you need to use Pulumi YAML is the [Pulumi CLI](/docs/install/).


### PR DESCRIPTION
## Description

the get started sections on these pages is confusing, and community convos makes people feel like they are in the wrong place. we also have a link to the get started page in the left nav, and the button at the top of the page. we also link to them from each of the cloud pages. dropping this content.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
