### PR TITLE
Skip loading segment for specific user agents to filter bot traffic

### DIFF
--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -213,10 +213,19 @@
 
         <!--Segment tracking-->
         <script>
+            // Do not load Segment for these user agents.
+            userAgentBlacklist = [
+                'Mozilla/5.0 (compatible; SiteAuditBot/0.97; +http://www.semrush.com/bot.html)',
+                'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36'
+            ]
+
             !(function () {
                 var analytics = (window.analytics = window.analytics || []);
                 if (!analytics.initialize)
                     if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice.");
+                    else if(userAgentBlacklist.includes(navigator.userAgent)) {
+                        console.log("Segment snippet not loaded for user agent: " + navigator.userAgent);
+                    }
                     else {
                         analytics.invoked = !0;
                         analytics.methods = [
@@ -281,6 +290,8 @@
         <!-- Facebook Domain Verification -->
         <meta name="facebook-domain-verification" content="phlf6qes2bxa9ufzk8zt2es0qivg8j" />
     {{- end }}
+
+
 
 
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->

--- a/themes/default/layouts/partials/head.html
+++ b/themes/default/layouts/partials/head.html
@@ -292,8 +292,6 @@
     {{- end }}
 
 
-
-
     <!-- Apply anchor links to headings in the docs, blog and taxonomy pages. -->
     {{ if and (not .IsHome) (.Section) (in "docs blog authors tags registry" .Section) }}
         <script async defer src="//cdnjs.cloudflare.com/ajax/libs/anchor-js/4.1.0/anchor.min.js"></script>


### PR DESCRIPTION
## Description
We've seen significant bot traffic from two specific user agents that are driving about 50% of our active users on Segment, driving us to overages. We'd like to filter them out from ever reaching Segment, to avoid renewing for a bigger contract with them for no reason.

These are the two user agents we've detected that are bringin up consumption considerably:

Mozilla/5.0 (compatible; SiteAuditBot/0.97; +http://www.semrush.com/bot.html)
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36

e.g. for August, we've seen 187k bot users, out of a total of 314k users.

Solves https://github.com/pulumi/marketing/issues/794

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
