### PR TITLE
Fix docs removing imports section

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/esc/get-started/_index.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/get-started/_index.md
@@ -499,11 +499,10 @@ Then return to your `Pulumi.<your-stack-name>.yaml` file and update it to import
 
 ```yaml
 environment:
-  imports:
   - app-env-dev
 ```
 
-Make sure to update the value in the `imports` section with the values of your own environment before saving the file.
+Make sure to update the value in the `environment` section with the name of your own environment before saving the file.
 
 Then run the `pulumi up` command.
 


### PR DESCRIPTION
## Description
Remove `imports:` from docs which was deprecated before shortly the launch of Pulumi ESC.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
