### PR TITLE
fix broken GitLab links

### DIFF
--- a/themes/default/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
+++ b/themes/default/content/blog/managing-aws-credentials-on-cicd-part-1/index.md
@@ -25,7 +25,7 @@ in a series going in-depth on how to do just that.
 
 The goal of this article series is to give you a clear understanding of AWS credential management and how that relates to using Pulumi within a CI/CD environment.
 Once you have the AWS credentials in-place, you can then follow our [Continuous Delivery](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/) guide for
-configuring your specific CI/CD service, whether you want to use [CircleCI](https://circleci.com), [GitLab CI](https://about.gitlab.com/product/continuous-integration/), or
+configuring your specific CI/CD service, whether you want to use [CircleCI](https://circleci.com), [GitLab CI](https://docs.gitlab.com/ee/topics/build_your_application.html), or
 [Travis CI](https://travis-ci.org).
 
 > **NOTE:** These recommendations do not apply if you are running your own CI/CD system within your

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -18,7 +18,7 @@ aliases:
 - /docs/guides/continuous-delivery/cd-gitlab-ci/
 ---
 
-[GitLab CI/CD](https://about.gitlab.com/features/gitlab-ci-cd/) enables the management of deploying
+[GitLab CI/CD](https://docs.gitlab.com/ee/topics/build_your_application.html) enables the management of deploying
 staging and production stacks based on commits to specific Git branches. This is sometimes
 referred to as Push-to-Deploy.
 


### PR DESCRIPTION
fixes: https://github.com/pulumi/docs/issues/9734

fix Gitlab links that are 404-ing. This is the most reasonable place I could find to link to as these pages no longer seem to exist.