### PR TITLE
Fix: GitLab CI pipeline integration docs not working

### DIFF
--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -80,7 +80,7 @@ only:
 - merge_requests
 ```
 
-We will use this configuration to run the `pulumi preview` command only in merge request pipelines.
+The example script provided below will demonstrate how to use this configuration to run the `pulumi preview` command only in merge request pipelines.
 
 ## Sample Scripts
 
@@ -93,9 +93,9 @@ by going to [https://gitlab.com](https://gitlab.com) > (select your project) > S
 
 The following are samples only. You may choose to structure your configuration any way you like.
 
-The `pulumi-preview.sh` script (not shown here) is similar to the `run-pulumi.sh`, except that
-it runs the `pulumi preview` command instead of the `pulumi up --yes` command, which performs a dry-run
-of your project deployment that only shows you changes (if any) in your infrastructure.
+The `pulumi-preview.sh` script (not shown here) is similar to the `run-pulumi.sh` script, except that
+it runs the `pulumi preview` command instead of the `pulumi up --yes` command. The preview command performs a dry-run
+of your project deployment and only shows you changes (if any) in your infrastructure.
 
 ### `.gitlab-ci.yml`
 

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -22,83 +22,82 @@ aliases:
 staging and production stacks based on commits to specific Git branches. This is sometimes
 referred to as Push-to-Deploy.
 
-Pulumi doesn't require any particular arrangement of stacks or workflow to work in a
-continuous integration / continuous deployment system. So the steps described here can be
-altered to fit into any existing type of deployment setup.
+Using GitLab with Pulumi is a great way to combine software development and infrastructure
+as code (IaC) best practices. Pulumi is built with CI/CD integration in mind because:
+
+- It doesn't require any particular arrangement of stacks or workflow to work in CI/CD processes.
+- It can be run from anywhere and your infrastructure code can be hosted anywhere.
+
+This guide will demonstrate examples under the context of a Pulumi TypeScript project with the code hosted in a GitLab repository,
+but the steps described below can be altered to fit into any existing type of deployment setup.
 
 ## Prerequisites
 
-- An account on [https://app.pulumi.com](https://app.pulumi.com) and that you have created a new project.
-    - This just means you will sign-in using your GitLab credentials.
-    - However, pulumi can be run from anywhere and your infrastructure code itself can be hosted anywhere.
-- The [latest CLI](/docs/install/).
-- A bare repo and set the remote URL to be your GitLab project.
-
-## Stack and Branch Mappings
-
-The scripts below act on a hypothetical stack: `acme/product-catalog-service-stack`.
-You can create a stack by running `pulumi stack init`.
-The source code for the stack is in a repository in GitLab and uses `TypeScript` as the language.
-
-**Note**: The names used above are purely for demonstration purposes only.
-You may choose a naming convention that best suits your organization.
-
-Alternatively, you can also run `pulumi new [template]` to create a [template project](/docs/cli/commands/pulumi_new/).
-
-## GitLab CI Runners
-
-## Protected Branches
-
-In order to prevent abuse of protected resources, as well as some sensitive information used
-by your repository, GitLab has the concept of [Protected Branches and Tags](https://gitlab.com/help/user/project/protected_branches.md).
-
-If you are running `pulumi` from any branch other than the `master` branch,
-you are likely to hit an error that the `PULUMI_ACCESS_TOKEN`
-environment variable (introduced later in this document) cannot be accessed.
-You can fix this by specifying a wildcard regex to allow specific branches to
-be able to access the secret environment variables. Refer to the [GitLab
-documentation](https://gitlab.com/help/user/project/protected_branches.md) to learn how to do that.
-
-## Merge Request Builds
-
-GitLab has the ability to restrict jobs to _only_ run for [merge requests](https://docs.gitlab.com/ee/ci/merge_request_pipelines/). This is done by adding the following configuration to your GitLab pipeline config file:
-
-```
-only:
-- merge_requests
-```
-
-We will use this to run the `pulumi preview` command only in merge request pipelines.
+- Sign up for a [Pulumi account](https://app.pulumi.com) using your GitLab credentials.
+- Create a [Pulumi Access Token](https://app.pulumi.com/account/tokens).
+- Install the [latest Pulumi CLI](/docs/install/).
+- Create a [blank GitLab project](https://docs.gitlab.com/ee/user/project/) without a README.
+- Create a [new Pulumi project](https://www.pulumi.com/learn/pulumi-fundamentals/create-a-pulumi-project/) and [initialize it as a git repository](https://git-scm.com/docs/git-init)
+- Set the remote URL of the Pulumi project to be your GitLab project.
+  - Ex: `git remote add origin <your-gitlab-repo-url>`
 
 ## Environment Variables
 
 To use Pulumi within GitLab CI, there are a few environment variables you'll need to set for each
 build.
 
-The first is `PULUMI_ACCESS_TOKEN`, which is required to authenticate with pulumi.com in order to
-perform the preview or update. You can [create a new Pulumi access token](/docs/pulumi-cloud/accounts#access-tokens) specifically for your
-CI/CD job on your [Pulumi Account page](https://app.pulumi.com/account/tokens).
+The first is `PULUMI_ACCESS_TOKEN`, which is required to authenticate with `pulumi.com` in order to
+perform the preview or update.
 
 Next, you will also need to set environment variables specific to your cloud resource provider.
-For example, if your stack is managing resources on AWS, `AWS_ACCESS_KEY_ID` and
+For example, if your stack is managing resources on AWS, you will need to set `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY`.
 
-**Note**: It is a good security practice to mark any sensitive variables as protected in GitLab.
-Read the note about **Protected Branches** above.
+{{% notes type="info" %}}
 
-## Scripts
+It is a security best practice to mark any sensitive variables as protected in GitLab. You can learn how
+to set and protect environment variables in GitLab by referencing their [variables](https://docs.gitlab.com/ee/ci/variables/) documentation.
 
-Your repository must contain the `.gitlab-ci.yml` in the root. GitLab looks there by default.
-If you are using an alternate location, be sure to update the settings for your GitLab project
-by going to [https://gitlab.com](https://gitlab.com) > (select your project) > Settings > General.
+{{% /notes %}}
+
+## Protected Branches
+
+In order to prevent abuse of protected resources as well as other sensitive information used
+by your repository, GitLab has the concept of [Protected Branches and Tags](https://gitlab.com/help/user/project/protected_branches.md).
+
+Your GitLab repository's `main` or `master` branch is is the only branch that is created as a protected branch by default. If you are running Pulumi CLI commands from any branch other than the `main | master` branch,
+you are likely to run into a login error. This is due to the `PULUMI_ACCESS_TOKEN` environment variable only being accessible by protected branches and tags.
+
+You can fix this by configuring branch protection using [wildcard rules](https://docs.gitlab.com/ee/user/project/protected_branches.html#protect-multiple-branches-with-wildcard-rules). Doing this will
+allow any branches with names that match this rule the ability to access the secret environment variables.
+
+## Merge Request Builds
+
+GitLab has the ability to restrict jobs to run only on [merge requests](https://docs.gitlab.com/ee/ci/merge_request_pipelines/). This is done by adding the following configuration to your GitLab pipeline config file:
+
+```
+only:
+- merge_requests
+```
+
+We will use this configuration to run the `pulumi preview` command only in merge request pipelines.
+
+## Sample Scripts
+
+In GitLab, a CI/CD pipeline is defined in a yaml file labeled `.gitlab-ci.yml`. This file must exist
+in the root of your repository as GitLab looks there by default.
+
+If you are storing this file in an alternate location, be sure to reflect this location in the CI/CD settings of your GitLab project
+by going to [https://gitlab.com](https://gitlab.com) > (select your project) > Settings > CI/CD and updating the value of
+"CI/CD configuration file" under the "General pipelines" section.
 
 The following are samples only. You may choose to structure your configuration any way you like.
 
 The `pulumi-preview.sh` script (not shown here) is similar to the `run-pulumi.sh`, except that
-it runs the `pulumi preview` command instead of the `pulumi up` command, which is sort of a dry-run
-that only shows you changes (if any) in your infrastructure.
+it runs the `pulumi preview` command instead of the `pulumi up --yes` command, which performs a dry-run
+of your project deployment that only shows you changes (if any) in your infrastructure.
 
-### Sample `.gitlab-ci.yml`
+### `.gitlab-ci.yml`
 
 ```yaml
 #
@@ -134,9 +133,9 @@ pulumi:
     # This is just a sample of how artifacts can be expired (removed) automatically in GitLab.
     # You may choose to not set this at all based on your organization's or team's preference.
     expire_in: 1 week
-  # This job should only be created if the pipeline is created for the master branch.
+  # This job should only be created if the pipeline is created for the master (or main) branch.
   only:
-  - master
+  - master # or main
 
 pulumi-preview:
   stage: infrastructure-update
@@ -167,9 +166,13 @@ export PATH=$PATH:$HOME/.pulumi/bin
 pulumi login
 # update the GitLab Runner's packages
 apt-get update -y
-apt-get install sudo -y
+apt-get install sudo ca-certificates curl gnupg -y
 # nodejs
-curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+NODE_MAJOR=20
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
+apt-get update -y
 apt-get install -y nodejs
 # yarn
 npm i -g yarn
@@ -195,7 +198,7 @@ pulumi stack select product-catalog-service
 # program needs.
 # Learn more about pulumi configuration at: {{< absurl "/docs/concepts/config/" >}}
 pulumi config set mysetting myvalue
-pulumi up --yes
+pulumi up --yes # this line will be the pulumi preview command in pulumi-preview.sh
 ```
 
 ## Enhance Merge Requests With Pulumi

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -28,7 +28,7 @@ as code (IaC) best practices. Pulumi is built with CI/CD integration in mind bec
 - It doesn't require any particular arrangement of stacks or workflow to work in CI/CD processes.
 - It can be run from anywhere and your infrastructure code can be hosted anywhere.
 
-This guide will demonstrate examples under the context of a Pulumi TypeScript project with the code hosted in a GitLab repository,
+The examples provided in this guide were created under the context of a Pulumi TypeScript project with the project code hosted in a GitLab repository,
 but the steps described below can be altered to fit into any existing type of deployment setup.
 
 ## Prerequisites

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -33,7 +33,7 @@ but the steps described below can be altered to fit into any existing type of de
 
 ## Prerequisites
 
-- Sign up for a [Pulumi account](https://app.pulumi.com) using your GitLab credentials.
+- Sign up for a [Pulumi account](https://app.pulumi.com).
 - Create a [Pulumi Access Token](https://app.pulumi.com/account/tokens).
 - Install the [latest Pulumi CLI](/docs/install/).
 - Create a [blank GitLab project](https://docs.gitlab.com/ee/user/project/) without a README.


### PR DESCRIPTION
## Description
Related to #1076 

Due to limited details in the original issue as well as the slack thread being over 90 days old, I was unable to acquire the context that I needed to reproduce the initial problem.

The updates made to this content were to provide more clarity on the topics covered and to update the NodeJS installation scripting which had soon to be deprecated code.

URL: /docs/using-pulumi/continuous-delivery/gitlab-ci/
