### PR TITLE
Remove Registry module and await in-progress workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,14 +31,9 @@ jobs:
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
 
-      - name: Fetch the latest pulumi/registry
-        run: |
-          hugo mod get github.com/pulumi/registry/themes/default
-          hugo mod tidy
-
       - name: Build assets
         run: |
-          make ensure build-assets
+          make ensure ci-await build-assets
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -47,12 +42,6 @@ jobs:
         with:
           file_pattern: theme/default/assets/js/bundle.js theme/default/assets/js/marketing.js theme/default/assets/css/bundle.css theme/default/assets/css/marketing.css
           commit_message: Commit asset bundles
-
-      - name: Commit any changes to go.mod/go.sum
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          file_pattern: go.*
-          commit_message: Update go.mod
 
   notify:
     if: failure()

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,10 @@ serve-all:
 build-assets:
 	yarn --cwd ./themes/default/theme run build
 
+.PHONY: ci-await
+ci-await:
+	node ./scripts/ci/await-in-progress.js
+
 .PHONY: ci-pull-request
 ci-pull-request: ensure lint
 	./scripts/ci/pull-request.sh

--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -19,18 +19,6 @@ module:
           target: assets
         - source: archetypes
           target: archetypes
-    - path: github.com/pulumi/registry/themes/default
-      mounts:
-        - source: content
-          target: content
-        - source: static
-          target: static
-        - source: layouts
-          target: layouts
-        - source: data
-          target: data
-        - source: assets
-          target: assets
 
 security:
   funcs:

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,4 @@ replace github.com/pulumi/pulumi-hugo/themes/default => ./themes/default
 
 require (
 	github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20220504042409-82f5a4588c0e // indirect
-	github.com/pulumi/registry/themes/default v0.0.0-20231026190107-c5b5b57df03e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,1 @@
 github.com/pulumi/pulumi-hugo/themes/default v0.0.0-20220504042409-82f5a4588c0e/go.mod h1:081/gGTOxNFBjrLQ3QvsyP34iiWgmmKDtoi5falfsuo=
-github.com/pulumi/registry/themes/default v0.0.0-20231026190107-c5b5b57df03e h1:FIiBsq7bYbZv/UGHyLNmX0jbUeMrMxPt8QjEnngyCcw=
-github.com/pulumi/registry/themes/default v0.0.0-20231026190107-c5b5b57df03e/go.mod h1:QSvobZqmJMqVmn3BTfSiYkbRKtJHhSA8gotu/pD1a0w=

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "author": "Christian Nunciato <c@nunciato.org>",
     "license": "MIT",
     "dependencies": {
+        "@octokit/rest": "^20.0.2",
         "concurrently": "^6.0.0",
         "js-yaml": "^3.13.1",
         "markdownlint": "^0.17.2",

--- a/scripts/ci/await-in-progress.js
+++ b/scripts/ci/await-in-progress.js
@@ -1,0 +1,60 @@
+const { Octokit } = require("@octokit/rest");
+
+// Wait for any in-progress runs of the same workflow on this branch to complete before
+// proceeding. In other words, if the current workflow is an instance of the "foo"
+// workflow, and there's another "foo" workflow running for a different commit on the same
+// branch as this one, wait for that workflow to complete before exiting (in order to
+// prevent the current workflow from continuing).
+// Inspired by https://github.com/softprops/turnstyle.
+async function waitForInProgressRuns() {
+    // See https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables
+    // for an explanation of each of these variables.
+    const githubToken = process.env.GITHUB_TOKEN;
+    const currentRunID = parseInt(process.env.GITHUB_RUN_ID, 10);
+    const workflowName = process.env.GITHUB_WORKFLOW;
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
+    const branch = process.env.GITHUB_HEAD_REF || process.env.GITHUB_REF.replace("refs/heads/", "");
+    const status = "in_progress";
+
+    const octokit = new Octokit({
+        auth: githubToken,
+    });
+
+    // Given the current workflow name, fetch its ID.
+    const workflows = await octokit.rest.actions.listRepoWorkflows({ owner, repo });
+    const workflow_id = workflows.data.workflows.find(workflow => workflow.name === workflowName).id;
+
+    // Fetch a paginated list of in-progress runs of the current workflow.
+    const runs = await octokit.paginate(
+        octokit.rest.actions.listWorkflowRuns.endpoint.merge({
+            owner,
+            repo,
+            branch,
+            workflow_id,
+            status,
+        }),
+    );
+
+    // Sort in-progress runs descendingly, excluding the current one.
+    const recent = runs.sort((a, b) => b.id - a.id).filter(run => run.id < currentRunID);
+
+    console.log(`Found ${recent.length} other ${workflowName} job(s) running on branch ${branch}.`);
+
+    if (recent.length > 0) {
+        const [mostRecent] = recent;
+        console.log(`Waiting for ${mostRecent.html_url} to complete before continuing.`);
+        await Promise.resolve(setTimeout(waitForInProgressRuns, 60000)); // One minute.
+    } else {
+        console.log("Continuing.");
+    }
+}
+
+// Unhandled errors that happen within Promises yield warnings, but do not (yet) cause the
+// process to exit nonzero. Since we want this script to fail loudly when something goes
+// wrong, we listen for unhandledRejection events and rethrow, exiting 1.
+// https://nodejs.org/api/process.html#process_event_unhandledrejection
+process.on("unhandledRejection", error => {
+    throw error;
+});
+
+waitForInProgressRuns();

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,103 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@octokit/auth-token@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-4.0.0.tgz#40d203ea827b9f17f42a29c6afb93b7745ef80c7"
+  integrity sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==
+
+"@octokit/core@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-5.0.1.tgz#865da2b30d54354cccb6e30861ddfa0e24494780"
+  integrity sha512-lyeeeZyESFo+ffI801SaBKmCfsvarO+dgV8/0gD8u1d87clbEdWsP5yC+dSj3zLhb2eIf5SJrn6vDz9AheETHw==
+  dependencies:
+    "@octokit/auth-token" "^4.0.0"
+    "@octokit/graphql" "^7.0.0"
+    "@octokit/request" "^8.0.2"
+    "@octokit/request-error" "^5.0.0"
+    "@octokit/types" "^12.0.0"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/endpoint@^9.0.0":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-9.0.1.tgz#c3f69d27accddcb04a3199fcef541804288149d2"
+  integrity sha512-hRlOKAovtINHQPYHZlfyFwaM8OyetxeoC81lAkBy34uLb8exrZB50SQdeW3EROqiY9G9yxQTpp5OHTV54QD+vA==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^7.0.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-7.0.2.tgz#3df14b9968192f9060d94ed9e3aa9780a76e7f99"
+  integrity sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==
+  dependencies:
+    "@octokit/request" "^8.0.1"
+    "@octokit/types" "^12.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^19.0.2":
+  version "19.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-19.0.2.tgz#d72778fe2f6151314b6f0201fbc771bb741276fc"
+  integrity sha512-8li32fUDUeml/ACRp/njCWTsk5t17cfTM1jp9n08pBrqs5cDFJubtjsSnuz56r5Tad6jdEPJld7LxNp9dNcyjQ==
+
+"@octokit/plugin-paginate-rest@^9.0.0":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.1.2.tgz#3d6196db8463bd0d935f4c9bc78de6325c95cbb8"
+  integrity sha512-euDbNV6fxX6btsCDnZoZM4vw3zO1nj1Z7TskHAulO6mZ9lHoFTpwll6farf+wh31mlBabgU81bBYdflp0GLVAQ==
+  dependencies:
+    "@octokit/types" "^12.1.1"
+
+"@octokit/plugin-request-log@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-4.0.0.tgz#260fa6970aa97bbcbd91f99f3cd812e2b285c9f1"
+  integrity sha512-2uJI1COtYCq8Z4yNSnM231TgH50bRkheQ9+aH8TnZanB6QilOnx8RMD2qsnamSOXtDj0ilxvevf5fGsBhBBzKA==
+
+"@octokit/plugin-rest-endpoint-methods@^10.0.0":
+  version "10.1.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.1.2.tgz#bf503f47881171bc9380d110793d8d3150158ed3"
+  integrity sha512-JztgZ82CY4JNlPTuF0jh4iWuuGpEi5czFCoXyAbMg4F2XyFBbG5DWAKfa3odRvdZww6Df1tQgBKnqpd9X0WF9g==
+  dependencies:
+    "@octokit/types" "^12.1.1"
+
+"@octokit/request-error@^5.0.0":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-5.0.1.tgz#277e3ce3b540b41525e07ba24c5ef5e868a72db9"
+  integrity sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==
+  dependencies:
+    "@octokit/types" "^12.0.0"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
+"@octokit/request@^8.0.1", "@octokit/request@^8.0.2":
+  version "8.1.4"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-8.1.4.tgz#12dfaebdb2ea375eaabb41d39d45182531ac2857"
+  integrity sha512-M0aaFfpGPEKrg7XoA/gwgRvc9MSXHRO2Ioki1qrPDbl1e9YhjIwVoHE7HIKmv/m3idzldj//xBujcFNqGX6ENA==
+  dependencies:
+    "@octokit/endpoint" "^9.0.0"
+    "@octokit/request-error" "^5.0.0"
+    "@octokit/types" "^12.0.0"
+    is-plain-object "^5.0.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/rest@^20.0.2":
+  version "20.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-20.0.2.tgz#5cc8871ba01b14604439049e5f06c74b45c99594"
+  integrity sha512-Ux8NDgEraQ/DMAU1PlAohyfBBXDwhnX2j33Z1nJNziqAfHi70PuxkFYIcIt8aIAxtRE7KVuKp8lSR8pA0J5iOQ==
+  dependencies:
+    "@octokit/core" "^5.0.0"
+    "@octokit/plugin-paginate-rest" "^9.0.0"
+    "@octokit/plugin-request-log" "^4.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "^10.0.0"
+
+"@octokit/types@^12.0.0", "@octokit/types@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-12.1.1.tgz#376726d8435625b3a1b6fcd8cd3e1b03ade939dc"
+  integrity sha512-qnJTldJ1NyGT5MTsCg/Zi+y2IFHZ1Jo5+njNCjJ9FcainV7LjuHgmB697kA0g4MjZeDAJsM3B45iqCVsCLVFZg==
+  dependencies:
+    "@octokit/openapi-types" "^19.0.2"
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz"
@@ -91,6 +188,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+before-after-hook@^2.2.0:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.3.tgz#c51e809c81a4e354084422b9b26bad88249c517c"
+  integrity sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -242,6 +344,11 @@ debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+deprecation@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
+  integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -417,6 +524,11 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
@@ -587,6 +699,13 @@ object-inspect@^1.12.2:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
+once@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
 
 onetime@^5.1.0:
   version "5.1.2"
@@ -907,6 +1026,11 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   resolved "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz"
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
+universal-user-agent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
+  integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz"
@@ -939,6 +1063,11 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 y18n@^5.0.5:
   version "5.0.5"


### PR DESCRIPTION
As a follow-up to https://github.com/pulumi/pulumi-hugo-private/issues/112, this change does a couple of things, both aimed at reducing the likelihood of the merge conflicts we see when running the `push` and `upstream-sync` workflows:

* Removes the `hugo mod get` that attempts to pull in the latest from pulumi/registry (along with the reference to that module in the Hugo config). There's no technical need to import this module, particularly since the Registry now runs as a completely separate app; the only purpose it serves is to show something at /registry in PR previews and in local development. (Removing this therefore means navigating to /registry in PR previews and in local development will 404, but I'm assuming that won't cause too much pain for contributors to this repo.)
* Adds a step to wait for any in-progress `push` workflows to finish before running the current one. This will ensure that `push` workflows always complete in the order in which they're merged (so that multiple merges that happen in proximity won't run into the same class of problem by producing CSS and JS bundles out of sequence). This is the same script we use in pulumi/docs for this purpose.

