### PR TITLE
fix: missing fmt in the go program and improve the "Pulumi Fundamentals" tutorial

### DIFF
--- a/themes/default/content/learn/pulumi-fundamentals/configure-and-provision/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/configure-and-provision/index.md
@@ -382,7 +382,16 @@ pulumi config set mongoPort 27017
 This set of commands creates a file in your directory called `Pulumi.dev.yaml`
 to store the configuration for this stack.
 
-Now, try and rerun your Pulumi program.
+The content of the file should be like this:
+
+```yaml
+config:
+  my_first_app:backendPort: "3000"
+  my_first_app:frontendPort: "3001"
+  my_first_app:mongoPort: "27017"
+```
+
+Now, try and rerun your Pulumi program with `pulumi up` command.
 
 Your Pulumi program should now run, but you're not actually using these newly
 configured ports just yet! That's because we don't have any container resources

--- a/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
@@ -213,8 +213,10 @@ backend = docker.RemoteImage(f"{backend_image_name}_image",
 package main
 
 import (
-    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-    "github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
+	"fmt"
+
+	"github.com/pulumi/pulumi-docker/sdk/v3/go/docker"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func main() {
@@ -433,6 +435,8 @@ mongo_image = docker.RemoteImage("mongo_image",
 {{% /choosable %}}
 
 {{% choosable language go %}}
+
+Add this code at the bottom of your program, just before the last return nil statement:
 
 ```go
 // Pull the frontend image

--- a/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
+++ b/themes/default/content/learn/pulumi-fundamentals/create-docker-images/index.md
@@ -436,7 +436,7 @@ mongo_image = docker.RemoteImage("mongo_image",
 
 {{% choosable language go %}}
 
-Add this code at the bottom of your program, just before the last return nil statement:
+Add this code at the bottom of your program, just before the last `return nil` statement:
 
 ```go
 // Pull the frontend image


### PR DESCRIPTION
## Description

I fixed a missing "fmt" import in the go program, without i the tutorial is not working.
I have also improved the tutorial with more information to guide the user.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] I have manually confirmed that all new links work.
