### PR TITLE
Update install-go.html to align with Go terms

### DIFF
--- a/themes/default/layouts/shortcodes/install-go.html
+++ b/themes/default/layouts/shortcodes/install-go.html
@@ -10,7 +10,7 @@
     </div>
     <div class="content">
         <p>
-            Pulumi requires a <a href="https://go.dev/doc/devel/release#policy">supported version of Go</a>&mdash; this typically refers to the two most recent major releases. If
+            Pulumi requires a <a href="https://go.dev/doc/devel/release#policy">supported version of Go</a>&mdash; this typically refers to the two most recent major releases. Note that Go calls 1.20, 1.21, etc. major releases, unlike semantic versioning. If
             you're using Linux, your distribution may not provide an up to date version of the Go compiler. To check what version of Go you have installed, use:
             <code>go version</code>.
         </p>

--- a/themes/default/layouts/shortcodes/install-go.html
+++ b/themes/default/layouts/shortcodes/install-go.html
@@ -10,7 +10,7 @@
     </div>
     <div class="content">
         <p>
-            Pulumi requires a <a href="https://go.dev/doc/devel/release#policy">supported version of Go</a>&mdash; this typically refers to the two most recent minor releases. If
+            Pulumi requires a <a href="https://go.dev/doc/devel/release#policy">supported version of Go</a>&mdash; this typically refers to the two most recent major releases. If
             you're using Linux, your distribution may not provide an up to date version of the Go compiler. To check what version of Go you have installed, use:
             <code>go version</code>.
         </p>


### PR DESCRIPTION
We were calling 1.20 to 1.21 a minor release. Go calls that a major release.