### PR TITLE
Don't send Sentry events for browsers we don't support

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -176,6 +176,17 @@
                 {{ if in "preview production" hugo.Environment }}
                     release: "{{ getenv "ASSET_BUNDLE_ID" }}",
                 {{ end }}
+
+                // Don't send Sentry events for browsers we don't support.
+                beforeSend(event) {
+                    const ua = event.request.headers["User-Agent"];
+
+                    if (ua && ua.match(/Linespider|Yeti/)) {
+                        return null;
+                    }
+
+                    return event;
+                }
             });
         });
     </script>


### PR DESCRIPTION
We've seen an uptick recently in Sentry errors originating from browsers that look like scrapers. This change adds a quick check to look at the user-agent string and bypass sending events to Sentry for browsers we know are problematic.