### PR TITLE
change cta getting started link

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -483,7 +483,7 @@
                     </ul>
 
                     <div class="cta-container">
-                        <a class="header-btn-primary" data-track="header-get-started" href="https://app.pulumi.com/signup" title="Sign up for Pulumi Cloud"> Get Started </a>
+                        <a class="header-btn-primary" data-track="header-get-started" href="/docs/get-started" title="Sign up for Pulumi Cloud"> Get Started </a>
                     </div>
                 </div>
             </header>


### PR DESCRIPTION
## Description

fixes: https://github.com/pulumi/pulumi-hugo/issues/3236

change getting started CTA to link to getting started instead of console in the header

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
