### PR TITLE
Change cloud engineering to platform engineering

### DIFF
--- a/themes/default/layouts/partials/header.html
+++ b/themes/default/layouts/partials/header.html
@@ -204,10 +204,10 @@
                                         </li>
                                         <li>
                                             <div class="list-title">
-                                                <a href="/cloud-engineering/">
+                                                <a href="/product/internal-developer-platforms/">
                                                     <i class="fas fa-book-open fa-fw"></i>
-                                                    Cloud Engineering
-                                                    <div class="list-sub-title">Learn best practices for infrastructure as code</div>
+                                                    Platform Engineering
+                                                    <div class="list-sub-title">Build and scale internal developer platforms</div>
                                                 </a>
                                             </div>
                                         </li>
@@ -402,7 +402,7 @@
                                 <hr />
                                 <div class="mobile-menu-subitems-why-pulumi">
                                     <li>
-                                        <a href="/cloud-engineering/"> <i class="fas fa-book-open fa-fw"></i> Cloud Engineering </a>
+                                        <a href="/product/internal-developer-platforms/"> <i class="fas fa-book-open fa-fw"></i> Platform Engineering </a>
                                     </li>
                                     <li>
                                         <a href="/solutions/"> <i class="fas fa-lightbulb fa-fw"></i> Solutions </a>


### PR DESCRIPTION
## Description

Update the menu from "Cloud Engineering" to "Platform Engineering"

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
