### PR TITLE
Removed 'Deployments' from meta description

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/aws.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/aws.md
@@ -1,6 +1,6 @@
 ---
 title_tag: Configure OpenID Connect for AWS | OIDC
-meta_desc: This page describes how to configure OIDC token exchange in AWS for use with Pulumi Deployments
+meta_desc: This page describes how to configure OIDC token exchange in AWS for use with Pulumi Cloud
 title: AWS
 h1: Configuring OpenID Connect for AWS
 meta_image: /images/docs/meta-images/docs-meta.png


### PR DESCRIPTION
## Description

This PR removes the word "Deployments" from the meta description.