### PR TITLE
Update gcp getting started guide go import to v7

### DIFF
--- a/themes/default/content/docs/clouds/gcp/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/review-project.md
@@ -103,7 +103,7 @@ pulumi.export("bucket_name", bucket.url)
 package main
 
 import (
-	"github.com/pulumi/pulumi-gcp/sdk/v6/go/gcp/storage"
+	"github.com/pulumi/pulumi-gcp/sdk/v7/go/gcp/storage"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 


### PR DESCRIPTION
## Description

Update gcp getting started guide go import to v7

Part of (https://github.com/pulumi/pulumi-gcp/issues/1243)
