### PR TITLE
Fix a few broken links

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/deployments/get-started.md
+++ b/themes/default/content/docs/pulumi-cloud/deployments/get-started.md
@@ -219,7 +219,7 @@ Alternatively, you can navigate to `https://app.pulumi.com`, select `Stacks` in 
 
 * Now configure settings specific to your Deployment, such as:
 
-    * [OIDC Connect](/docs/pulumi-cloud/deployments/oidc/)
+    * [OIDC Connect](/docs/pulumi-cloud/oidc/)
     * [Environment Variables](/docs/pulumi-cloud/deployments/reference/#environment-variables)
 
 (See [Using Deployments](/docs/pulumi-cloud/deployments/reference/) for more information about all of the available settings.)

--- a/themes/default/content/docs/pulumi-cloud/esc/get-started/_index.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/get-started/_index.md
@@ -29,7 +29,7 @@ Pulumi ESC is a service of Pulumi Cloud that can be used with or without Pulumi 
 {{< /notes >}}
 - An [Amazon Web Services](https://aws.amazon.com/) account
 - The [AWS CLI](https://aws.amazon.com/cli/)
-- An [OIDC provider created for Pulumi](/docs/pulumi-cloud/deployments/oidc/aws/) in AWS
+- An [OIDC provider created for Pulumi](/docs/pulumi-cloud/oidc/aws/) in AWS
   - Note that when defining the  `Subject Identifier`, the format for environments is `pulumi:environments:org:<pulumi-org>:env:<environment-name>`
 - Python 3.7 or higher installed
 
@@ -244,7 +244,7 @@ $ esc login
 Manage your Pulumi ESC environments by logging in.
 Run `esc --help` for alternative login options.
 Enter your access token from https://app.pulumi.com/account/tokens
-    or hit <ENTER> to log in using your browser                   :  
+    or hit <ENTER> to log in using your browser                   :
 Logged in to https://api.pulumi.com/ as your-pulumi-org (https://app.pulumi.com/your-pulumi-org)
 ```
 

--- a/themes/default/content/docs/pulumi-cloud/insights/import.md
+++ b/themes/default/content/docs/pulumi-cloud/insights/import.md
@@ -89,7 +89,7 @@ $ pulumi up --skip-preview --show-reads # run the Kubernetes cloud import progra
 
 Cloud Import is available as a fully managed experience within the Pulumi Cloud. The feature is currently in private preview and you can request access via [the waitlist](/product/private-previews/). Once you have access, you can click on the `Cloud Import` tab to get started.
 
-This managed experience uses [Pulumi Deployments](/docs/pulumi-cloud/deployments/) to run the Cloud Import program on your behalf. Within the Pulumi Cloud you can fill out a simple form that takes in your [OIDC configuration](/docs/pulumi-cloud/deployments/oidc/) to use a secure temporary credential workflow to connect to your cloud account. This will create the following:
+This managed experience uses [Pulumi Deployments](/docs/pulumi-cloud/deployments/) to run the Cloud Import program on your behalf. Within the Pulumi Cloud you can fill out a simple form that takes in your [OIDC configuration](/docs/pulumi-cloud/oidc/) to use a secure temporary credential workflow to connect to your cloud account. This will create the following:
 
 1. A Pulumi stack to store the `external` resources from your cloud account.
 2. Deployment Settings for that stack that contain all configuration necessary to run the import program against your cloud account.
@@ -99,13 +99,13 @@ This managed experience uses [Pulumi Deployments](/docs/pulumi-cloud/deployments
 
 ### AWS
 
-Cloud Import for AWS within the Pulumi Cloud requires that you configure OIDC to enable a secure, temporary credential exchange workflow. See [the guide on configuring OIDC for AWS with Pulumi Deployments](/docs/pulumi-cloud/deployments/oidc/aws/) for more details.
+Cloud Import for AWS within the Pulumi Cloud requires that you configure OIDC to enable a secure, temporary credential exchange workflow. See [the guide on configuring OIDC for AWS with Pulumi Deployments](/docs/pulumi-cloud/oidc/aws/) for more details.
 
 !["The Cloud Import for AWS configuration form within the Pulumi Cloud"](../cloud-import-aws.png)
 
 ### Azure
 
-Cloud Import for Azure within the Pulumi Cloud requires that you configure OIDC to enable a secure, temporary credential exchange workflow. See [the guide on configuring OIDC for Azure with Pulumi Deployments](/docs/pulumi-cloud/deployments/oidc/azure/) for more details.
+Cloud Import for Azure within the Pulumi Cloud requires that you configure OIDC to enable a secure, temporary credential exchange workflow. See [the guide on configuring OIDC for Azure with Pulumi Deployments](/docs/pulumi-cloud/oidc/azure/) for more details.
 
 !["The Cloud Import for Azure configuration form within the Pulumi Cloud."](../cloud-import-azure.png)
 

--- a/themes/default/content/docs/using-pulumi/define-and-provision-resources/index.md
+++ b/themes/default/content/docs/using-pulumi/define-and-provision-resources/index.md
@@ -259,6 +259,6 @@ In this tutorial, you made an EC2 instance configured as an Nginx webserver and 
 
 To learn more about creating resources in Pulumi, take a look at the following resources:
 
-- Learn more about stack outputs and references in the [Stack Ouputs and References](/docs/tutorials/stack-outputs-and-references/) tutorial.
+- Learn more about stack outputs and references in the [Stack Outputs and References](/docs/using-pulumi/stack-outputs-and-references/) tutorial.
 - Learn more about inputs and outputs in the [Inputs and Outputs](/docs/concepts/inputs-outputs/) documentation.
 - Learn more about [resource names](/docs/concepts/resources/names/), [options](/docs/concepts/options/), and [providers](/docs/concepts/resources/providers/) in the Pulumi documentation.

--- a/themes/default/content/docs/using-pulumi/stack-outputs-and-references/index.md
+++ b/themes/default/content/docs/using-pulumi/stack-outputs-and-references/index.md
@@ -560,5 +560,5 @@ You exported Lambda properties into stack outputs, and referenced those outputs 
 
 To learn more about creating and managing resources in Pulumi, take a look at the following resources:
 
-- Learn more about [stacks ouputs and references](/docs/concepts/stack/#stackreferences) in the Pulumi documentation.
+- Learn more about [stack outputs and references](/docs/concepts/stack/#stackreferences) in the Pulumi documentation.
 - Learn more about [Pulumi inputs and outputs](/docs/concepts/inputs-outputs/) in the Pulumi documentation.


### PR DESCRIPTION
Following up from https://github.com/pulumi/pulumi-hugo/pull/3554, this fixes up a few links that showed up in the most recent crawl:

- /docs/pulumi-cloud/deployments/get-started/ → https://www.pulumi.com/docs/pulumi-cloud/deployments/oidc/ (HTTP_403)
- /docs/pulumi-cloud/insights/import/ → https://www.pulumi.com/docs/pulumi-cloud/deployments/oidc/ (HTTP_403)
- /docs/using-pulumi/define-and-provision-resources/ → https://www.pulumi.com/docs/tutorials/stack-outputs-and-references/ (HTTP_404)

Also fixes a couple lil' typos.