### PR TITLE
block indexing on blog/tags page

### DIFF
--- a/themes/default/content/blog/tag.md
+++ b/themes/default/content/blog/tag.md
@@ -2,6 +2,7 @@
 title: "Pulumi Blog: All tags"
 layout: tags
 meta_desc: A list of all Pulumi blog tags, sorted alphabetically.
+block_external_search_index: true
 ---
 
 All [Pulumi blog](/blog/) tags, sorted alphabetically.


### PR DESCRIPTION
## Description

fixes: https://github.com/pulumi/marketing/issues/818

Disable search indexing on /blog/tags page.

I verified in the page source:

![Screenshot from 2023-10-20 14-09-19](https://github.com/pulumi/pulumi-hugo/assets/16751381/aa2069ae-1e9c-4c35-be5d-4e6468ae4fe9)

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
