### PR TITLE
Remove erroneous reference to Python 3.7

### DIFF
--- a/themes/default/layouts/shortcodes/install-python.html
+++ b/themes/default/layouts/shortcodes/install-python.html
@@ -1,6 +1,6 @@
 <p class="mt-4">
     Install
-    <a href="https://www.python.org/downloads/" target="_blank" rel="noopener">Python version 3.7 or later</a>. To reduce potential issues with setting up your Python environment
+    <a href="https://www.python.org/downloads/" target="_blank" rel="noopener">Python</a>. To reduce potential issues with setting up your Python environment
     on Windows or macOS, you should install Python through the official Python installer.
 </p>
 


### PR DESCRIPTION
## Description

We don't support Python 3.7 (it's end of life), but the install instructions still referred to it.

Rather than having to keep coming back and updating this number I've just removed the version text entirely, the link to the python downloads page clearly shows which versions are considers "active".

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
