### PR TITLE
update AWS OIDC docs to highlight <yaml> issue when using environment in pulumi IaC

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/aws.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/aws.md
@@ -86,6 +86,18 @@ In the following example, the role may only be assumed by the `development` envi
 }
 ```
 
+{{< notes type="warning" >}}
+
+If you are integrating Pulumi ESC with Pulumi IaC, using the specific name of the ESC environment in the subject identifier will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the value of the subject identifier that is sent to AWS from Pulumi.
+
+The steps in this guide will work for Pulumi ESC if you use the following syntax instead:
+
+`pulumi:environments:org:contoso:env:<yaml>`
+
+Make sure to replace `contoso` with the name of your Pulumi organization and use the literal value of `<yaml>` as shown above.
+
+{{< /notes >}}
+
 ## Configure OIDC via the Pulumi Console
 
 ### Pulumi Deployments


### PR DESCRIPTION
## Description

As mentioned in
- pulumi/pulumi#14509 

both AWS and Azure currently send a subject claim ending in `<yaml>` rather then the actual environment name being used when utilising environments in IaC config. 

This adds a warning until this is resolved.

## Checklist:

- [X] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
