### PR TITLE
fix code blocks in notes

### DIFF
--- a/themes/default/theme/src/scss/_notes.scss
+++ b/themes/default/theme/src/scss/_notes.scss
@@ -54,11 +54,7 @@
         font-size: 14px;
         color: #131314;
         flex-direction: row;
-    }
-
-    code {
-        border-radius: 4px;
-        padding: 1px 6px 3px 6px;
+        min-width: 0;
     }
 
     &.note-info {
@@ -96,5 +92,9 @@
         code {
             background: #f9e6d4;
         }
+    }
+
+    div.highlight div.copy-button-container button.copy-button i {
+        color: #fff;
     }
 }


### PR DESCRIPTION
## Description
fixes https://github.com/pulumi/pulumi-hugo/issues/3009
if ya wanna see it live in the preview the concepts state and backends page has one
`/docs/concepts/state/#aws-s3`
### before
<img width="947" alt="Screenshot 2023-06-08 at 4 51 24 PM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/ffbbf118-51ad-4479-b0f5-3b5cd7f6b2f1">

### after
<img width="814" alt="Screenshot 2023-06-08 at 4 52 07 PM" src="https://github.com/pulumi/pulumi-hugo/assets/5489125/55f4132a-3c1f-4b17-b960-a630e989c5e0">

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
