### PR TITLE
Add ESC as a next step to the AWS, Azure and GCP guides

### DIFF
--- a/themes/default/content/docs/clouds/aws/get-started/next-steps.md
+++ b/themes/default/content/docs/clouds/aws/get-started/next-steps.md
@@ -17,26 +17,34 @@ aliases:
 
 Congrats! You've deployed your first project on AWS with Pulumi. Here are some next steps, depending on your learning style.
 
-## Learn Pulumi
+## Try a tutorial
 
-Dive into Learn Pulumi for a comprehensive walkthrough of key Pulumi concepts in the context of a real-life application.
+Let our AWS tutorials guide you through key Pulumi concepts.
 
-{{< get-started-next-step path="/learn/pulumi-fundamentals" label="Learn Pulumi Fundamentals" ref="gs-aws-learn" >}}
+{{< get-started-next-step path="/docs/using-pulumi/" label="Browse tutorials" ref="gs-aws-tutorials" >}}
 
-## How-to Guides
+## Launch a new project with a template
 
-Explore our how-to guides if you're looking for examples of specific architectures or application stacks. These guides are available in all Pulumi languages and cover many common architectures such as [static websites](/registry/packages/aws-native/how-to-guides/aws-native-ts-s3-folder/), [EC2 virtual machines](/registry/packages/aws/how-to-guides/ec2-webserver/), [EKS clusters](/registry/packages/aws/how-to-guides/aws-ts-eks/), [Fargate containers](/registry/packages/aws/how-to-guides/ecs-fargate/), and [serverless applications](/registry/packages/aws/how-to-guides/rest-api/).
+Easily deploy the most common cloud architectures, from [static websites](/templates/static-website/aws/) to [serverless applications](/templates/serverless-application/aws/), [virtual machines](/templates/virtual-machine/aws/), [container services](/templates/container-service/aws/), and [Kubernetes clusters](/templates/kubernetes/aws/).
 
-{{< get-started-next-step path="/registry/packages/aws/how-to-guides" label="Explore How-to Guides" ref="gs-aws-guides" >}}
+{{< get-started-next-step path="/templates/" label="Browse templates" ref="gs-aws-guides" >}}
 
-## How Pulumi Works
+## Dive into the docs
 
-Learn how Pulumi works from its architecture to key concepts, including [stacks](/docs/concepts/stack/), [state](/docs/concepts/state/), [configuration](/docs/concepts/config/), and [secrets](/docs/concepts/secrets/).
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read Documentation" ref="gs-aws-docs" >}}
+{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-aws-docs" >}}
 
-## Blog Posts
+## Try Pulumi ESC (Environments, Secrets, and Configuration)
 
-Read through the latest blog posts about using Pulumi with AWS, including everything from new AWS features and products supported by Pulumi to technical architectures and best practices.
+In this guide, you used [stack configuration](/docs/concepts/config/) and environment variables to configure a single project and stack. Did you know you can also configure multiple Pulumi projects, and even other applications, with [Pulumi ESC](/product/esc/)?
 
-{{< get-started-next-step path="/blog/tag/aws" label="Read the Pulumi Blog" ref="gs-aws-blog" >}}
+Pulumi ESC introduces the concept of _environments_ --- managed collections of static and dynamic settings that you can use to configure any project, stack, application, or service, including with short-lived cloud credentials through OpenID Connect.
+
+{{< get-started-next-step path="/blog/environments-secrets-configurations-management/" label="Learn more about Pulumi ESC" ref="gs-aws-esc" >}}
+
+## Check out the blog
+
+Browse the latest posts on using Pulumi with AWS, including everything from new AWS products and features to technical architectures and best practices.
+
+{{< get-started-next-step path="/blog/tag/aws" label="Browse AWS posts" ref="gs-aws-blog" >}}

--- a/themes/default/content/docs/clouds/azure/get-started/next-steps.md
+++ b/themes/default/content/docs/clouds/azure/get-started/next-steps.md
@@ -15,7 +15,7 @@ aliases:
 - /docs/get-started/azure/next-steps/
 ---
 
-Congrats! You've deployed your first project on Azure with Pulumi. Here are some next steps, depending on your learning style.
+Congrats! You've deployed your first project on Microsoft Azure with Pulumi. Here are some next steps, depending on your learning style.
 
 ## Learn Pulumi
 
@@ -23,20 +23,28 @@ Dive into Learn Pulumi for a comprehensive walkthrough of key Pulumi concepts in
 
 {{< get-started-next-step path="/learn/pulumi-fundamentals" label="Learn Pulumi Fundamentals" ref="gs-azure-learn" >}}
 
-## How-to Guides
+## Launch a new project with a template
 
-Explore our how-to guides if you're looking for examples of specific architectures or application stacks. These guides are available in all Pulumi languages and cover many common architectures such as [static websites](/registry/packages/azure-native/how-to-guides/azure-ts-static-website/), [virtual machines](/registry/packages/azure-native/how-to-guides/azure-ts-webserver/), [AKS clusters](/registry/packages/azure-native/how-to-guides/azure-ts-aks/), [container instances](/registry/packages/azure-native/how-to-guides/azure-ts-aci/), and [functions](/registry/packages/azure-native/how-to-guides/azure-ts-functions/).
+Easily deploy the most common cloud architectures, from [static websites](/templates/static-website/azure/) to [serverless applications](/templates/serverless-application/azure/), [virtual machines](/templates/virtual-machine/azure/), [container services](/templates/container-service/azure/), and [Kubernetes clusters](/templates/kubernetes/azure/).
 
-{{< get-started-next-step path="/registry/packages/azure-native/how-to-guides" label="Explore How-to Guides" ref="gs-azure-guides" >}}
+{{< get-started-next-step path="/templates/" label="Browse templates" ref="gs-azure-guides" >}}
 
-## How Pulumi Works
+## Dive into the docs
 
-Learn how Pulumi works from its architecture to key concepts, including [stacks](/docs/concepts/stack/), [state](/docs/concepts/state/), [configuration](/docs/concepts/config/), and [secrets](/docs/concepts/secrets/).
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read Documentation" ref="gs-azure-docs" >}}
+{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-azure-docs" >}}
 
-## Blog Posts
+## Try Pulumi ESC (Environments, Secrets, and Configuration)
 
-Read through the latest blog posts about using Pulumi with Azure, including everything from new Azure features and products supported by Pulumi to technical architectures and best practices.
+In this guide, you used [stack configuration](/docs/concepts/config/) and environment variables to configure a single project and stack. Did you know you can also configure multiple Pulumi projects, and even other applications, with [Pulumi ESC](/product/esc/)?
 
-{{< get-started-next-step path="/blog/tag/azure" label="Read the Pulumi Blog" ref="gs-azure-blog" >}}
+Pulumi ESC introduces the concept of _environments_ --- managed collections of static and dynamic settings that you can use to configure any project, stack, application, or service, including with short-lived cloud credentials through OpenID Connect.
+
+{{< get-started-next-step path="/blog/environments-secrets-configurations-management/" label="Learn more about Pulumi ESC" ref="gs-azure-esc" >}}
+
+## Check out the blog
+
+Browse the latest posts on using Pulumi with Microsoft Azure, including everything from new Azure products and features to technical architectures and best practices.
+
+{{< get-started-next-step path="/blog/tag/azure" label="Browse Azure posts" ref="gs-azure-blog" >}}

--- a/themes/default/content/docs/clouds/gcp/get-started/next-steps.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/next-steps.md
@@ -23,20 +23,28 @@ Dive into Learn Pulumi for a comprehensive walkthrough of key Pulumi concepts in
 
 {{< get-started-next-step path="/learn/pulumi-fundamentals" label="Learn Pulumi Fundamentals" ref="gs-gcp-learn" >}}
 
-## How-to Guides
+## Launch a new project with a template
 
-Explore our how-to guides if you're looking for examples of specific architectures or application stacks. These guides are available in all Pulumi languages and cover many common architectures such as [GKE clusters](/registry/packages/gcp/how-to-guides/gcp-ts-gke-hello-world/), [Cloud Run containers](/registry/packages/gcp/how-to-guides/gcp-ts-cloudrun/), and [Cloud Function HTTP endpoints](/registry/packages/gcp/how-to-guides/gcp-ts-functions/).
+Easily deploy the most common cloud architectures, from [static websites](/templates/static-website/gcp/) to [serverless applications](/templates/serverless-application/gcp/), [virtual machines](/templates/virtual-machine/gcp/), [container services](/templates/container-service/gcp/), and [Kubernetes clusters](/templates/kubernetes/gcp/).
 
-{{< get-started-next-step path="/registry/packages/gcp/how-to-guides" label="Explore How-to Guides" ref="gs-gcp-guides" >}}
+{{< get-started-next-step path="/templates/" label="Browse templates" ref="gs-gcp-guides" >}}
 
-## How Pulumi Works
+## Dive into the docs
 
-Learn how Pulumi works from its architecture to key concepts, including [stacks](/docs/concepts/stack/), [state](/docs/concepts/state/), [configuration](/docs/concepts/config/), and [secrets](/docs/concepts/secrets/).
+Read more about Pulumi's architecture and foundational concepts in depth, including [projects](/docs/concepts/projects/), [stacks](/docs/concepts/stack/), [configuration](/docs/concepts/config/), [secrets](/docs/concepts/secrets/), [resources](/docs/concepts/resources/), [state](/docs/concepts/state/), and more.
 
-{{< get-started-next-step path="/docs/concepts/" label="Read Documentation" ref="gs-gcp-docs" >}}
+{{< get-started-next-step path="/docs/concepts/" label="Read the docs" ref="gs-gcp-docs" >}}
 
-## Blog Posts
+## Try Pulumi ESC (Environments, Secrets, and Configuration)
 
-Read through the latest blog posts about using Pulumi with Google Cloud, including everything from new Google Cloud features and products supported by Pulumi to technical architectures and best practices.
+In this guide, you used [stack configuration](/docs/concepts/config/) and environment variables to configure a single project and stack. Did you know you can also configure multiple Pulumi projects, and even other applications, with [Pulumi ESC](/product/esc/)?
 
-{{< get-started-next-step path="/blog/tag/google-cloud" label="Read the Pulumi Blog" ref="gs-gcp-blog" >}}
+Pulumi ESC introduces the concept of _environments_ --- managed collections of static and dynamic settings that you can use to configure any project, stack, application, or service, including with short-lived cloud credentials through OpenID Connect.
+
+{{< get-started-next-step path="/blog/environments-secrets-configurations-management/" label="Learn more about Pulumi ESC" ref="gs-gcp-esc" >}}
+
+## Check out the blog
+
+Browse the latest posts on using Pulumi with Google Cloud, including everything from new Google Cloud products and features to technical architectures and best practices.
+
+{{< get-started-next-step path="/blog/tag/gcp" label="Browse Google Cloud posts" ref="gs-gcp-blog" >}}


### PR DESCRIPTION
Mentions ESC at the end of each getting-started guide as a thing to follow up with, and links to the new AWS tutorials instead of Learn, since that's there now.

Also tweaks a few words in the headings and bodies to make them a bit tighter and more engaging (verbs!).

Fixes https://github.com/pulumi/docs/issues/10214.