### PR TITLE
Fix assets file path

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Commit artifacts
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          file_pattern: theme/default/assets/js/bundle.js theme/default/assets/js/marketing.js theme/default/assets/css/bundle.css theme/default/assets/css/marketing.css
+          file_pattern: themes/default/assets/js/bundle.js themes/default/assets/js/marketing.js themes/default/assets/css/bundle.css themes/default/assets/css/marketing.css
           commit_message: Commit asset bundles
 
       - name: Commit any changes to go.mod/go.sum


### PR DESCRIPTION
We intend to rebuild assets files when PRs are merged and commit them to master. This is not happening since the file paths were wrong, so this updates them.
