### PR TITLE
docs: fix issue in javascript example

### DIFF
--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -42,7 +42,7 @@ Finally, the server's resulting IP address and DNS name are exported as stack ou
 {{% choosable language javascript %}}
 
 ```javascript
-"user strict";
+"use strict";
 const pulumi = require("@pulumi/pulumi");
 const aws = require("@pulumi/aws");
 


### PR DESCRIPTION
Fix issue in javascript example on the "Pulumi" concepts page.

## Description
In the javascript code, the use strict mode was written as "user mode" and it was fixed.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
