### PR TITLE
Pull shared content out of the GCP begin page

### DIFF
--- a/themes/default/content/docs/clouds/gcp/get-started/begin.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/begin.md
@@ -70,7 +70,19 @@ Pulumi requires cloud credentials to manage and provision resources. You must us
 
 In this guide, you will need an IAM user account with permissions that can create and populate a Cloud Storage bucket, such as those in the predefined Storage Admin (`roles/storage.admin`) or the Storage Legacy Bucket Owner (`roles/storage.legacyBucketOwner`) roles.
 
-{{% configure-gcp %}}
+When developing locally, we recommend that you install the [Google Cloud SDK](https://cloud.google.com/sdk/install) and then [authorize access with a user account](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account).
+
+If `gcloud` is not configured to interact with your Google Cloud project, set it with the `config` command using the project's ID:
+
+```bash
+gcloud config set project <YOUR_GCP_PROJECT_ID>
+```
+
+Next, Pulumi requires default application credentials to interact with your Google Cloud resources, so run `auth application-default login` command to obtain those credentials.
+
+```bash
+gcloud auth application-default login
+```
 
 For additional information on setting and using Google Cloud credentials, see [Google Cloud Setup](/registry/packages/gcp/installation-configuration/).
 


### PR DESCRIPTION
This change removes the use of a shortcode from the GCP getting-started guide because the shortcode's content doesn't quite work in this context. The change restores the content that belonged to the shortcode before this additional content (which is otherwise used only [in](https://github.com/pulumi/registry/blob/30b15aaa0aee99e8f734f252be1da57b5831b358/themes/default/content/registry/packages/gcp/installation-configuration.md?plain=1#L23) [the](https://github.com/pulumi/registry/blob/30b15aaa0aee99e8f734f252be1da57b5831b358/themes/default/content/registry/packages/gcp-global-cloudrun/installation-configuration.md?plain=1#L18) [Registry](https://github.com/pulumi/registry/blob/30b15aaa0aee99e8f734f252be1da57b5831b358/themes/default/content/registry/packages/google-native/installation-configuration.md?plain=1#L20)) was added.

Fixes https://github.com/pulumi/pulumi-hugo/issues/3094.

As a follow-up, we should move this shortcode to the Registry. This'll need to be done in two steps (first added there, then removed here) so as not to break the build.
