### PR TITLE
Fix broken links for removing relref

### DIFF
--- a/themes/default/layouts/partials/footer.html
+++ b/themes/default/layouts/partials/footer.html
@@ -17,12 +17,12 @@
 
             <ul>
                 <li><a data-track="footer-enterprise" href="/enterprise/" class="link">Enterprise</a></li>
-                <li><a data-track="footer-aws" href="/partner/aws/" class="link">AWS</a></li>
-                <li><a data-track="footer-azure" href="/partner/azure/" class="link">Azure</a></li>
-                <li><a data-track="footer-gcp" href="/partner/gcp/" class="link">Google Cloud</a></li>
-                <li><a href="/topics/containers/" class="link">Containers</a></li>
-                <li><a href="/topics/serverless/" class="link">Serverless</a></li>
-                <li><a href="/topics/kubernetes/" class="link">Kubernetes</a></li>
+                <li><a data-track="footer-aws" href="/aws/" class="link">AWS</a></li>
+                <li><a data-track="footer-azure" href="/azure/" class="link">Azure</a></li>
+                <li><a data-track="footer-gcp" href="/gcp/" class="link">Google Cloud</a></li>
+                <li><a href="/containers/" class="link">Containers</a></li>
+                <li><a href="/serverless/" class="link">Serverless</a></li>
+                <li><a href="/kubernetes/" class="link">Kubernetes</a></li>
             </ul>
 
             <ul>


### PR DESCRIPTION
## Description

Fixes the broken links in the footer from removing relrefs.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
