### PR TITLE
Fix missing reference to 'homepage' variable

### DIFF
--- a/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
@@ -382,29 +382,34 @@ var indexHtml = new BucketObject("index.html", BucketObjectArgs.builder()
 {{% choosable language yaml %}}
 
 ```yaml
-ownership-controls:
-  type: aws:s3:BucketOwnershipControls
-  properties:
-    bucket: ${my-bucket.id}
-    rule:
-      objectOwnership: ObjectWriter
 
-public-access-block:
-  type: aws:s3:BucketPublicAccessBlock
-  properties:
-    bucket: ${my-bucket.id}
-    blockPublicAcls: false
+resources:
+  # ...
 
-index.html:
-  type: aws:s3:BucketObject
-  properties:
-    bucket: ${my-bucket.id}
-    source: ${homepage}
-    contentType: text/html
-    acl: public-read
-  options:
-    dependsOn:
-      - ${public-access-block}
+  ownership-controls:
+    type: aws:s3:BucketOwnershipControls
+    properties:
+      bucket: ${my-bucket.id}
+      rule:
+        objectOwnership: ObjectWriter
+
+  public-access-block:
+    type: aws:s3:BucketPublicAccessBlock
+    properties:
+      bucket: ${my-bucket.id}
+      blockPublicAcls: false
+
+  index.html:
+    type: aws:s3:BucketObject
+    properties:
+      bucket: ${my-bucket.id}
+      source:
+        fn::fileAsset: ./index.html
+      contentType: text/html
+      acl: public-read
+    options:
+      dependsOn:
+        - ${public-access-block}
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
This change fixes a bug in the YAML path that references a non-existent `homepage` variable.

Fixes #3617. 

The automated tests didn't catch this because while the code in the getting-started repo was correct, a portion had been omitted (the `variables` block) when it was copied into the guide.

Related PR to update the automated tests to match what's included here: https://github.com/pulumi/getting-started/pull/12 