### PR TITLE
Update links in earlier Zephyr posts

### DIFF
--- a/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-code-organization-and-stacks/index.md
@@ -26,7 +26,7 @@ Here are links to all the blog posts in the series (entries below that are not l
 * [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * [IaC Recommended Practices: Using Stack References](/blog/iac-recommended-practices-using-stack-references/)
 * [IaC Recommended Practices: RBAC and Security](/blog/iac-recommended-practices-rbac-and-security/)
-* IaC Recommended Practices: Using Automation API
+* [IaC Recommended Practices: Using Automation API](/blog/iac-recommended-practices-using-automation-api/)
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse
 

--- a/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-developer-stacks-git-branches/index.md
@@ -26,7 +26,7 @@ Here are links to all of the posts in the series. Entries below that are not yet
 * [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * [IaC Recommended Practices: Using Stack References](/blog/iac-recommended-practices-using-stack-references/)
 * [IaC Recommended Practices: RBAC and Security](/blog/iac-recommended-practices-rbac-and-security/)
-* IaC Recommended Practices: Using Automation API
+* [IaC Recommended Practices: Using Automation API](/blog/iac-recommended-practices-using-automation-api/)
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse
 

--- a/themes/default/content/blog/iac-recommended-practices-rbac-and-security/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-rbac-and-security/index.md
@@ -25,7 +25,7 @@ For ease of navigation, here are links to all the blog posts in the series (any 
 * [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * [IaC Recommended Practices: Using Stack References](/blog/iac-recommended-practices-using-stack-references/)
 * **IaC Recommended Practices: RBAC and Security (the post you're reading)**
-* IaC Recommended Practices: Using Automation API
+* [IaC Recommended Practices: Using Automation API](/blog/iac-recommended-practices-using-automation-api/)
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse
 

--- a/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-structuring-pulumi-projects/index.md
@@ -24,7 +24,7 @@ Here are links to all the blog posts in the series (entries below that are not l
 * **IaC Recommended Practices: Structuring Pulumi Projects** (this post)
 * [IaC Recommended Practices: Using Stack References](/blog/iac-recommended-practices-using-stack-references/)
 * [IaC Recommended Practices: RBAC and Security](/blog/iac-recommended-practices-rbac-and-security/)
-* IaC Recommended Practices: Using Automation API
+* [IaC Recommended Practices: Using Automation API](/blog/iac-recommended-practices-using-automation-api/)
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse
 

--- a/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
+++ b/themes/default/content/blog/iac-recommended-practices-using-stack-references/index.md
@@ -24,7 +24,7 @@ Here are links to all the blog posts in the series (entries not linked below are
 * [IaC Recommended Practices: Structuring Pulumi Projects](/blog/iac-recommended-practices-structuring-pulumi-projects/)
 * **IaC Recommended Practices: Using Stack References** (you are here)
 * [IaC Recommended Practices: RBAC and Security](/blog/iac-recommended-practices-rbac-and-security/)
-* IaC Recommended Practices: Using Automation API
+* [IaC Recommended Practices: Using Automation API](/blog/iac-recommended-practices-using-automation-api/)
 * IaC Recommended Practices: Adding Pulumi Deployments
 * IaC Recommended Practices: Refactoring for Reuse
 


### PR DESCRIPTION
## Description

This PR adds links to the latest Zephyr post to all earlier posts. This should have been done in the PR to publish the latest post, but it was missed.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
