### PR TITLE
Fix typo: Referencing an(d) environment

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/esc/environments.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/environments.md
@@ -444,7 +444,7 @@ values:
     paymentsApiKey: ${secrets.paymentApiKey}
 ```
 
-### Referencing and environment in your Pulumi stack config.
+### Referencing an environment in your Pulumi stack config.
 
 In order to reference an environment, we just add a new `environment:` section at the top level of our stack yaml file.
 


### PR DESCRIPTION
## Description
Fix typo!

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
