### PR TITLE
Updated "Get Started" verbiage

### DIFF
--- a/themes/default/content/docs/clouds/aws/guides/_index.md
+++ b/themes/default/content/docs/clouds/aws/guides/_index.md
@@ -339,7 +339,7 @@ Watch this video to dive into an Amazon ECS and Fargate code example that concep
 ## Getting Started
 
 To get started with Pulumi Crosswalk for AWS, [download and install Pulumi](/docs/install/), and [configure it to work with your AWS account](/registry/packages/aws/installation-configuration/). Afterwards,
-[try the Getting Started tutorial](/registry/packages/aws/how-to-guides/ecs-fargate/) or select one of the
+[try the tutorial for Running Containers on ECS Fargate](/registry/packages/aws/how-to-guides/ecs-fargate/) or select one of the
 relevant User Guides to get started:
 
 ### Containers


### PR DESCRIPTION
## Description
On the Crosswalk for AWS Guides page, in the [Getting Started](https://www.pulumi.com/docs/clouds/aws/guides/#getting-started) section, the [try the Getting Started tutorial](https://www.pulumi.com/registry/packages/aws/how-to-guides/ecs-fargate/) part links to a How-To guide for ECS Fargate.

I was expecting to be sent to the equivalent of one of "Get Started" series (ex: [Get started with Pulumi & AWS](https://www.pulumi.com/docs/clouds/aws/get-started/)). I initially thought that I was redirected to an incorrect page altogether, but this How-To has a focus on deploying using Pulumi Crosswalk for AWS so I believe this was intentional.

This PR changes the verbiage so that the call to action is less confusing.

Fixes [#9650](https://github.com/pulumi/docs/issues/9650)

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
