### PR TITLE
Fix C# snippet

### DIFF
--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -52,7 +52,10 @@ public class MyStack : Stack
     public MyStack()
     {
         // Create an Azure Resource Group
-        var resourceGroup = new ResourceGroup("resourceGroup");
+        var resourceGroup = new ResourceGroup("resourceGroup", new ResourceGroupArgs
+        {
+            Location = "West Europe",
+        });
 
         // Create an Azure Storage Account
         var storageAccount = new Account("storage", new AccountArgs

--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -47,7 +47,7 @@ class Program
     static Task<int> Main() => Deployment.RunAsync<MyStack>();
 }
 
-public MyStack : Stack
+public class MyStack : Stack
 {
     public MyStack()
     {


### PR DESCRIPTION
## Description

Noticed that official C# documentation has a code which doesn't compile: https://www.pulumi.com/docs/languages-sdks/dotnet/#example
Snippet was simply missing a `class` modifier.

- [x] Fix C# documentation snippet 
