### PR TITLE
Adding warning note about <yaml> sub to GCP page

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
@@ -84,7 +84,7 @@ You can learn more about setting up OIDC for Pulumi ESC by referring to the [rel
 
 {{< notes type="warning" >}}
 
-If you are integrating Pulumi ESC with Pulumi IaC, using the specific name of the ESC environment in the subject identifier will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the value of the subject identifier that is sent to AWS from Pulumi.
+If you are integrating Pulumi ESC with Pulumi IaC, using the specific name of the ESC environment in the subject identifier will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the value of the subject identifier that is sent to the provider from Pulumi.
 
 The steps in this guide will work for Pulumi ESC if you use the following syntax instead:
 

--- a/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
@@ -82,6 +82,18 @@ The below is an example of a valid subject claim for the `development` environme
 
 You can learn more about setting up OIDC for Pulumi ESC by referring to the [relevant Pulumi documentation](/docs/pulumi-cloud/esc/providers/#setting-up-oidc).
 
+{{< notes type="warning" >}}
+
+If you are integrating Pulumi ESC with Pulumi IaC, using the specific name of the ESC environment in the subject identifier will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the value of the subject identifier that is sent to AWS from Pulumi.
+
+The steps in this guide will work for Pulumi ESC if you use the following syntax instead:
+
+`pulumi:environments:org:contoso:env:<yaml>`
+
+Make sure to replace `contoso` with the name of your Pulumi organization and use the literal value of `<yaml>` as shown above.
+
+{{< /notes >}}
+
 ## Configure OIDC in the Pulumi Console
 
 ### Pulumi Deployments


### PR DESCRIPTION
## Description

Prompted by [this PR](https://github.com/pulumi/pulumi-hugo/pull/3637), I am adding the warning note to the GCP OIDC page about the [known `<yaml>` sub ID bug](https://github.com/pulumi/pulumi/issues/14509). This was originally noticed with Azure, but it seems to be a Pulumi ESC thing in general.
