### PR TITLE
Remove menu definition from front matter to fix sorting issue

### DIFF
--- a/themes/default/content/blog/introducing-crd2pulumi/index.md
+++ b/themes/default/content/blog/introducing-crd2pulumi/index.md
@@ -2,11 +2,6 @@
 title: "Introducing crd2pulumi: Typed CustomResources for Kubernetes"
 date: 2020-08-12
 meta_desc: Generate Kubernetes CustomResource types in TypeScript, Python, C#, and Go.
-menu:
-  converters:
-    identifier: crd2pulumi
-linktitle: Kubernetes CustomResources to Pulumi
-weight: 2
 meta_image: crd.png
 authors:
     - levi-blackstone


### PR DESCRIPTION
## Description

Removes the front matter from this blog post to fix a sorting issue on the main blog listings.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
