### PR TITLE
Remove programming-model docs alias

### DIFF
--- a/themes/default/content/docs/concepts/how-pulumi-works.md
+++ b/themes/default/content/docs/concepts/how-pulumi-works.md
@@ -15,7 +15,6 @@ aliases:
 - /docs/tour/programs-resources/
 - /docs/tour/programs-stacks/
 - /docs/intro/concepts/how-pulumi-works/
-- /docs/intro/concepts/programming-model/
 ---
 
 Pulumi uses a desired state model for managing infrastructure. A Pulumi program is executed by a _language host_ to compute a desired state for a stack's infrastructure. The _deployment engine_ compares this desired state with the stack's current state and determines what resources need to be created, updated or deleted. The engine uses a set of _resource providers_ (such as [AWS](/docs/clouds/aws/get-started/), [Azure](/docs/clouds/azure/get-started/), [Kubernetes](/docs/clouds/kubernetes/get-started/), and so on) in order to manage the individual resources.  As it operates, the engine updates the _state_ of your infrastructure with information about all resources that have been provisioned as well as any pending operations.

--- a/themes/default/content/docs/concepts/programming-model.md
+++ b/themes/default/content/docs/concepts/programming-model.md
@@ -1,7 +1,6 @@
 ---
 title: "Programming Model"
-aliases:
-- /docs/reference/programming-model/
+url: /docs/intro/concepts/programming-model
 block_external_search_index: true
 ---
 
@@ -58,4 +57,4 @@ block_external_search_index: true
 -->
 <meta http-equiv="refresh" content="4; url=/docs/concepts">
 
-This content has moved. Redirecting to [Architecture &amp; Concepts](/docs/concepts)...
+This content has moved. Redirecting to [Pulumi Concepts](/docs/concepts)....


### PR DESCRIPTION
This change removes an alias to a placeholder page that we still need in order to properly redirect client-side requests based on HTML anchors. We have a number of places still linking to this page, at this particular URL (`/docs/intro/concepts/programming-model`), so we need this page to continue to exist in order to handle those requests.