### PR TITLE
Updated Epsagon link to Cisco

### DIFF
--- a/themes/default/content/blog/pulumi-and-epsagon-define-deploy-and-monitor-serverless-applications/index.md
+++ b/themes/default/content/blog/pulumi-and-epsagon-define-deploy-and-monitor-serverless-applications/index.md
@@ -20,7 +20,7 @@ wired together as part of a larger set of infrastructure and application
 code.
 <!--more-->
 
-[Epsagon is a serverless monitoring solution](https://epsagon.com/) that
+[Epsagon is a serverless monitoring solution](www.cisco.com/site/us/en/solutions/full-stack-observability/index.html) that
 lets users observe entire serverless applications composed of many
 functions and other AWS infrastructure, instead of just looking at
 individual functions one at a time. This is a great fit for Pulumi
@@ -109,4 +109,4 @@ makes it easy to monitor them. Users get an application-centric view
 across their full serverless application infrastructure.
 
 Checkout the quickstart guides for [Pulumi](/docs/get-started/)
-and [Epsagon](https://docs.epsagon.com/#/quick-start-guide) now!
+and [Epsagon](www.cisco.com/site/us/en/solutions/full-stack-observability/index.html) now!


### PR DESCRIPTION
## Description

Epsagon was acquired by Cisco and rolled into their full-stack observability suite. Updated the previous Epsagon links to direct to this instead.
