### PR TITLE
Fix broken typescript example in dynamic-providers.md

### DIFF
--- a/themes/default/content/docs/concepts/resources/dynamic-providers.md
+++ b/themes/default/content/docs/concepts/resources/dynamic-providers.md
@@ -684,7 +684,7 @@ exports.Label = Label;
 
 ```typescript
 import * as pulumi from "@pulumi/pulumi";
-import * as Ocktokit from "@octokit/rest";
+import { Octokit } from "@octokit/rest";
 
 // Set this value before creating an instance to configure the authentication token to use for deployments
 let auth = "token invalid";
@@ -708,18 +708,30 @@ interface LabelInputs {
 
 const githubLabelProvider: pulumi.dynamic.ResourceProvider = {
     async create(inputs: LabelInputs) {
-        const ocktokit = new Ocktokit({auth});
-        const label = await ocktokit.issues.createLabel(inputs);
+        const ocktokit = new Octokit({auth});
+        const label = await ocktokit.issues.createLabel({
+            owner: inputs.owner,
+            repo: inputs.repo,
+            name: inputs.name,
+            color: inputs.color
+        });
         return { id: label.data.id.toString(), outs: label.data };
     },
-    async update(id, olds: LabelInputs, news: LabelInputs) {
-        const ocktokit = new Ocktokit({auth});
-        const label = await ocktokit.issues.updateLabel({ ...news, current_name: olds.name });
-        return { outs: label.data };
+    async update(id: string, olds: LabelInputs, news: LabelInputs) {
+        const ocktokit = new Octokit({auth});
+        const label = await ocktokit.issues.updateLabel({
+            owner: news.owner,
+            repo: news.repo,
+            current_name: olds.name,
+            name: news.name,
+            color: news.color
+        });
+        return {outs: label.data};
     },
-    async delete(id, props: LabelInputs) {
-        const ocktokit = new Ocktokit({auth});
-        await ocktokit.issues.deleteLabel(props);
+
+    async delete(id: string, props: LabelInputs) {
+        const ocktokit = new Octokit({auth});
+        await ocktokit.issues.deleteLabel({owner: props.owner, repo: props.repo, name: props.name});
     }
 }
 

--- a/themes/default/content/docs/concepts/resources/dynamic-providers.md
+++ b/themes/default/content/docs/concepts/resources/dynamic-providers.md
@@ -655,18 +655,18 @@ exports.setAuth = function(token) { auth = token; }
 
 const githubLabelProvider = {
     async create(inputs) {
-        const ocktokit = new Ocktokit({auth});
-        const label = await ocktokit.issues.createLabel(inputs);
+        const octokit = new Octokit({auth});
+        const label = await octokit.issues.createLabel(inputs);
         return { id: label.data.id.toString(), outs: label.data };
     },
     async update(id, olds, news) {
-        const ocktokit = new Ocktokit({auth});
-        const label = await ocktokit.issues.updateLabel({ ...news, current_name: olds.name });
+        const octokit = new Octokit({auth});
+        const label = await octokit.issues.updateLabel({ ...news, current_name: olds.name });
         return { outs: label.data };
     },
     async delete(id, props) {
-        const ocktokit = new Ocktokit({auth});
-        await ocktokit.issues.deleteLabel(props);
+        const octokit = new Octokit({auth});
+        await octokit.issues.deleteLabel(props);
     }
 }
 
@@ -708,8 +708,8 @@ interface LabelInputs {
 
 const githubLabelProvider: pulumi.dynamic.ResourceProvider = {
     async create(inputs: LabelInputs) {
-        const ocktokit = new Octokit({auth});
-        const label = await ocktokit.issues.createLabel({
+        const octokit = new Octokit({auth});
+        const label = await octokit.issues.createLabel({
             owner: inputs.owner,
             repo: inputs.repo,
             name: inputs.name,
@@ -718,8 +718,8 @@ const githubLabelProvider: pulumi.dynamic.ResourceProvider = {
         return { id: label.data.id.toString(), outs: label.data };
     },
     async update(id: string, olds: LabelInputs, news: LabelInputs) {
-        const ocktokit = new Octokit({auth});
-        const label = await ocktokit.issues.updateLabel({
+        const octokit = new Octokit({auth});
+        const label = await octokit.issues.updateLabel({
             owner: news.owner,
             repo: news.repo,
             current_name: olds.name,
@@ -730,8 +730,8 @@ const githubLabelProvider: pulumi.dynamic.ResourceProvider = {
     },
 
     async delete(id: string, props: LabelInputs) {
-        const ocktokit = new Octokit({auth});
-        await ocktokit.issues.deleteLabel({owner: props.owner, repo: props.repo, name: props.name});
+        const octokit = new Octokit({auth});
+        await octokit.issues.deleteLabel({owner: props.owner, repo: props.repo, name: props.name});
     }
 }
 


### PR DESCRIPTION
There was a change in the @octokit/rest package usage.

fixes:[[<link to issue>](https://github.com/pulumi/pulumi-hugo/issues/3120)](https://github.com/pulumi/pulumi-hugo/issues/3120)

## Description

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
