### PR TITLE
fixing broken gitlab links

### DIFF
--- a/themes/default/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
+++ b/themes/default/content/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/index.md
@@ -371,7 +371,7 @@ $ pulumi up
 GitLab pipelines are configured using `.gitlab-ci.yml` files in the root
 of each repository. GitLab Silver and above is capable of [running
 pipelines that cross project
-boundaries](https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#passing-variables-to-a-downstream-pipeline),
+boundaries](https://docs.gitlab.com/ee/ci/pipelines/downstream_pipelines.html),
 so we will be using that to construct our pipeline.
 
 All three `.gitlab-ci.yml` files that we use are very similar in

--- a/themes/default/content/blog/coronavirus-plan/index.md
+++ b/themes/default/content/blog/coronavirus-plan/index.md
@@ -26,7 +26,7 @@ Here are some of the concrete steps we have taken.
 
 The Pulumi team is fortunate enough to have been remote-friendly since our inception, with many employees already outside of our Seattle HQ, including international employees who are ready to help our customers. Over 2 weeks ago, we made the quick decision to move to 100% remote temporarily so that employees are safe and to support social distancing initiatives.
 
-This shift ensures we are doing our utmost to support the containment of the disease spreading. Moving from remote-friendly to all-remote has required some changes, however, our own team has felt that it has overall pushed us to improve communication and knowledge sharing. [GitLab’s all-remote guide](https://about.gitlab.com/company/culture/all-remote/) has been very helpful in this transition.
+This shift ensures we are doing our utmost to support the containment of the disease spreading. Moving from remote-friendly to all-remote has required some changes, however, our own team has felt that it has overall pushed us to improve communication and knowledge sharing. [GitLab’s all-remote guide](https://handbook.gitlab.com/handbook/company/culture/all-remote/) has been very helpful in this transition.
 
 ## Software as a service continuity
 

--- a/themes/default/content/blog/gitlab-project-integration/index.md
+++ b/themes/default/content/blog/gitlab-project-integration/index.md
@@ -15,7 +15,7 @@ with confidence.
 
 ## New To Pulumi and GitLab CI/CD?
 
-GitLab's [merge request pipelines](https://docs.gitlab.com/ee/ci/merge_request_pipelines/) runs a CI/CD workflow for building and testing your software.
+GitLab's [merge request pipelines](https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html) runs a CI/CD workflow for building and testing your software.
 Pulumi makes a great addition to it, by allowing you to preview any infrastructure changes as part of your merge request flow.
 
 Using the merge request pipeline feature with Pulumi can validate the changes to your infrastructure before they are applied.

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-app.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-app.md
@@ -29,7 +29,7 @@ To enable the integration with your GitLab project, you will need to ensure you 
   * After you add the organization, ensure that it uses GitLab [as its identity provider](/docs/pulumi-cloud/organizations#changing-identity-providers).
 
 {{% notes type="warning" %}}
-This feature is currently not compatible with GitLab's [pipelines for merged results](https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html).
+This feature is currently not compatible with GitLab's [pipelines for merged results](https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html).
 See the [GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/350086) for details as to why.
 {{% /notes %}}
 

--- a/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
+++ b/themes/default/content/docs/using-pulumi/continuous-delivery/gitlab-ci.md
@@ -65,7 +65,7 @@ to set and protect environment variables in GitLab by referencing their [variabl
 In order to prevent abuse of protected resources as well as other sensitive information used
 by your repository, GitLab has the concept of [Protected Branches and Tags](https://gitlab.com/help/user/project/protected_branches.md).
 
-Your GitLab repository's `main` or `master` branch is is the only branch that is created as a protected branch by default. If you are running Pulumi CLI commands from any branch other than the `main | master` branch,
+Your GitLab repository's `main` or `master` branch is the only branch that is created as a protected branch by default. If you are running Pulumi CLI commands from any branch other than the `main | master` branch,
 you are likely to run into a login error. This is due to the `PULUMI_ACCESS_TOKEN` environment variable only being accessible by protected branches and tags.
 
 You can fix this by configuring branch protection using [wildcard rules](https://docs.gitlab.com/ee/user/project/protected_branches.html#protect-multiple-branches-with-wildcard-rules). Doing this will
@@ -73,7 +73,7 @@ allow any branches with names that match this rule the ability to access the sec
 
 ## Merge Request Builds
 
-GitLab has the ability to restrict jobs to run only on [merge requests](https://docs.gitlab.com/ee/ci/merge_request_pipelines/). This is done by adding the following configuration to your GitLab pipeline config file:
+GitLab has the ability to restrict jobs to run only on [merge requests](https://docs.gitlab.com/ee/ci/pipelines/merge_request_pipelines.html). This is done by adding the following configuration to your GitLab pipeline config file:
 
 ```
 only:


### PR DESCRIPTION
## Description
:link: [/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/](https://www.pulumi.com/blog/continuous-delivery-with-gitlab-and-pulumi-on-amazon-eks/) → https://docs.gitlab.com/ee/ci/multi_project_pipelines.html#passing-variables-to-a-downstream-pipeline (HTTP_404)
:link: [/blog/coronavirus-plan/](https://www.pulumi.com/blog/coronavirus-plan/) → https://about.gitlab.com/company/culture/all-remote/ (HTTP_404)
:link: [/blog/gitlab-project-integration/](https://www.pulumi.com/blog/gitlab-project-integration/) → https://docs.gitlab.com/ee/ci/merge_request_pipelines/ (HTTP_404)
:link: [/docs/using-pulumi/continuous-delivery/gitlab-app/](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/gitlab-app/) → https://docs.gitlab.com/ee/ci/pipelines/pipelines_for_merged_results.html (HTTP_404)
:link: [/docs/using-pulumi/continuous-delivery/gitlab-ci/](https://www.pulumi.com/docs/using-pulumi/continuous-delivery/gitlab-ci/) → https://docs.gitlab.com/ee/ci/merge_request_pipelines/ (HTTP_404)
## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
