### PR TITLE
update CTAs on homepage to 'Get Started' and 'Contact Sales'

### DIFF
--- a/themes/default/content/_index.md
+++ b/themes/default/content/_index.md
@@ -6,7 +6,10 @@ hero:
   title: [ "Infrastructure as code", "in any programming language" ]
   description: |
     Build infrastructure intuitively on any cloud using familiar languages.
-  cta_text: Try Pulumi Cloud
+  cta_text: Get Started
+  cta_link: /docs/get-started
+  secondary_cta_text: Contact Sales
+  secondary_cta_link: /contact/?form=sales
 
 code_faster:
   title: Code and ship faster

--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -11,8 +11,8 @@
             </h1>
             <p class="text-center leading-7">{{ .Params.hero.description | markdownify }}</p>
             <div class="overlay-middle mt-8 flex text-center justify-center items-center flex-col mx-auto lg:mx-0 md:flex-row">
-                <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="https://app.pulumi.com/signup">{{ .Params.hero.cta_text }}</a>
-                <a class="btn-secondary home-hero-btn-secondary rounded-full cursor-pointer" href="{{ relref . "/docs/get-started" }}">Get Started</a>
+                <a class="home-hero-btn-primary mr-0 md:mr-4 mb-3 md:mb-0" href="{{ .Params.hero.cta_link }}">{{ .Params.hero.cta_text }}</a>
+                <a class="btn-secondary home-hero-btn-secondary rounded-full cursor-pointer" href="{{ .Params.hero.secondary_cta_link }}">{{ .Params.hero.secondary_cta_text }}</a>
             </div>
         </div>
     </header>


### PR DESCRIPTION
## Description
Primary CTA now [Get Started](https://www.pulumi.com/docs/get-started/)
Secondary CTA now [Contact Sales](https://www.pulumi.com/contact/?form=sales)

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
