### PR TITLE
Changes to launch blogs

### DIFF
--- a/themes/default/content/blog/introducing-azure-native-v2/index.md
+++ b/themes/default/content/blog/introducing-azure-native-v2/index.md
@@ -154,6 +154,7 @@ The Pulumi Azure Native Provider 2.0 is available today for Pulumi programs usin
 Try out the Pulumi Azure Native Provider 2.0 today and take the next step in your journey with infrastructure as code on Microsoft Azure!
 
 ## Getting Started
+
 Try Infrastructure as Code on Azure by following this quick [getting started guide](/docs/clouds/azure/get-started/).
 
 [Join](/resources/azure-github-workshop/) Pulumi, Azure, and GitHub on Tuesday, September 19, 2023 for a [live workshop](/resources/azure-github-workshop/) on getting started with infrastructure as code on azure. You'll learn how to use the Azure Native Provider and set up an automated deployment workflow through GitHub.

--- a/themes/default/content/blog/introducing-azure-native-v2/index.md
+++ b/themes/default/content/blog/introducing-azure-native-v2/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure Native 2.0 for Infrastructure as Code on Azure"
+title: "Azure Native Provider 2.0: Streamlined, Expanded, and More Powerful than Ever"
 allow_long_title: true
 
 date: 2023-06-14T14:00:00-04:00

--- a/themes/default/content/blog/introducing-azure-native-v2/index.md
+++ b/themes/default/content/blog/introducing-azure-native-v2/index.md
@@ -1,5 +1,6 @@
 ---
-title: "Introducing Azure Native 2.0"
+title: "Azure Native 2.0 for Infrastructure as Code on Azure"
+allow_long_title: true
 
 date: 2023-06-14T14:00:00-04:00
 
@@ -25,6 +26,10 @@ We are thrilled to announce the [release](https://github.com/pulumi/pulumi-azure
 <!--more-->
 
 At Pulumi, we understand the importance of keeping up with the ever-evolving cloud landscape. The Pulumi Azure Native Provider 2.0 represents our commitment to providing you with the best tools to harness the full power of Microsoft Azure. With automatic generation from Azure API specs, we are able to provide you with same-day access to the entire [Azure API surface](https://docs.microsoft.com/en-us/rest/api/azure/) including all available properties. Let's dive into some of the key enhancements in this release!
+
+{{% notes type="info" %}}
+Join Pulumi, Azure, and GitHub on Tuesday, September 19, 2023 for a live workshop on [getting started with infrastructure as code on azure](/resources/azure-github-workshop/). You'll learn how to use the Azure Native Provider and set up an automated deployment workflow through GitHub.
+{{% /notes %}}
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/XfBTjYhb0G4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -147,3 +152,8 @@ While you can immediately start leveraging the improved performance, you may nee
 The Pulumi Azure Native Provider 2.0 is available today for Pulumi programs using TypeScript, Python, .NET, and Go. To learn more about the Pulumi Azure Native Provider 2.0 and explore its capabilities, check out our [updated documentation](https://www.pulumi.com/registry/packages/azure-native/) and resources. We value your feedback and encourage you to reach out in community slack or [open an issue](https://github.com/pulumi/pulumi-azure-native) for any questions or suggestions.
 
 Try out the Pulumi Azure Native Provider 2.0 today and take the next step in your journey with infrastructure as code on Microsoft Azure!
+
+## Getting Started
+Try Infrastructure as Code on Azure by following this quick [getting started guide](/docs/clouds/azure/get-started/).
+
+[Join](/resources/azure-github-workshop/) Pulumi, Azure, and GitHub on Tuesday, September 19, 2023 for a [live workshop](/resources/azure-github-workshop/) on getting started with infrastructure as code on azure. You'll learn how to use the Azure Native Provider and set up an automated deployment workflow through GitHub.

--- a/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
+++ b/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
@@ -20,7 +20,7 @@ tags:
 
 Since the very earliest days of the Pulumi project, Kubernetes has been a core part of the Pulumi platform.  The initial Pulumi Kubernetes provider supported the entire API surface area of the Kubernetes platform, derived directly and automatically from the Kubernetes OpenAPI specifications, and available to all of Pulumi's familiar programming languages.  Since then, we have offered day one support for every new Kubernetes version, added support for Helm, YAML, Kustomize and CRDs, added tools for converting to Pulumi (kube2pulumi and crd2pulumi) and delivered the Pulumi Kubernetes Operator.  During that same time, Kubernetes usage has continued to expand within the ecosystem and among Pulumi users, with the Kubernetes provider growing from the fourth most used to the second most used provider on the platform.
 
-Today, we are excited to release the next major version of our Kubernetes provider - [Pulumi Kubernetes 4.0](/registry/packages/kubernetes/).
+We are excited to release the next major version of our Kubernetes provider - [Pulumi Kubernetes 4.0](/registry/packages/kubernetes/).
 
 <!--more-->
 {{% notes type="info" %}}

--- a/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
+++ b/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
@@ -226,5 +226,4 @@ For users migrating to 4.0, check out the [v4 Provider Migration Guide](https://
 
 Try Infrastructure as Code for Kubernetes by following this quick [getting started guide](/docs/clouds/kubernetes/get-started/).
 
-Join us for a free, [on-demand webinar with Pulumi and the CNCF](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/) to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms. 
-[Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)
+Join us for a free, [on-demand webinar with Pulumi and the CNCF](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/) to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms.[Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)

--- a/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
+++ b/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
@@ -226,4 +226,5 @@ For users migrating to 4.0, check out the [v4 Provider Migration Guide](https://
 
 Try Infrastructure as Code for Kubernetes by following this quick [getting started guide](/docs/clouds/kubernetes/get-started/).
 
-Join us for a free, on-demand webinar with Pulumi and the CNCF to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms. [Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)
+Join us for a free, [on-demand webinar with Pulumi and the CNCF](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/) to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms. 
+[Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)

--- a/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
+++ b/themes/default/content/blog/kubernetes-4-0-even-more-kubernetes-native/index.md
@@ -23,6 +23,9 @@ Since the very earliest days of the Pulumi project, Kubernetes has been a core p
 Today, we are excited to release the next major version of our Kubernetes provider - [Pulumi Kubernetes 4.0](/registry/packages/kubernetes/).
 
 <!--more-->
+{{% notes type="info" %}}
+Join us for a free, on-demand webinar with Pulumi and the CNCF to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms. [Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)
+{{% /notes %}}
 
 Pulumi Kubernetes 4.0 uses Kubernetes Server-Side Apply by default, supports upserting on all resources, and enables new Patch resources for every resource type in the provider.  It also brings improved diffs, removes dependence on kubectl annotations, and provides simpler access to outputs in the Python, Go and Java SDKs, supporting any self-hosted or managed Kubernetes cluster with version 1.13 or newer.
 
@@ -215,6 +218,12 @@ As part of this work, we removed the use of the `kubectl.kubernetes.io/last-appl
 
 ## Migrating to Kubernetes 4.0
 
-You can migrate your existing Pulumi Kubernetes projects to 4.0 today, or start a new project targeting 4.0 with any of the Pulumi templates.  
+You can migrate your existing Pulumi Kubernetes projects to 4.0 today, or start a new project targeting 4.0 with any of the Pulumi templates.
 
 For users migrating to 4.0, check out the [v4 Provider Migration Guide](https://www.pulumi.com/registry/packages/kubernetes/how-to-guides/v4-migration/) with full details of the additional changes in this release.
+
+## Getting Started
+
+Try Infrastructure as Code for Kubernetes by following this quick [getting started guide](/docs/clouds/kubernetes/get-started/).
+
+Join us for a free, on-demand webinar with Pulumi and the CNCF to learn how to use Pulumi's Kubernetes Provider and other open-source tools to build internal developer platforms. [Register &rarr;](https://community.cncf.io/events/details/cncf-cncf-online-programs-presents-cncf-on-demand-webinar-how-to-start-building-a-self-service-infrastructure-platform-on-kubernetes/)

--- a/themes/default/content/resources/azure-github-workshop/index.md
+++ b/themes/default/content/resources/azure-github-workshop/index.md
@@ -71,7 +71,7 @@ main:
     datetime: "7/27/2023 8:00am - 9:30am PDT"
     # Description of the webinar.
     description: |
-        When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s [Azure Native v2 provider]() and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
+        When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s [Azure Native v2 provider](/blog/introducing-azure-native-v2/) and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
 
     # The webinar presenters
     presenters:

--- a/themes/default/content/resources/azure-github-workshop/index.md
+++ b/themes/default/content/resources/azure-github-workshop/index.md
@@ -41,7 +41,7 @@ event_data:
   end_date: 2023-09-19T09:00:00.000-07:00
   url: "https://www.pulumi.com/resources/azure-github-workshop"
   description: |
-    When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s Azure Native v2 provider and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
+    When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s [Azure Native v2 provider](/blog/introducing-azure-native-v2/) and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
 
 # The url slug for the webinar landing page. If this is an external
 # webinar, use the external URL as the value here.
@@ -60,7 +60,7 @@ hero:
 # Content for the left hand side section of the page.
 main:
     # Webinar title.
-    title: "Getting Started with Azure IaC and Review Stacks"
+    title: "Getting Started with Azure IaC and Review Stacks on GitHub"
     # URL for embedding a URL for ungated webinars.
     youtube_url:
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
@@ -71,7 +71,7 @@ main:
     datetime: "7/27/2023 8:00am - 9:30am PDT"
     # Description of the webinar.
     description: |
-        When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s Azure Native v2 provider and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
+        When managing cloud infrastructure, it’s important to establish a build-test-release process for your team. In this session, experts from the Azure, GitHub, and Pulumi teams will show you how to use Pulumi’s [Azure Native v2 provider]() and your favorite programming languages to stand up new projects on Azure quickly. Then, we’ll show you how Pulumi’s new Review Stacks feature creates a temporary cloud environment for every Pull Request in GitHub automatically – making it easier than ever to validate both infrastructure and app code before release.
 
     # The webinar presenters
     presenters:
@@ -84,9 +84,9 @@ main:
 
     # A bullet point list containing what the user will learn during the webinar.
     learn:
-        - Infrastructure as Code on Azure
-        - Serverless architectures
-        - Setting up Review Stacks with GitHub and Pulumi
+        - Infrastructure as Code on Azure in programming languages
+        - How to deploy serverless architectures with code
+        - Set up an infrastructure deployment workflow using GitHub and Pulumi's Review Stacks feature
 
 # The right hand side form section.
 form:


### PR DESCRIPTION
## Description
Add workshops to the launch blogs for Azure Native v2 and Kubernetes v4, along with minor changes to help with ongoing marketing. Also small tweaks to the Azure Native workshop page.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
