### PR TITLE
Fix example test workflow

### DIFF
--- a/.github/workflows/scheduled-test.yml
+++ b/.github/workflows/scheduled-test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: "Scheduled Jobs: Run Tests"
 on:
   schedule:
     - cron: "0 8 * * *"
@@ -6,10 +6,8 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  PULUMI_TEST_OWNER: "moolumi"
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
   AWS_REGION: "us-west-2"
-  PULUMI_API: https://api.pulumi-staging.io
 
 jobs:
   test:


### PR DESCRIPTION
The access token we've applied to the repo doesn't work against the staging API, so removing that, and fixing the name up to align with other scheduled ones.