### PR TITLE
Update pulumi's outbound IPS with the ones used by workflow runners

### DIFF
--- a/themes/default/content/docs/support/faq.md
+++ b/themes/default/content/docs/support/faq.md
@@ -94,6 +94,8 @@ Should your network have egress limitations, please ensure you allowlist the sub
 - api.pulumi.com
 - 34.208.94.47
 - 34.212.116.224
+- 44.241.59.217
+- 52.40.198.20
 
 These IP addresses and URL are the external facing addresses of the Pulumi Cloud SaaS and should be added to your allowlist to allow traffic from your network to reach our services.
 


### PR DESCRIPTION
## Description

The IPs documented are the ones used by pulumi-service. This two new IPs are the NAT gateways configured in the workflow runners account

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
