### PR TITLE
Fix example code bug for configuring policies

### DIFF
--- a/themes/default/content/docs/using-pulumi/crossguard/configuration.md
+++ b/themes/default/content/docs/using-pulumi/crossguard/configuration.md
@@ -73,7 +73,7 @@ const examplePolicy: ResourceValidationPolicy = {
             }
         },
     },
-    validateResource: validateTypedResource(aws.s3.Bucket, (_, args, reportViolation) => {
+    validateResource: validateResourceOfType(aws.s3.Bucket, (_, args, reportViolation) => {
         const config = args.getConfig<{ message?: string }>();
         if (!config.message) {
             config.message = "Setting reasonable defaults is recommended!";
@@ -137,7 +137,7 @@ const examplePolicy: ResourceValidationPolicy = {
         },
         required: ["message"],
     },
-    validateResource: validateTypedResource(aws.s3.Bucket, (_, args, reportViolation) => {
+    validateResource: validateResourceOfType(aws.s3.Bucket, (_, args, reportViolation) => {
         // The `?` after the `message` property in the type specified to the `getConfig` function is no
         // longer necessary since `message` is required and will always have a value.
         const config = args.getConfig<{ message: string }>();


### PR DESCRIPTION
The TypeScript examples for configuring policies is using `validateTypedResource`, but that should be `validateResourceOfType`.

Fixes #3426