### PR TITLE
Make the migration guide link more noticeable

### DIFF
--- a/themes/default/content/blog/announcing-6-0-of-the-pulumi-aws-classic-provider/index.md
+++ b/themes/default/content/blog/announcing-6-0-of-the-pulumi-aws-classic-provider/index.md
@@ -59,6 +59,8 @@ The 6.0 release removes several deprecated resources. All of those resources wer
 
 We also shipped a few, small breaking changes to properties that may allow one or many items. We aligned those with the capabilities of the upstream provider and the AWS services ensure Pulumi users can access the full capabilities of the AWS platform.
 
+### Migration Guide
+
 You can see a full list of changes and learn more about migrating your existing programs in our [Migration Guide](https://www.pulumi.com/registry/packages/aws/how-to-guides/6-0-migration).
 
 ### Get Started Today


### PR DESCRIPTION
A user [reported](https://github.com/pulumi/pulumi-aws/pull/2584#issuecomment-1699344037) that a breaking change was missing from the blogpost, and didn't look at the migration guide. When I went to point out the migration guide in the blogpost, I didn't see the link since it looked like it was part of "### MaxItemsOne and Deprecations".

## Description

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
