### PR TITLE
Updated Python code snippet to resolve Output discrepancy

### DIFF
--- a/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
@@ -30,7 +30,7 @@ Previewing update (dev):
  +   └─ kubernetes:core:Service  nginx           create
 
  Outputs:
-  + ip  : "Value pending deployment"
+  + ip  : "output<string>"
   - name: "nginx-xw231xdt"
 
 Resources:

--- a/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
@@ -30,7 +30,7 @@ Previewing update (dev):
  +   └─ kubernetes:core:Service  nginx           create
 
  Outputs:
-  + ip  : output<string>
+  + ip  : "Value pending deployment"
   - name: "nginx-xw231xdt"
 
 Resources:
@@ -54,7 +54,7 @@ Updating (dev):
  +   └─ kubernetes:core:Service  nginx           created
 
 Outputs:
-  + ip  : "10.100.249.54"
+  + ip  : "a88e9d6d9c86d40a5b0effe1431e9d0c-123456789.eu-central-1.elb.amazonaws.com"
   - name: "nginx-xw231xdt"
 
 Resources:

--- a/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
@@ -30,7 +30,7 @@ Previewing update (dev):
  +   └─ kubernetes:core:Service  nginx           create
 
  Outputs:
-  + ip  : "output<string>"
+  + ip  : output<string>
   - name: "nginx-xw231xdt"
 
 Resources:

--- a/themes/default/content/docs/clouds/kubernetes/get-started/modify-program.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/modify-program.md
@@ -153,8 +153,8 @@ result = None
 if is_minikube:
     result = frontend.spec.apply(lambda v: v["cluster_ip"] if "cluster_ip" in v else None)
 else:
-    ingress = frontend.status.load_balancer.apply(lambda v: v["ingress"][0] if "ingress" in v else "Value pending deployment")
-    result = ingress.apply(lambda v: v["ip"] if v and "ip" in v else (v["hostname"] if v and "hostname" in v else "Value pending deployment"))
+    ingress = frontend.status.load_balancer.apply(lambda v: v["ingress"][0] if "ingress" in v else "output<string>")
+    result = ingress.apply(lambda v: v["ip"] if v and "ip" in v else (v["hostname"] if v and "hostname" in v else "output<string>"))
 
 pulumi.export("ip", result)
 ```

--- a/themes/default/content/docs/clouds/kubernetes/get-started/modify-program.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/modify-program.md
@@ -153,9 +153,8 @@ result = None
 if is_minikube:
     result = frontend.spec.apply(lambda v: v["cluster_ip"] if "cluster_ip" in v else None)
 else:
-    ingress = frontend.status.apply(lambda v: v["load_balancer"]["ingress"][0] if "load_balancer" in v else None)
-    if ingress is not None:
-        result = ingress.apply(lambda v: v["ip"] if "ip" in v else v["hostname"])
+    ingress = frontend.status.load_balancer.apply(lambda v: v["ingress"][0] if "ingress" in v else "Value pending deployment")
+    result = ingress.apply(lambda v: v["ip"] if v and "ip" in v else (v["hostname"] if v and "hostname" in v else "Value pending deployment"))
 
 pulumi.export("ip", result)
 ```


### PR DESCRIPTION
## Description

The [Kubernetes Getting Started guide](https://www.pulumi.com/docs/clouds/kubernetes/get-started/deploy-changes/) is not showing the updated output in the preview as expected when following the Python code.

This PR resolves this discrepancy by updating the code in the corresponding `else` statement to better accommodate for the asynchronous nature of Pulumi Outputs and to also provide a value to `result` which was previously being populated with `None`. This `None` value is what was preventing the new output from being shown in the preview.

Related to #1553 

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
