### PR TITLE
Fix a bug in the ECS prededence rules docs

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/esc/environments.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/environments.md
@@ -586,8 +586,8 @@ values:
 ```yaml
 # environment-c
 imports:
-  - environment-b
   - environment-a
+  - environment-b
 values:
   foo: qux
   pulumiConfig:


### PR DESCRIPTION
Accidentally copy-pasted the wrong thing.
