### PR TITLE
Remove TypeScript only note

### DIFF
--- a/themes/default/content/docs/clouds/aws/guides/lambda.md
+++ b/themes/default/content/docs/clouds/aws/guides/lambda.md
@@ -25,10 +25,6 @@ for virtually any type of application or backend service with zero administratio
 takes care of everything required to run and scale your code with high availability. You can set up your code to
 automatically trigger from other AWS services or call it directly from any web or mobile app.
 
-{{% notes type="info" %}}
-This functionality is available in TypeScript only and as part of the [AWS Classic provider](/registry/packages/aws/).
-{{% /notes %}}
-
 ## Overview
 
 Pulumi Crosswalk for AWS brings a more natural, and easier to use, way of building serverless applications using


### PR DESCRIPTION
## Description

Remove the note saying Pulumi Crosswalk is only available for TypeScript runtime

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
