### PR TITLE
add redirect get-started

### DIFF
--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -10,6 +10,7 @@ menu:
     weight: 1
 
 aliases:
+- /get-started/install/
 - /docs/reference/install/
 - /docs/get-started/install/
 


### PR DESCRIPTION
## Description

Redirect `/get-started/install` to `/docs/get-started/install`

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
