### PR TITLE
add missing kube template

### DIFF
--- a/themes/default/content/docs/clouds/aws/_index.md
+++ b/themes/default/content/docs/clouds/aws/_index.md
@@ -83,6 +83,8 @@ templates:
   url: static-website/aws/
 - display_name: Virtual machine on AWS
   url: virtual-machine/aws/
+- display_name: Kubernetes cluster on AWS
+  url: kubernetes/aws/
 guides:
   description: Learn how to use AWS & Pulumi together.
   guides_list:

--- a/themes/default/content/docs/clouds/azure/_index.md
+++ b/themes/default/content/docs/clouds/azure/_index.md
@@ -70,4 +70,6 @@ templates:
   url: static-website/azure/
 - display_name: Virtual machine on Azure
   url: virtual-machine/azure/
+- display_name: Kubernetes cluster on Azure
+  url: kubernetes/azure/
 ---

--- a/themes/default/content/docs/clouds/gcp/_index.md
+++ b/themes/default/content/docs/clouds/gcp/_index.md
@@ -59,4 +59,6 @@ templates:
   url: static-website/gcp/
 - display_name: Virtual machine on Google Cloud
   url: virtual-machine/gcp/
+- display_name: Kubernetes cluster on Google Cloud
+  url: kubernetes/gcp/
 ---

--- a/themes/default/content/docs/clouds/kubernetes/_index.md
+++ b/themes/default/content/docs/clouds/kubernetes/_index.md
@@ -58,7 +58,7 @@ templates:
 - display_name: Helm Chart on Kubernetes
   url: kubernetes-application/helm-chart/
 - display_name: Web application on Kubernetes
-  url: /kubernetes-application/web-application/
+  url: kubernetes-application/web-application/
 guides-description: Learn how to use Pulumi & Kubernetes together.
 guides:
   description: Learn how to use Kubernetes & Pulumi together.

--- a/themes/default/content/docs/clouds/kubernetes/_index.md
+++ b/themes/default/content/docs/clouds/kubernetes/_index.md
@@ -57,6 +57,8 @@ templates:
   url: kubernetes/gcp/
 - display_name: Helm Chart on Kubernetes
   url: kubernetes-application/helm-chart/
+- display_name: Web application on Kubernetes
+  url: /kubernetes-application/web-application/
 guides-description: Learn how to use Pulumi & Kubernetes together.
 guides:
   description: Learn how to use Kubernetes & Pulumi together.

--- a/themes/default/layouts/partials/docs/cloud-overview.html
+++ b/themes/default/layouts/partials/docs/cloud-overview.html
@@ -94,15 +94,48 @@
             choice.
         </p>
         <div class="flex">
-            {{ range $template := .Params.templates }}
-                <div class="flex-2-col">
-                    <a href="/templates/{{ $template.url }}">
-                        <div class="card-inner">
-                            <div>
-                                <p>{{ $template.display_name }}</p>
+            {{ range $index, $template := .Params.templates }}
+                {{ if le $index 3 }}
+                    <div class="flex-2-col">
+                        <a href="/templates/{{ $template.url }}">
+                            <div class="card-inner">
+                                <div>
+                                    <p>{{ $template.display_name }}</p>
+                                </div>
                             </div>
+                        </a>
+                    </div>
+                {{ end }}
+            {{ end }}
+            {{ if ge (len .Params.templates) 5 }}
+                <div id="accordion-components" class="accordion flex-1-col">
+                    <div>
+                        <input type="checkbox" id="accordion-checkbox-templates" />
+                        <div class="accordion-content flex">
+                            {{ range $index, $template := .Params.templates }}
+                                {{ if ge $index 4 }}
+                                    <div class="flex-2-col">
+                                        {{ $url := print "/templates/" $template.url }}
+                                        <a href="{{ $template.url }}">
+                                            <div class="card-inner">
+                                                <div>
+                                                    <p>{{ $template.display_name }}</p>
+                                                </div>
+                                            </div>
+                                        </a>
+                                    </div>
+                                {{ end }}
+                            {{ end }}
                         </div>
-                    </a>
+                        <label for="accordion-checkbox-templates" class="show">
+                            Show {{ sub (len .Params.templates) 4 }} more
+                            <div class="icon icon-16-16 keyboard-arrow-down-gray"></div>
+                        </label>
+                        <label for="accordion-checkbox-templates" class="hide">
+                            Show {{ sub (len .Params.templates) 4 }} less
+                            <div class="icon icon-16-16 keyboard-arrow-up-gray"></div>
+                        </label>
+                    </div>
                 </div>
             {{ end }}
         </div>

--- a/themes/default/layouts/partials/docs/cloud-overview.html
+++ b/themes/default/layouts/partials/docs/cloud-overview.html
@@ -108,7 +108,7 @@
                 {{ end }}
             {{ end }}
             {{ if ge (len .Params.templates) 5 }}
-                <div id="accordion-components" class="accordion flex-1-col">
+                <div id="accordion-templates" class="accordion flex-1-col">
                     <div>
                         <input type="checkbox" id="accordion-checkbox-templates" />
                         <div class="accordion-content flex">

--- a/themes/default/layouts/partials/docs/cloud-overview.html
+++ b/themes/default/layouts/partials/docs/cloud-overview.html
@@ -116,7 +116,7 @@
                                 {{ if ge $index 4 }}
                                     <div class="flex-2-col">
                                         {{ $url := print "/templates/" $template.url }}
-                                        <a href="{{ $template.url }}">
+                                        <a href="{{ $url }}">
                                             <div class="card-inner">
                                                 <div>
                                                     <p>{{ $template.display_name }}</p>

--- a/themes/default/theme/src/scss/docs/_cloud-overview.scss
+++ b/themes/default/theme/src/scss/docs/_cloud-overview.scss
@@ -409,6 +409,20 @@ $box-shadow: #5f606524;
             }
         }
 
+        div#accordion-templates {
+            div.accordion-content,
+            input,
+            label.hide,
+            input:checked ~ label.show  {
+                display: none;
+            }
+        
+            input:checked ~ div.accordion-content,
+            input:checked ~ label.hide {
+                display: flex;
+            }
+        }
+
         div.icon {
             display: block;
             text-indent: -9999px;


### PR DESCRIPTION
## Description
reviewers note: i know i can refactor this and make it better and more dry
only trying to get this out quickly

this...

- adds the associated kube template to the cloud providers pages
- adds the missing kube template to the kube page

<img width="765" alt="Screenshot 2023-05-26 at 1 22 43 PM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/d93e34dc-8aa8-41a5-a49b-7b011d2956a5">
<img width="784" alt="Screenshot 2023-05-26 at 1 22 39 PM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/477fc30d-ebfe-45ce-8793-66695442c797">


## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
