### PR TITLE
Update providers.md to add clarity on AWS vs Azure Example

### DIFF
--- a/themes/default/content/docs/concepts/resources/providers.md
+++ b/themes/default/content/docs/concepts/resources/providers.md
@@ -113,6 +113,10 @@ It creates a single EC2 instance in the us-west-2 region.
 
 While the default provider configuration may be appropriate for the majority of Pulumi programs, some programs may have special requirements. One example is a program that needs to deploy to multiple AWS regions simultaneously. Another example is a program that needs to deploy to a Kubernetes cluster, created earlier in the program, which requires explicitly creating, configuring, and referencing providers. This is typically done by instantiating the relevant package’s `Provider` type and passing in the options for each `Resource` that needs to use it. For example, the following configuration and program creates an ACM certificate in the `us-east-1` region and a load balancer listener in the `us-west-2` region.
 
+{{% notes type="info" %}}
+**Note:** This example for AWS does not apply to Azure which provides access to all regions regardless of the default region defined in your Pulumi program. That means you don't need to explicitly create and configure providers for each region when working with Azure. You can simply specify the region in the resource definition itself.
+{{% /notes %}}
+
 {{< chooser language "javascript,typescript,python,go,csharp,java" >}}
 
 {{% choosable language javascript %}}


### PR DESCRIPTION
## Description
Adds more clarification to the example in our explicit provider configuration section, to not the example does not apply to azure, which has cause some confusion in our community.

fixes :[#2614]

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
