### PR TITLE
WIP: Link linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "concurrently": "^6.0.0",
         "js-yaml": "^3.13.1",
         "markdownlint": "^0.17.2",
+        "node-html-parser": "^6.1.10",
         "sass": "^1.39.2"
     },
     "devDependencies": {

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,5 +2,6 @@
 
 set -o errexit -o pipefail
 
+node ./scripts/lint/lint-links.js
 node ./scripts/lint/lint-markdown.js
 yarn prettier --check .

--- a/scripts/lint/lint-links.js
+++ b/scripts/lint/lint-links.js
@@ -1,0 +1,121 @@
+const fs = require("fs");
+const path = require("path");
+const { parse } = require("node-html-parser");
+
+function getFiles(basePath, results = []) {
+    const contents = fs.readdirSync(basePath);
+
+    for (const file of contents) {
+        const filePath = path.join(basePath, file);
+        if (fs.lstatSync(filePath).isDirectory()) {
+            const dirContents = getFiles(filePath);
+            results.push(...dirContents);
+            continue;
+        }
+
+        results.push(filePath);
+    }
+
+    return results;
+}
+
+function checkLinks(filePath) {
+    const failures = [];
+
+    const file = fs.readFileSync(filePath).toString();
+    const root = parse(file);
+    const links = root.querySelectorAll("a");
+    for (const l of links) {
+        const b = file.substring(0, file.indexOf(l.outerHTML.split("\n")[0]));
+        const lineNumber = b.split("\n").length;
+        const element = l.outerHTML;
+
+        if (!l.getAttribute("href")) {
+            failures.push({
+                element,
+                filePath,
+                lineNumber,
+                message: "Missing href",
+            });
+            continue;
+        }
+
+        if (l.getAttribute("href").indexOf("relref") > -1) {
+            failures.push({
+                element,
+                filePath,
+                lineNumber,
+                message: "Links is using a relref which is no longer supported",
+            });
+            continue;
+        }
+
+        if (l.getAttribute("href").split("#")[0].slice(-1) !== "/") {
+            failures.push({
+                element,
+                filePath,
+                lineNumber,
+                message: "Missing trailing slash",
+            });
+        }
+    }
+
+    return failures;
+}
+
+async function checkFiles(files, failures = []) {
+    const file = files.shift();
+    const fileFailures = checkLinks(file);
+    failures.push(...fileFailures);
+
+    if (files.length === 0) {
+        return failures;
+    }
+
+    return checkFiles(files, failures);
+}
+
+function renderFileOutput(filePath, failures) {
+    return `${filePath}:
+  ${failures.sort((a, b) => a.lineNumber > b.lineNumber).map(f => `Line ${f.lineNumber}: ${f.message}`).join("\n  ")}`
+}
+
+async function main() {
+    const files = getFiles("./themes/default/layouts/");
+
+    const failures = await checkFiles(files);
+    const sortedFailures = failures.reduce((res, curr) => {
+        if (!res[curr.filePath]) {
+            res[curr.filePath] = [];
+        }
+
+        res[curr.filePath].push(curr);
+
+        return res;
+    }, {});
+
+    const output = [];
+    for (const key of Object.keys(sortedFailures)) {
+        const value = sortedFailures[key];
+        output.push(renderFileOutput(key, value));
+    }
+
+    console.log(`
+Link Lint Results:
+  - ${files.length} files checked
+  - ${Object.values(output).length} issues found.
+`);
+
+    if (Object.values(output).length > 0) {
+        console.log("Issues:\n");
+        console.log(output.join("\n\n"), "\n");
+        throw Error("Issues with links found");
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch(e => {
+        console.log("ERROR", e);
+        process.exit(1);
+    });

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz"
@@ -231,6 +236,22 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
 date-fns@^2.16.1:
   version "2.19.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.19.0.tgz"
@@ -242,6 +263,36 @@ debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -257,6 +308,11 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@~2.0.0:
   version "2.0.3"
@@ -350,6 +406,11 @@ has@^1.0.3:
   integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
   dependencies:
     function-bind "^1.1.1"
+
+he@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -561,6 +622,14 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+node-html-parser@^6.1.10:
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.10.tgz#5db11eac3ccbea6fc1b04a22c8a0e3a0774cfae6"
+  integrity sha512-6/uWdWxjQWQ7tMcFK2wWlrflsQUzh1HsEzlIf2j5+TtzfhT2yUvg3DwZYAmjEHeR3uX74ko7exjHW69J0tOzIg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
+
 normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz"
@@ -582,6 +651,13 @@ npm-run-path@^5.1.0:
   integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
   dependencies:
     path-key "^4.0.0"
+
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
 
 object-inspect@^1.12.2:
   version "1.12.2"


### PR DESCRIPTION
## Description

This PR adds a link linter to our tools, so that we can ensure no more `relrefs` or links without trailing slashes make into the website. We stopped using `relrefs` in practice a while back and now they seem to cause build failures from time to time so we should remove them and make sure they don't come back.

Missing trailing slashes cause a 302 redirect to happen, which isn't great for SEO. It is just at the warning level in SEMrush, but we should clean that up and also ensure we don't introduce more into the website.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
