### PR TITLE
Improve the first YAML example

### DIFF
--- a/themes/default/content/docs/languages-sdks/yaml/_index.md
+++ b/themes/default/content/docs/languages-sdks/yaml/_index.md
@@ -29,20 +29,39 @@ All you need to use Pulumi YAML is the [Pulumi CLI](/docs/install/).
 ```yaml
 name: simple-yaml
 runtime: yaml
+config:
+  message:
+    default: Hello, world!
+    type: string
 resources:
   my-bucket:
     type: aws:s3:Bucket
     properties:
       website:
         indexDocument: index.html
+  ownership-controls:
+    type: aws:s3:BucketOwnershipControls
+    properties:
+      bucket: ${my-bucket.id}
+      rule:
+        objectOwnership: ObjectWriter
+  public-access-block:
+    type: aws:s3:BucketPublicAccessBlock
+    properties:
+      bucket: ${my-bucket.id}
+      blockPublicAcls: false
   index.html:
     type: aws:s3:BucketObject
     properties:
       bucket: ${my-bucket}
       source:
-        Fn::StringAsset: <h1>Hello, world!</h1>
+        fn::stringAsset: <h1>${message}</h1>
       acl: public-read
       contentType: text/html
+    options:
+      dependsOn:
+        - ${ownership-controls}
+        - ${public-access-block}
 outputs:
   bucketEndpoint: http://${my-bucket.websiteEndpoint}
 ```


### PR DESCRIPTION
The example has a few issues:
1. It doesn't work - since AWS made breaking changes to public buckets earlier this year
2. It doesn't show off `config` or `options`
3. It uses the now-deprecated capitalized `Fn::` syntax

These changes address all three.
