### PR TITLE
Add alias for secrets docs page

### DIFF
--- a/themes/default/content/docs/concepts/secrets.md
+++ b/themes/default/content/docs/concepts/secrets.md
@@ -9,6 +9,7 @@ menu:
     weight: 7
 aliases:
 - /docs/intro/concepts/secrets/
+- /secrets/
 ---
 
 All resource input and output values are recorded as [`state`](/docs/concepts/state), and are stored in the Pulumi Cloud, a file, or a pluggable provider that you choose. These raw values are usually just server names, configuration settings, etc. However, these values sometimes contain sensitive data, such as database passwords or service tokens. **Pulumi never sends authentication secrets or credentials to the Pulumi Cloud**.


### PR DESCRIPTION
## Description

This PR adds an alias for the secrets docs page for `/secrets/` as requested by @SaraDPH .

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
