### PR TITLE
Ease docs navigation experience by allowing ToC to be scrolled separately

### DIFF
--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -369,7 +369,6 @@ body.section-registry {
         .docs-table-of-contents {
             max-width: 700px;
             min-width: 0;
-            height: 90vh;
             display: flex;
 
             .table-of-contents {
@@ -471,7 +470,7 @@ body.section-registry {
                 margin-top: 38px;
                 padding: 16px 0 16px 0;
                 overflow-y: auto;
-                height: min-content;
+                height: 90vh;
                 position: sticky;
                 top: 94px;
                 display: block;

--- a/themes/default/theme/src/scss/docs/_docs-main.scss
+++ b/themes/default/theme/src/scss/docs/_docs-main.scss
@@ -369,6 +369,7 @@ body.section-registry {
         .docs-table-of-contents {
             max-width: 700px;
             min-width: 0;
+            height: 90vh;
             display: flex;
 
             .table-of-contents {


### PR DESCRIPTION
## Description

Small change to set height of ToC wrapper class to allow scrolling in _docs-main.scss

Currently navigating docs is a bit frustrating because your ToC can overflow offscreen as you scroll down long pages.

Ideally we'd make the ToC individually scrollable, remove/style the scrollbar for visual consistency, and also have it scroll to follow your position relative to the content. For now, this at least makes the ToC navigable again.

#### Before

![image](https://github.com/pulumi/pulumi-hugo/assets/789029/bbdd05b8-0826-4a28-a37c-7500dac417cb)

#### After

![image](https://github.com/pulumi/pulumi-hugo/assets/789029/75773cc5-442a-42d5-b398-a8c8079cdedc)

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.

Fixes #3132.
