### PR TITLE
Fix linting errors

### DIFF
--- a/themes/default/content/what-is/what-is-aws-secrets-manager.md
+++ b/themes/default/content/what-is/what-is-aws-secrets-manager.md
@@ -7,7 +7,7 @@ type: what-is
 page_title: "What is AWS Secrets Manager?"
 ---
 
-Amazon Web Services (AWS) is a leader in cloud computing, transforming the way organizations manage their digital infrastructure. A critical aspect of this landscape is the management of sensitive data, commonly known as "[secrets](/what-is/what-is-secrets-management/)". AWS Secrets Manager is a service designed for the secure handling of these secrets, offering tools for storing, accessing, and managing confidential information in the cloud. 
+Amazon Web Services (AWS) is a leader in cloud computing, transforming the way organizations manage their digital infrastructure. A critical aspect of this landscape is the management of sensitive data, commonly known as "[secrets](/what-is/what-is-secrets-management/)". AWS Secrets Manager is a service designed for the secure handling of these secrets, offering tools for storing, accessing, and managing confidential information in the cloud.
 
 ## What is AWS Secrets Manager?
 
@@ -137,6 +137,7 @@ const secretVersion = new aws.secretsmanager.SecretVersion("secretVersion", {
 // Export secret ID (in this case the ARN)
 export const secretId = secret.id;
 ```
+
 {{% /choosable %}}
 
 {{% choosable language python %}}
@@ -160,6 +161,7 @@ secret_version = secretsmanager.SecretVersion("secret_version",
 # Export secret ID (in this case the ARN)
 pulumi.export("secret_id", secret.id)
 ```
+
 {{% /choosable %}}
 
 {{% choosable language go %}}
@@ -196,6 +198,7 @@ func main() {
 	})
 }
 ```
+
 {{% /choosable %}}
 
 {{% choosable language csharp %}}
@@ -228,6 +231,7 @@ class MyStack : Stack
     public Output<string> SecretId { get; set; }
 }
 ```
+
 {{% /choosable %}}
 
 - **Advanced secrets management**: Explore Pulumi’s detailed guides on the centralized management of secrets in cloud applications, particularly with Pulumi ESC (Environments, Secrets, and Configurations). For more information, visit the [Pulumi ESC documentation for the AWS Secrets provider](/docs/pulumi-cloud/esc/providers/aws-secrets/).

--- a/themes/default/content/what-is/what-is-azure-key-vault.md
+++ b/themes/default/content/what-is/what-is-azure-key-vault.md
@@ -66,7 +66,6 @@ $ az group create --location westus --name MyResourceGroup
 }
 ```
 
-
 You can create a Key Vault using the `az keyvault create` command. Note that Key Vault names are [globally unique](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates), so you will need to replace the value of `<YourVaultName>` below with a unique name for your resource:
 
 ```bash


### PR DESCRIPTION
## Description

This PR corrects some linting errors in the AWS Secrets Manager and Azure Key Vault SEO pages. This will unblock merging the serverless SEO page.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
