### PR TITLE
Enable Algolia insights

### DIFF
--- a/themes/default/assets/js/bundle.js
+++ b/themes/default/assets/js/bundle.js
@@ -62,4 +62,4 @@
                     `,noResults:({html:e,state:t})=>{if(t.query)return e`
                         <img src="/images/search/no-results.svg"/>
                         <p>We couldn't find any results for <mark>${t.query}</mark>.</p>
-                    `}}}}(e,0,r)),pp(o)},plugins:[up(wp)]})}var Cp;window.addEventListener("DOMContentLoaded",(()=>{const e=document.querySelector("#search");e&&Sp(e)})),"undefined"!=typeof customElements&&[So,Co,Do,_o,Eo,ko,xo,Oo,$o,To,Ao,Po,jo,Io,Fo,Lo,Mo,No,Bo,Ro,zo,qo,Uo,Ho,Wo,Vo,Go,Ko,Yo,Jo,Xo,Qo,Zo,es,ts,ns,rs,is].forEach((e=>{customElements.get(e.is)||customElements.define(e.is,e,Cp)}))})()})();
+                    `}}}}(e,0,r)),pp(o)},insights:!0,plugins:[up(wp)]})}var Cp;window.addEventListener("DOMContentLoaded",(()=>{const e=document.querySelector("#search");e&&Sp(e)})),"undefined"!=typeof customElements&&[So,Co,Do,_o,Eo,ko,xo,Oo,$o,To,Ao,Po,jo,Io,Fo,Lo,Mo,No,Bo,Ro,zo,qo,Uo,Ho,Wo,Vo,Go,Ko,Yo,Jo,Xo,Qo,Zo,es,ts,ns,rs,is].forEach((e=>{customElements.get(e.is)||customElements.define(e.is,e,Cp)}))})()})();

--- a/themes/default/theme/src/ts/algolia/autocomplete.ts
+++ b/themes/default/theme/src/ts/algolia/autocomplete.ts
@@ -299,6 +299,10 @@ function initAutocomplete(el: HTMLElement) {
             return debounce(sources);
         },
 
+        // Enable Algolia insights.
+        // https://www.algolia.com/doc/guides/building-search-ui/events/js/
+        insights: true,
+
         // https://www.algolia.com/doc/ui-libraries/autocomplete/core-concepts/plugins/
         plugins: [
             getTagsPlugin(baseTags),


### PR DESCRIPTION
To help us better understand how our users are using search, this change [enables Algolia insights](https://www.algolia.com/doc/guides/building-search-ui/events/js), which sends anonymous usage data (such as click events) to Algolia.

Fixes https://github.com/pulumi/devrel-team/issues/573.