### PR TITLE
Fix a few issues with the Vault OIDC docs

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/vault/_index.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/vault/_index.md
@@ -10,7 +10,7 @@ menu:
         weight: 1
 ---
 
-This document outlines the steps required configured to use Pulumi to use OpenID Connect to authenticate with Vault. This is accomplished using [Vault's JWT authentication method](https://developer.hashicorp.com/vault/docs/auth/jwt#jwt-authentication) to assume a role. Access to the role is authorized using a [Vault policy](https://developer.hashicorp.com/vault/docs/concepts/policies) that validates the contents of the OIDC token issued by Pulumi Cloud.
+This document outlines the steps required to use Pulumi with OpenID Connect to authenticate with Vault. This is accomplished using [Vault's JWT authentication method](https://developer.hashicorp.com/vault/docs/auth/jwt#jwt-authentication) to assume a role. Access to the role is authorized using a [Vault policy](https://developer.hashicorp.com/vault/docs/concepts/policies) that validates the contents of the OIDC token issued by Pulumi Cloud.
 
 {{% notes "info" %}}
 The `namespaces` functionality of Vault is not currently supported. More specifically, this configuration will only work for the `root` namespace. This means that this configuration will only work with Vault OSS at this time (Vault HCP and Enterprise are not supported).
@@ -123,24 +123,26 @@ $ vault write auth/jwt/role/<role-name> -<<EOF
 EOF
 ```
 
-## Configure OIDC via the Pulumi Console
+## Configure OIDC via the Pulumi Cloud console
 
 ### Pulumi Deployments
 
 You can pull vault secrets from Pulumi ESC in Deployments. To set this up:
 
   1. Follow the steps under [Pulumi ESC](#pulumi-esc) below to create an environment with vault secrets.
-  2. Follow the [Getting Started](../esc/get-started/) guide and replace environment names to reference the environment created in Step 1.
+  2. Follow the [Getting Started](/docs/pulumi-cloud/esc/get-started/) guide and replace environment names to reference the environment created in Step 1.
 
 ### Pulumi ESC
 
-To configure OIDC for Pulumi ESC, create a new environment in the [Pulumi Console](https://app.pulumi.com/). Make sure that you have the correct organization selected in the left-hand navigation menu. Then:
+To configure OIDC for Pulumi ESC, create a new environment in the [Pulumi Cloud console](https://app.pulumi.com/). Make sure that you have the correct organization selected in the left-hand navigation menu. Then:
 
   1. Click the **Environments** link.
   2. Click the **Create environment** button.
   3. Provide a name for your environment.
   4. Click the  **Create environment** button.
-    {{< video title="Creating a new Pulumi ESC environment" src="../aws/create-new-environment.mp4" autoplay="true" loop="true" >}}
+
+      {{< video title="Creating a new Pulumi ESC environment" src="/docs/pulumi-cloud/oidc/aws/create-new-environment.mp4" autoplay="true" loop="true" >}}
+
   5. You will be presented with a split-pane editor view. Delete the default placeholder content in the editor and replace it with the following code:
 
       ```yaml
@@ -162,10 +164,10 @@ To configure OIDC for Pulumi ESC, create a new environment in the [Pulumi Consol
   6. Replace `<your-vault-url>`, `<your-role-name>`, and `<path-to-secret>` with the values from the previous steps.
   7. Scroll to the bottom of the page and click **Save**.
 
-  ![Vault environment config](./vault-environment-config.png)
+      ![Vault environment config](./vault-environment-config.png)
 
 {{% notes "info" %}}
-If you configured the vault jwt auth method to use a different [mount path](https://developer.hashicorp.com/vault/docs/auth#enabling-disabling-auth-methods) than `jwt`, you will need to specify that path using the `mount` option of the [vault-login](../esc/providers/vault-login.md) provider.
+If you configured the Vault JWT auth method to use a different [mount path](https://developer.hashicorp.com/vault/docs/auth#enabling-disabling-auth-methods) than `jwt`, you will need to specify that path using the `mount` option of the [vault-login](/docs/pulumi-cloud/esc/providers/vault-login/) provider.
 {{% /notes %}}
 
 You can validate that your configuration is working by running either of the following:
@@ -203,4 +205,4 @@ $ esc open <my-org>/<my-environment>
 }
 ```
 
-To learn more about how to set up and use the various providers in Pulumi ESC, please refer to the [relevant Pulumi documentation](/docs/pulumi-cloud/esc/providers/)
+To learn more about how to set up and use the various providers in Pulumi ESC, please refer to the [Pulumi ESC providers documentation](/docs/pulumi-cloud/esc/providers/).


### PR DESCRIPTION
This changes makes a few fixes to this page:

* Fixes some broken links
* Moves `vault.md` into the `vault` folder so it can live alongside the images that go with it
* Makes all links root-relative
* Fixes a few little typos
* Corrects the product name (Pulumi Console -> Pulumi Cloud console)
