### PR TITLE
Remove erroneous reference to .NET 3.1 and 5.

### DIFF
--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -23,7 +23,7 @@ You can use your favorite .NET tools &mdash; such as editors, package managers, 
 
 ## Prerequisites
 
-Before using Pulumi for .NET, you will need to install both Pulumi and .NET Core SDK 3.1, .NET 5, or .NET 6 (recommended).
+Before using Pulumi for .NET, you will need to install both Pulumi and a [supported .NET version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
 
 1. [Install Pulumi](/docs/install/)
 1. [Install .NET SDK](https://dotnet.microsoft.com/download)


### PR DESCRIPTION
## Description

We don't support .NET 3.1 and 5 anymore (EoL) but the install instructions still referred to it.

Rather than having to keep coming back and updating this number I've just removed the version text entirely, the link to the .NET support page clearly shows which versions are considers "active".

Fixes #3553.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
