### PR TITLE
remove future mention

### DIFF
--- a/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
+++ b/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
@@ -62,7 +62,7 @@ Specifically, you should author a few pages:
 1. `installation-configuration.md`, which will be shown on your package's Installation & Configuration tab. Use this page to describe how to set up your package, including authenticating to a cloud provider, and to list the configuration options that can be used with your package. The title of this page should be in the form `<Package display name> Installation & Configuration`.
 
 {{% notes type="info" %}}
-A future improvement to Pulumi Packages will enable Pulumi Registry to create the contents for the Overview tab of your package directly from a `README.md` in the root of your package's repository. Until then, we recommend keeping the contents of `README.md` and `_index.md` similar or the same, save for the YAML metadata/front-matter that's in `_index.md`.
+We recommend keeping the contents of `README.md` and `_index.md` similar or the same, save for the YAML metadata/front-matter that's in `_index.md`.
 {{% /notes %}}
 
 ### Package metadata


### PR DESCRIPTION
## Description
sometimes the future never comes
we should document what is, not what might happen in the future as it often disappoints users or confuses them

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
