### PR TITLE
Fix GCP getting-started tutorial

### DIFF
--- a/themes/default/content/docs/clouds/gcp/get-started/deploy-stack.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/deploy-stack.md
@@ -23,42 +23,45 @@ $ pulumi up
 This command evaluates your program and determines the resource updates to make. First, a preview is shown that outlines the changes that will be made when you run the update:
 
 ```
-Previewing update (dev):
+Previewing update (dev)
+
      Type                   Name            Plan
  +   pulumi:pulumi:Stack    quickstart-dev  create
  +   └─ gcp:storage:Bucket  my-bucket       create
+
+Outputs:
+    bucketName: output<string>
 
 Resources:
     + 2 to create
 
 Do you want to perform this update?  [Use arrows to move, enter to select, type to filter]
-  yes
-> no
+> yes
+  no
   details
 ```
 
 Once the preview has finished, you are given three options to choose from. Choosing `details` will show you a rich diff of the changes to be made. Choosing `yes` will create your new storage bucket in Google Cloud. Choosing `no` will return you to the user prompt without performing the update operation.
 
 ```
-Do you want to perform this update? yes
-Updating (dev):
+Updating (dev)
 
      Type                   Name            Status
-     pulumi:pulumi:Stack    quickstart-dev  created
- +   └─ gcp:storage:Bucket  my-bucket       created
+ +   pulumi:pulumi:Stack    quickstart-dev  created (3s)
+ +   └─ gcp:storage:Bucket  my-bucket       created (1s)
 
 Outputs:
-  + bucketName: "gs://my-bucket-62f8bc7"
+    bucketName: "gs://my-bucket-daa12be"
 
 Resources:
     + 2 created
 
-Duration: 3s
+Duration: 4s
 ```
 
 Remember the output you defined in the previous step? That [stack output](/docs/concepts/stack#outputs) can be seen in the `Outputs:` section of your update. You can access your outputs from the CLI by running the `pulumi stack output [property-name]` command. For example you can print the name of your bucket with the following command:
 
-{{< chooser language "typescript,python,go,csharp,java,yaml" / >}}
+{{< chooser language "typescript,javascript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language javascript %}}
 

--- a/themes/default/content/docs/clouds/gcp/get-started/destroy-stack.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/destroy-stack.md
@@ -14,58 +14,59 @@ aliases:
 - /docs/get-started/gcp/destroy-stack/
 ---
 
-Now that you've seen how to deploy changes to our program, let's clean up and tear down the resources that are part of your stack.
+Now that you've seen how to deploy and manage cloud resources with Pulumi, let's clean up by tearing down all of the resources that belong to this stack.
 
-To destroy resources, run the following:
+To do so, run the following:
 
 ```bash
 $ pulumi destroy
 ```
 
-You'll be prompted to make sure you really want to delete these resources. This can take a minute or two; Pulumi waits until all resources are shut down and deleted before it considers the destroy operation complete.
+Again you'll be presented with a preview of the changes to be made. Choose `yes`. The destroy operation may take few moments, as Pulumi waits for all resources are to be deleted before considering the operation complete:
 
 ```
-Previewing destroy (dev):
+Previewing destroy (dev)
 
- -   pulumi:pulumi:Stack              quickstart-dev         delete
- -   ├─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   delete
- -   ├─ gcp:storage:BucketObject      index.html             delete
- -   └─ gcp:storage:Bucket            my-bucket              delete
+     Type                             Name               Plan
+ -   pulumi:pulumi:Stack              quickstart-dev     delete
+ -   ├─ gcp:storage:BucketIAMBinding  my-bucket-binding  delete
+ -   ├─ gcp:storage:BucketObject      index.html         delete
+ -   └─ gcp:storage:Bucket            my-bucket          delete
 
 Outputs:
-  - bucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
-  - bucketName    : "gs://my-bucket-0167228"
+  - bucketEndpoint: "http://storage.googleapis.com/my-bucket-daa12be/index.html-a52debd"
+  - bucketName    : "gs://my-bucket-daa12be"
 
 Resources:
     - 4 to delete
 
 Do you want to perform this destroy? yes
-Destroying (dev):
+Destroying (dev)
 
- -   pulumi:pulumi:Stack              quickstart-dev         deleted
- -   ├─ gcp:storage:BucketIAMBinding  my-bucket-IAMBinding   deleted
- -   ├─ gcp:storage:BucketObject      index.html             deleted
- -   └─ gcp:storage:Bucket            my-bucket              deleted
+     Type                             Name               Status
+ -   pulumi:pulumi:Stack              quickstart-dev     deleted
+ -   ├─ gcp:storage:BucketIAMBinding  my-bucket-binding  deleted (6s)
+ -   ├─ gcp:storage:BucketObject      index.html         deleted (0.78s)
+ -   └─ gcp:storage:Bucket            my-bucket          deleted (1s)
 
 Outputs:
-  - bucketEndpoint: "http://storage.googleapis.com/my-bucket-0167228/index.html-50b2ce9"
-  - bucketName    : "gs://my-bucket-0167228"
+  - bucketEndpoint: "http://storage.googleapis.com/my-bucket-daa12be/index.html-a52debd"
+  - bucketName    : "gs://my-bucket-daa12be"
 
 Resources:
     - 4 deleted
 
-Duration: 7s
+Duration: 9s
 ```
 
-> To delete the stack itself, run [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm).
-Note that this removes the stack entirely from the Pulumi Cloud, along with all of its update history.
+Optionally, to delete the stack itself, you can also run [`pulumi stack rm`](/docs/cli/commands/pulumi_stack_rm). Doing so removes the stack entirely from the Pulumi Cloud, along with all of its update history.
 
 Congratulations! You've successfully provisioned some cloud resources using Pulumi. By completing this guide you have successfully:
 
 - Created a Pulumi new project.
 - Provisioned a new storage bucket.
 - Added an `index.html` file to your bucket.
-- Served the `index.html` as a static website.
+- Served the file as a static website.
 - Destroyed the resources you've provisioned.
 
 On the next page, we have a collection of examples and tutorials that you can deploy as they are or use them as a foundation for your own applications and infrastructure projects.

--- a/themes/default/content/docs/clouds/gcp/get-started/modify-program.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/modify-program.md
@@ -60,15 +60,15 @@ EOT
 
 {{% /choosable %}}
 
-Now that you have your new `index.html` with some content, open your program file and modify it to add the contents of your `index.html` file to your storage bucket.
+Now that you have an `index.html` file with some content, open {{< langfile >}} and modify it to add that file to your storage bucket.
 
-To accomplish this, you will use Pulumi's `FileAsset` class to assign the content of the file to a new  `BucketObject`.
+For this, you'll use Pulumi's `FileAsset` class to assign the content of the file to a new `BucketObject`.
 
 {{< chooser language "javascript,typescript,python,go,csharp,java,yaml" / >}}
 
 {{% choosable language javascript %}}
 
-In `index.js`, create the `BucketObject` right after creating the bucket itself.
+In `index.js`, create the `BucketObject` right after creating the bucket itself:
 
 ```javascript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
@@ -81,7 +81,7 @@ const bucketObject = new gcp.storage.BucketObject("index.html", {
 
 {{% choosable language typescript %}}
 
-In `index.ts`, create the `BucketObject` right after creating the bucket itself.
+In `index.ts`, create the `BucketObject` right after creating the bucket itself:
 
 ```typescript
 const bucketObject = new gcp.storage.BucketObject("index.html", {
@@ -97,10 +97,8 @@ const bucketObject = new gcp.storage.BucketObject("index.html", {
 In `__main__.py`, create a new bucket object by adding the following right after creating the bucket itself:
 
 ```python
-bucketObject = storage.BucketObject(
-    'index.html',
-    bucket=bucket.name,
-    source=pulumi.FileAsset('index.html')
+bucket_object = storage.BucketObject(
+    "index.html", bucket=bucket.name, source=pulumi.FileAsset("index.html")
 )
 ```
 
@@ -108,10 +106,10 @@ bucketObject = storage.BucketObject(
 
 {{% choosable language go %}}
 
-In `main.go`, create the `BucketObject` right after creating the bucket itself.
+In `main.go`, create the `BucketObject` right after creating the bucket itself:
 
 ```go
-bucketObject, err := storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
+_, err = storage.NewBucketObject(ctx, "index.html", &storage.BucketObjectArgs{
     Bucket: bucket.Name,
     Source: pulumi.NewFileAsset("index.html"),
 })
@@ -124,7 +122,7 @@ if err != nil {
 
 {{% choosable language csharp %}}
 
-In `Program.cs`, create the `BucketObject` right after creating the bucket itself.
+In `Program.cs`, create the `BucketObject` right after creating the bucket itself:
 
 ```csharp
 var bucketObject = new BucketObject("index.html", new BucketObjectArgs
@@ -138,18 +136,20 @@ var bucketObject = new BucketObject("index.html", new BucketObjectArgs
 
 {{% choosable language java %}}
 
-In {{< langfile >}}, import the `FileAsset`, `BucketObject`, and `BucketObjectArgs` classes, then create the `BucketObject` right after creating the bucket itself.
+In {{< langfile >}}, import the following additional classes, then create the `BucketObject` right after creating the bucket itself:
 
 ```java
 // ...
 import com.pulumi.asset.FileAsset;
+import com.pulumi.gcp.storage.BucketIAMBinding;
+import com.pulumi.gcp.storage.BucketIAMBindingArgs;
 import com.pulumi.gcp.storage.BucketObject;
 import com.pulumi.gcp.storage.BucketObjectArgs;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            // var bucket = ...
+            // ...
 
             // Create a Bucket object
             var bucketObject = new BucketObject("index.html", BucketObjectArgs.builder()
@@ -158,7 +158,7 @@ public class App {
                 .build()
             );
 
-            // ctx.export(...
+            // ...
         });
     }
 }
@@ -173,17 +173,115 @@ In {{< langfile >}}, create the `BucketObject` right below the bucket itself.
 ```yaml
 resources:
   # ...
-  index-object:
+  index-html:
     type: gcp:storage:BucketObject
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::FileAsset: ./index.html
+        fn::fileAsset: ./index.html
 ```
 
 {{% /choosable %}}
 
-Notice how you provide the bucket you created earlier as an input to your new `BucketObject`. This is so Pulumi knows what storage bucket the object should live in.
+Notice how you provide the name of the bucket you created earlier as an input for the `BucketObject`. This tells Pulumi which bucket the object should live in.
+
+Below the `BucketObject`, add an IAM binding allowing the contents of the bucket to be viewed anonymously over the Internet:
+
+{{% choosable language typescript %}}
+
+```typescript
+const bucketBinding = new gcp.storage.BucketIAMBinding("my-bucket-binding", {
+    bucket: bucket.name,
+    role: "roles/storage.objectViewer",
+    members: ["allUsers"]
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language javascript %}}
+
+```javascript
+const bucketBinding = new gcp.storage.BucketIAMBinding("my-bucket-binding", {
+    bucket: bucket.name,
+    role: "roles/storage.objectViewer",
+    members: ["allUsers"]
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language python %}}
+
+```python
+bucket_iam_binding = storage.BucketIAMBinding(
+    "my-bucket-binding",
+    bucket=bucket.name,
+    role="roles/storage.objectViewer",
+    members=["allUsers"],
+)
+```
+
+{{% /choosable %}}
+
+{{% choosable language go %}}
+
+```go
+_, err = storage.NewBucketIAMBinding(ctx, "my-bucket-binding", &storage.BucketIAMBindingArgs{
+    Bucket: bucket.Name,
+    Role:   pulumi.String("roles/storage.objectViewer"),
+    Members: pulumi.StringArray{
+        pulumi.String("allUsers"),
+    },
+})
+if err != nil {
+    return err
+}
+```
+
+{{% /choosable %}}
+
+{{% choosable language csharp %}}
+
+```csharp
+var bucketBinding = new BucketIAMBinding("my-bucket-binding", new BucketIAMBindingArgs
+{
+    Bucket = bucket.Name,
+    Role = "roles/storage.objectViewer",
+    Members = new[]
+    {
+        "allUsers",
+    },
+});
+```
+
+{{% /choosable %}}
+
+{{% choosable language java %}}
+
+```java
+var bucketBinding = new BucketIAMBinding("my-bucket-binding", BucketIAMBindingArgs.builder()
+    .bucket(bucket.name())
+    .role("roles/storage.objectViewer")
+    .members("allUsers")
+    .build());
+```
+
+{{% /choosable %}}
+
+{{% choosable language yaml %}}
+
+```yaml
+my-bucket-binding:
+  type: gcp:storage:BucketIAMBinding
+  properties:
+    bucket: ${my-bucket.name}
+    role: "roles/storage.objectViewer"
+    members:
+      - allUsers
+```
+
+{{% /choosable %}}
 
 Next, you'll deploy your changes.
 

--- a/themes/default/content/docs/clouds/gcp/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/review-project.md
@@ -55,7 +55,9 @@ const pulumi = require("@pulumi/pulumi");
 const gcp = require("@pulumi/gcp");
 
 // Create a Google Cloud resource (Storage Bucket)
-const bucket = new gcp.storage.Bucket("my-bucket");
+const bucket = new gcp.storage.Bucket("my-bucket", {
+    location: "US"
+});
 
 // Export the DNS name of the bucket
 exports.bucketName = bucket.url;
@@ -70,7 +72,9 @@ import * as pulumi from "@pulumi/pulumi";
 import * as gcp from "@pulumi/gcp";
 
 // Create a Google Cloud resource (Storage Bucket)
-const bucket = new gcp.storage.Bucket("my-bucket");
+const bucket = new gcp.storage.Bucket("my-bucket", {
+    location: "US",
+});
 
 // Export the DNS name of the bucket
 export const bucketName = bucket.url;
@@ -85,10 +89,10 @@ import pulumi
 from pulumi_gcp import storage
 
 # Create a Google Cloud resource (Storage Bucket)
-bucket = storage.Bucket('my-bucket')
+bucket = storage.Bucket("my-bucket", location="US")
 
 # Export the DNS name of the bucket
-pulumi.export('bucket_name',  bucket.url)
+pulumi.export("bucket_name", bucket.url)
 ```
 
 {{% /choosable %}}
@@ -99,24 +103,24 @@ pulumi.export('bucket_name',  bucket.url)
 package main
 
 import (
-    "github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
-    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
-    pulumi.Run(func(ctx *pulumi.Context) error {
-        // Create a Google Cloud resource (Storage Bucket)
-	bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
-	    Location: pulumi.String("US"),
-	})
-	if err != nil {
-	    return err
-	}
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		// Create a Google Cloud resource (Storage Bucket)
+		bucket, err := storage.NewBucket(ctx, "my-bucket", &storage.BucketArgs{
+			Location: pulumi.String("US"),
+		})
+		if err != nil {
+			return err
+		}
 
-        // Export the DNS name of the bucket
-        ctx.Export("bucketName", bucket.Url)
-        return nil
-    })
+		// Export the DNS name of the bucket
+		ctx.Export("bucketName", bucket.Url)
+		return nil
+	})
 }
 ```
 
@@ -131,19 +135,18 @@ using System.Collections.Generic;
 
 return await Deployment.RunAsync(() =>
 {
-    // Create a Google Cloud resource (Storage Bucket)
+    // Create a Google Cloud resource (Storage Bucket).
     var bucket = new Bucket("my-bucket", new BucketArgs
     {
-        Location = "US"
+        Location = "US",
     });
 
-    // Export the DNS name of the bucket
+    // Export the DNS name of the bucket.
     return new Dictionary<string, object?>
     {
-        ["bucketName"] = bucket.Url
+        ["bucketName"] = bucket.Url,
     };
 });
-
 ```
 
 {{% /choosable %}}
@@ -161,10 +164,12 @@ import com.pulumi.gcp.storage.BucketArgs;
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
-            var bucket = new Bucket("my-bucket",
-                                    BucketArgs.builder()
-                                    .location("US")
-                                    .build());
+            // Create a Google Cloud resource (Storage Bucket)
+            var bucket = new Bucket("my-bucket", BucketArgs.builder()
+                .location("US")
+                .build());
+
+            // Export the DNS name of the bucket
             ctx.export("bucketName", bucket.url());
         });
     }
@@ -215,7 +220,7 @@ export const bucketName = bucket.url;
 {{% choosable language python %}}
 
 ```python
-pulumi.export('bucket_name',  bucket.url)
+pulumi.export("bucket_name", bucket.url)
 ```
 
 {{% /choosable %}}
@@ -233,7 +238,7 @@ ctx.Export("bucketName", bucket.Url)
 ```csharp
 return new Dictionary<string, object?>
 {
-    ["bucketName"] = bucket.Url
+    ["bucketName"] = bucket.Url,
 };
 ```
 


### PR DESCRIPTION
This change fixes a number of issues with the GCP getting-started tutorial. There are a lot of little changes here, so I apologize for the noise. The primary changes are these:

* Adds required `location` properties to bucket declarations. These exist in the `gcp-*` templates, but were missing from the code samples. Without these, initial deployments would fail.

* Fixes a Go variable name in the modify-program step. Without this, the Go program would not compile.

* Fixes a warning about using a deprecated syntax for the `FileAsset` in YAML.

* Adds the `BucketIAMBinding` declaration earlier on in the program, removing the need for an additional `BucketIAMMember`. This was the main issue, and it broke in a few ways: 

    * First, in Go, the `bucketMember` variable was unused, leading to a compile error.
    * Second, for all languages, the update in the deploy-changes step would fail on creating the `BucketIAMMember` and on updating the `BucketObject`: 
      ```
      gcp:storage:BucketIAMMember (bucketIAMMember):
        error: expected non-nil error with nil state during Create of urn:pulumi:dev::quickstart::gcp:storage/bucketIAMMember:BucketIAMMember::bucketIAMMember

      gcp:storage:BucketObject (index.html):
        error: 1 error occurred:
            * Error when reading or editing Storage Bucket Object "index.html-0514f1d": googleapi: Error 403: christian@pulumi.com does not have storage.objects.get access to the Google Cloud Storage object. Permission 'storage.objects.get' denied on resource (or it may not exist)., forbidden
      ```

    * Third, the destroy step would also fail (also for all languages) on the bucket being non-empty, leaving the program wedged and requiring that the file be deleted out of band before the destroy could be completed:
        ```
        gcp:storage:Bucket (my-bucket):
          error: deleting urn:pulumi:dev::quickstart::gcp:storage/bucket:Bucket::my-bucket: 1 error occurred:
              * Error trying to delete bucket my-bucket-544ee90 containing objects without `force_destroy` set to true
        ```

I'll admit I don't fully understand why the provider wasn't able to reconcile all of these changes in one step, but I suspect it has something to do with the combination of changes (to overall bucket permissions, a bucket object property that  triggers a replacement, the addition of a `BucketIAMMember` resource, etc.) and some sort of competition between them -- probably involving the replacement. I'll investigate a bit more for my own understanding (and file a bug on the provider if necessary), but regardless, removing the `BucketIAMMember` resource (which is not actually required here) and applying the bucket permissions earlier on in the workflow simplifies things overall and works reliably now across all languages.

As part of this, I've also [added some automation for this tutorial to the getting-started repo](https://github.com/pulumi/getting-started/pull/3) so we can test this code daily along with the code for the AWS version. The code changes here were all sourced from that repo.

Lastly I went ahead and updated all of the output snippets as well (as they'd drifted a bit) and tightened up some of the language as I walked through these changes myself.

Fixes https://github.com/pulumi/docs/issues/9595.