### PR TITLE
Making the 1Password workshop on demand

### DIFF
--- a/themes/default/content/resources/getting-started-with-1password-and-pulumi/index.md
+++ b/themes/default/content/resources/getting-started-with-1password-and-pulumi/index.md
@@ -8,7 +8,7 @@ meta_image: "/images/resources/1password-pulumi-jilian.png"
 featured: false
 
 # If the video is pre-recorded or live.
-pre_recorded: false
+pre_recorded: true
 
 # If the video is part of the PulumiTV series. Setting this value to true will list the video in the "PulumiTV" section.
 pulumi_tv: false
@@ -21,7 +21,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars
@@ -49,7 +49,7 @@ main:
     # Webinar title.
     title: "Getting Started with 1Password and Pulumi"
     # URL for embedding a URL for ungated webinars.
-    youtube_url:
+    youtube_url: "https://www.youtube.com/embed/K_02cyfA5gE?si=QksmdY81T6Qjb2vO?rel=0"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2023-09-12T08:00:00-07:00
     # Duration of the webinar.
@@ -67,7 +67,6 @@ main:
     presenters:
         - name: Ringo De Smet
           role: Customer Experience Architect, Pulumi
-
         - name: Jillian Morgan
           role: Senior Software Engineer, 1Password
 


### PR DESCRIPTION
## Description

Sales get a lot of requests about this workshop.
I am adding it to  Resources as there is clearly a demand for it.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
