### PR TITLE
Set Go version to 1.20 to align with currently supported

### DIFF
--- a/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
+++ b/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
@@ -1,6 +1,6 @@
 module aws-eks-cluster-go
 
-go 1.21
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.3.0

--- a/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-ecr-eks-deployment-service-yaml
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.2.0

--- a/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
@@ -1,8 +1,6 @@
 module repo-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.2.0

--- a/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-ecr-repository-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.3.0

--- a/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-elb-multi-listener-redirect-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.9.0

--- a/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-elb-private-subnet-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.3.0

--- a/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-elb-vpc-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.3.0

--- a/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
@@ -1,8 +1,6 @@
 module myproject
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.3.0

--- a/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-load-balanced-ec2-instances-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.9.0

--- a/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.10.0

--- a/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.10.0

--- a/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
@@ -1,8 +1,6 @@
 module awsx-vpc-fargate-service-yaml
 
-go 1.21
-
-toolchain go1.21.4
+go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.10.0


### PR DESCRIPTION
Examples are all currently written for Go 1.20, and this is what we run in CI as well (as we currently support 1.20 and 1.21), so this change sets all `go.mod` files to use that.

Fixes https://github.com/pulumi/pulumi-hugo/issues/3702.