### PR TITLE
Add admin tokens to access tokens perms table

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
@@ -60,10 +60,12 @@ Both organization and team token activities produce audit log events which are a
 | Update team membership | | | | ✅ |
 | Grant stack access to team | | | | ✅ |
 | Remove stack access from team | | | | ✅ |
+| Create team token | ✅ | | | ✅ |
+| Delete team token | ✅ | | | ✅ |
 | Update member role | | | | ✅ |
 | List access tokens | | | | ✅ |
-| Create access token | | | | ✅ |
-| Delete access token | | | | ✅ |
+| Create access token | | | | |
+| Delete access token | | | | |
 | List webhooks | | | ✅ | ✅ |
 | Create webhook | | | ✅ | ✅ |
 | Get webhook | | | ✅ | ✅ |

--- a/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
@@ -60,8 +60,8 @@ Both organization and team token activities produce audit log events which are a
 | Update team membership | | | | ✅ |
 | Grant stack access to team | | | | ✅ |
 | Remove stack access from team | | | | ✅ |
-| Create team token | ✅ | | | ✅ |
-| Delete team token | ✅ | | | ✅ |
+| Create team token |  | | | ✅ |
+| Delete team token |  | | | ✅ |
 | Update member role | | | | ✅ |
 | List access tokens | | | | ✅ |
 | Create access token | | | | |

--- a/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
+++ b/themes/default/content/docs/pulumi-cloud/access-management/access-tokens.md
@@ -28,50 +28,50 @@ Personal access tokens map to the permissions of a user, organization access tok
 
 Both organization and team token activities produce audit log events which are accessible from the **Audit Logs** page. All audit log events surface the token’s unique name, and in the event of audit log export, the token’s UUID as well.
 
-| Action | Personal | Team | Organization |
-| - | - | - | - |
-| **Stacks** | **Personal** | **Team** | **Organization** |
-| List stacks | ✅ | ✅ | ✅ |
-| Get stack | ✅ | ✅ | ✅ |
-| Get stack state | ✅ | ✅ | ✅ |
-| Transfer stack | | | |
-| Delete stack | ✅ | ✅ | ✅ |
-| List webhooks | | ✅ | ✅ |
-| Create webhook | | ✅ | ✅ |
-| Get webhook | | ✅ | ✅ |
-| Ping webhook | | ✅ | ✅ |
-| List webhook deliveries | | ✅ | ✅ |
-| **Stack tags** | **Personal** | **Team** | **Organization** |
-| Get stack tags | ✅ | ✅ | ✅ |
-| Set stack tag | ✅ | ✅ | ✅ |
-| Delete stack tag | ✅ | ✅ | ✅ |
-| **Stack updates** | **Personal** | **Team** | **Organization** |
-| List stack updates | ✅ | ✅ | ✅ |
-| Get update status | ✅ | ✅ | ✅ |
-| List update events | ✅ | ✅ | ✅ |
-| List previews | ✅ | ✅ | ✅ |
-| **Organizations** | **Personal** | **Team** | **Organization** |
-| List users | | ✅ | ✅ |
-| Add user to organization | | | |
-| Remove user from organization | | | |
-| List teams | | ✅ | ✅ |
-| Create team | | | ✅ |
-| Delete team | | | ✅ |
-| Update team membership | | | |
-| Grant stack access to team | | | |
-| Remove stack access from team | | | |
-| Update member role | | | |
-| List access tokens | | | |
-| Create access token | | | |
-| Delete access token | | | |
-| List webhooks | | | ✅ |
-| Create webhook | | | ✅ |
-| Get webhook | | | ✅ |
-| Ping webhook | | | ✅ |
-| List webhooks deliveries | | | ✅ |
-| **Audit logs** | **Personal** | **Team** | **Organization** |
-| Get audit log events (JSON) | | | |
-| Export audit log events (CSV or CEF) | | | |
+| Action | Personal | Team | Organization | Admin |
+| - | - | - | - | - |
+| **Stacks** | **Personal** | **Team** | **Organization** | **Admin** |
+| List stacks | ✅ | ✅ | ✅ | ✅ |
+| Get stack | ✅ | ✅ | ✅ | ✅ |
+| Get stack state | ✅ | ✅ | ✅ |✅ |
+| Transfer stack | | | | ✅ |
+| Delete stack | ✅ | ✅ | ✅ | ✅ |
+| List webhooks | | ✅ | ✅ | ✅ |
+| Create webhook | | ✅ | ✅ | ✅ |
+| Get webhook | | ✅ | ✅ | ✅ |
+| Ping webhook | | ✅ | ✅ | ✅ |
+| List webhook deliveries | | ✅ | ✅ | ✅ |
+| **Stack tags** | **Personal** | **Team** | **Organization** | **Admin** |
+| Get stack tags | ✅ | ✅ | ✅ | ✅ |
+| Set stack tag | ✅ | ✅ | ✅ | ✅ |
+| Delete stack tag | ✅ | ✅ | ✅ | ✅ |
+| **Stack updates** | **Personal** | **Team** | **Organization** | **Admin** |
+| List stack updates | ✅ | ✅ | ✅ | ✅ |
+| Get update status | ✅ | ✅ | ✅ | ✅ |
+| List update events | ✅ | ✅ | ✅ | ✅ |
+| List previews | ✅ | ✅ | ✅ | ✅ |
+| **Organizations** | **Personal** | **Team** | **Organization** | **Admin** |
+| List users | | ✅ | ✅ | ✅ |
+| Add user to organization | | | | ✅ |
+| Remove user from organization | | | | ✅ |
+| List teams | | ✅ | ✅ | ✅ |
+| Create team | | | ✅ | ✅ |
+| Delete team | | | ✅ | ✅ |
+| Update team membership | | | | ✅ |
+| Grant stack access to team | | | | ✅ |
+| Remove stack access from team | | | | ✅ |
+| Update member role | | | | ✅ |
+| List access tokens | | | | ✅ |
+| Create access token | | | | ✅ |
+| Delete access token | | | | ✅ |
+| List webhooks | | | ✅ | ✅ |
+| Create webhook | | | ✅ | ✅ |
+| Get webhook | | | ✅ | ✅ |
+| Ping webhook | | | ✅ | ✅ |
+| List webhooks deliveries | | | ✅ | ✅ |
+| **Audit logs** | **Personal** | **Team** | **Organization** | **Admin** |
+| Get audit log events (JSON) | | | | ✅ |
+| Export audit log events (CSV or CEF) | | | | ✅ |
 
 ## Personal access tokens
 


### PR DESCRIPTION
## Description
Add admin tokens to the tokens permissions table to help surface more detail on the permissions available to these tokens.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
