### PR TITLE
Fix plugins in Pulumi.json reference

### DIFF
--- a/themes/default/content/docs/concepts/projects/project-file.md
+++ b/themes/default/content/docs/concepts/projects/project-file.md
@@ -45,12 +45,12 @@ template:
       secret: true
 plugins:
   providers:
-    name: aws
-    path: ../../bin
+    - name: aws
+      path: ../../bin
   languages:
-    name: yaml
-    path: ../../../pulumi-yaml/bin
-    version: 1.2.3
+    - name: yaml
+      path: ../../../pulumi-yaml/bin
+      version: 1.2.3
 ```
 
 ## Attributes
@@ -161,9 +161,9 @@ Use this option to link to local plugin binaries. This option is intended for us
 
 | Name | Required | Description |
 | - | - | - |
-| `providers` | optional | Plugin for the provider. |
-| `analyzers` | optional | Plugin for the policy. |
-| `languages` | optional | Plugin for the language. |
+| `providers` | optional | List of provider plugins. |
+| `analyzers` | optional | List of policy plugins. |
+| `languages` | optional | List of language plugins. |
 
 #### Options for `providers`, `analyzers`, and `languages`
 


### PR DESCRIPTION
## Description

The plugins properties are lists, not single element. This is described in our schema here: https://github.com/pulumi/pulumi/blob/af3dea6e2d3ad15282835f19a9550c5b71b2fca6/sdk/go/common/workspace/project.json#L204-L231

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] ~If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).~
- [ ] ~I have manually confirmed that all new links work.~
- [ ] ~I added aliases (i.e., redirects) for all filename changes.~
- [ ] ~If making css changes, I rebuilt the bundle.~
