### PR TITLE
[project-file] add newly supported template fields

### DIFF
--- a/themes/default/content/docs/concepts/projects/project-file.md
+++ b/themes/default/content/docs/concepts/projects/project-file.md
@@ -157,7 +157,7 @@ Schemas are only valid for project property keys. For setting the value of a pro
 
 | Name | Required | Description |
 | - | - | - |
-| `displayName` | optional | A user-friendly name for the template. |
+| `displayName` | optional | A user-friendly name for the template. This should follow `Title Case` format and be succinct. |
 | `description` | optional | Description of the template. |
 | `config` | required | Config to request when using this template with `pulumi new`. |
 | `metadata` | optional | A map of user-defined tags to attach to the template. |

--- a/themes/default/content/docs/concepts/projects/project-file.md
+++ b/themes/default/content/docs/concepts/projects/project-file.md
@@ -157,10 +157,10 @@ Schemas are only valid for project property keys. For setting the value of a pro
 
 | Name | Required | Description |
 | - | - | - |
-| `displayName` | optional | A user-friendly name for the template. This should follow `Title Case` format and be succinct. |
+| `displayName` | optional | A user-friendly name for the template. This should follow `Title Case` format and be succinct. This field is only supported by Pulumi CLI >= 3.95. |
 | `description` | optional | Description of the template. |
 | `config` | required | Config to request when using this template with `pulumi new`. |
-| `metadata` | optional | A map of user-defined tags to attach to the template. |
+| `metadata` | optional | A map of user-defined tags to attach to the template. This field is only supported by Pulumi CLI >= 3.95. |
 
 #### `config`
 

--- a/themes/default/content/docs/concepts/projects/project-file.md
+++ b/themes/default/content/docs/concepts/projects/project-file.md
@@ -38,12 +38,15 @@ backend:
 options:
   refresh: always
 template:
+  displayName: Example Template
   description: An example template
   config:
     aws:region:
       description: The AWS region to deploy into
       default: us-east-1
       secret: true
+  metadata:
+    cloud: aws
 plugins:
   providers:
     - name: aws
@@ -154,8 +157,10 @@ Schemas are only valid for project property keys. For setting the value of a pro
 
 | Name | Required | Description |
 | - | - | - |
+| `displayName` | optional | A user-friendly name for the template. |
 | `description` | optional | Description of the template. |
 | `config` | required | Config to request when using this template with `pulumi new`. |
+| `metadata` | optional | A map of user-defined tags to attach to the template. |
 
 #### `config`
 


### PR DESCRIPTION
## Description
Template blocks now support optional `displayName` and `metadata` fields that are used by the console to aid in the discovery of any template (pulumi-hosted or self-hosted).

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).