### PR TITLE
Remove relrefs from the main and docs navs

### DIFF
--- a/themes/default/layouts/partials/docs-top-nav.html
+++ b/themes/default/layouts/partials/docs-top-nav.html
@@ -8,13 +8,13 @@
                 </div>
                 <ul id="logo-nav-menu" role="menu" class="logo-nav-menu hidden">
                     <li role="none"><a role="menuitem" href="/">Pulumi home</a></li>
-                    <li role="none"><a role="menuitem" href="{{ relref . " /pricing" }}">Pricing</a></li>
-                    <li role="none"><a role="menuitem" href="{{ relref . " /blog" }}">Blog</a></li>
-                    <li role="none"><a role="menuitem" href="{{ relref . " /resources" }}">Events & workshops</a></li>
+                    <li role="none"><a role="menuitem" href="/pricing/">Pricing</a></li>
+                    <li role="none"><a role="menuitem" href="/blog/">Blog</a></li>
+                    <li role="none"><a role="menuitem" href="/resources/">Events & workshops</a></li>
                 </ul>
             </div>
             <div class="get-started">
-                <a class="get-started-header-button" data-track="get-started-practitioner-nav" href="{{ relref . " /docs/get-started" }}">Get Started</a>
+                <a class="get-started-header-button" data-track="get-started-practitioner-nav" href="/docs/get-started/">Get Started</a>
             </div>
         </div>
         <div class="nav-items">
@@ -38,19 +38,19 @@
                     </a>
                 </li>
                 <li class="docs">
-                    <a data-track="header-docs" href="{{ relref . " /docs" }}">
+                    <a data-track="header-docs" href="/docs/">
                         <div class="icon icon-16-16 book-outline"></div>
                         Docs
                     </a>
                 </li>
                 <li class="registry">
-                    <a data-track="header-registry" href="{{ relref . " /registry" }}">
+                    <a data-track="header-registry" href="/registry/">
                         <div class="icon icon-14-14 packages-outline"></div>
                         Registry
                     </a>
                 </li>
                 <li class="ai">
-                    <a data-track="header-ai" href="{{ relref . " /ai" }}">
+                    <a data-track="header-ai" href="/ai">
                         <div class="icon icon-16-16 robot-outline"></div>
                         Pulumi AI
                     </a>

--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -40,7 +40,7 @@
                     </a>
                 </li>
                 <li class="mr-8">
-                    <a data-track="header-ai" href="{{ relref . "/ai" }}">
+                    <a data-track="header-ai" href="/ai">
                         <i class="fas fa-robot mr-0.5"></i>
                         Pulumi AI
                     </a>
@@ -471,7 +471,7 @@
                                 <a href="https://slack.pulumi.com/">Slack</a>
                                 <a href="{{ relref . "/docs" }}">Docs</a>
                                 <a href="{{ relref . "/registry" }}">Registry</a>
-                                <a href="{{ relref . "/ai" }}">Pulumi AI</a>
+                                <a href="/ai">Pulumi AI</a>
                                 <a href="https://app.pulumi.com/">
                                     {{ partial "top-nav-user-toggle" }}
                                 </a>

--- a/themes/default/layouts/partials/top-nav.html
+++ b/themes/default/layouts/partials/top-nav.html
@@ -9,19 +9,19 @@
         </div>
         <ul id="logo-nav-menu" role="menu" class="logo-nav-menu hidden">
             <li role="none"><a role="menuitem" href="/">Pulumi Home</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . "/docs/get-started" }}">Get Started</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /cloud-engineering" }}">Cloud Engineering</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /product" }}">Product</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /pricing" }}">Pricing</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /docs" }}">Docs</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /blog" }}">Blog</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /learn" }}">Learn Pulumi</a></li>
-            <li role="none"><a role="menuitem" href="{{ relref . " /resources" }}">Events & Workshops</a></li>
+            <li role="none"><a role="menuitem" href="/docs/get-started/">Get Started</a></li>
+            <li role="none"><a role="menuitem" href="/cloud-engineering/">Cloud Engineering</a></li>
+            <li role="none"><a role="menuitem" href="/product/">Product</a></li>
+            <li role="none"><a role="menuitem" href="/pricing/">Pricing</a></li>
+            <li role="none"><a role="menuitem" href="/docs/">Docs</a></li>
+            <li role="none"><a role="menuitem" href="/blog/">Blog</a></li>
+            <li role="none"><a role="menuitem" href="/learn/">Learn Pulumi</a></li>
+            <li role="none"><a role="menuitem" href="/resources/">Events & Workshops</a></li>
             <ul role="menu" class="sm:hidden">
                 <li role="none"><a role="menuitem" href="https://github.com/pulumi/pulumi">GitHub</a></li>
                 <li role="none"><a role="menuitem" href="https://slack.pulumi.com">Slack</a></li>
-                <li role="none"><a role="menuitem" href="{{ relref . " /registry" }}">Registry</a></li>
-                <li role="none"><a role="menuitem" href="{{ relref . " /ai" }}">Pulumi AI</a></li>
+                <li role="none"><a role="menuitem" href="/registry/">Registry</a></li>
+                <li role="none"><a role="menuitem" href="/ai">Pulumi AI</a></li>
                 <li role="none">
                     <a role="menuitem" href="https://app.pulumi.com">
                         {{ partial "top-nav-user-toggle" }}
@@ -29,7 +29,7 @@
                 </li>
             </ul>
         </ul>
-        <a class="get-started-header-button" data-track="get-started-practitioner-nav" href="{{ relref . " /docs/get-started" }}">Get Started</a>
+        <a class="get-started-header-button" data-track="get-started-practitioner-nav" href="/docs/get-started/">Get Started</a>
         <div class="flex-1"></div>
         <ul class="hidden w-full lg:flex lg:w-1/2 justify-end items-center order-first lg:order-last">
             <li class="github-widget mr-8">
@@ -51,19 +51,19 @@
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-github" href="{{ relref . " /docs" }}">
+                <a data-track="header-github" href="/docs/">
                     <i class="fas fa-book mr-0.5"></i>
                     Docs
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-github" href="{{ relref . " /registry" }}">
+                <a data-track="header-github" href="/registry/">
                     <i class="fas fa-archive mr-0.5"></i>
                     Registry
                 </a>
             </li>
             <li class="mr-8">
-                <a data-track="header-ai" href="{{ relref . " /ai" }}">
+                <a data-track="header-ai" href="/ai">
                     <i class="fas fa-robot mr-0.5"></i>
                     Pulumi AI
                 </a>


### PR DESCRIPTION
In #3394, we removed the content page for /ai, which surfaced a number of `relref` failures from pages still using that shortcode to link to `/ai`. This change removes all `relref`s from the main and docs navs to fix that up.