### PR TITLE
ESC - fixing azure example output in gcp provider page

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/esc/providers/gcp-secrets.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/providers/gcp-secrets.md
@@ -45,14 +45,12 @@ Make sure to replace `<your-org>` and `<your-environment>` with the values of yo
 
 ```json
 {
-  "azure": {
+  "gcp": {
     "login": {
-      "clientId": "b537....",
-      "oidc": {
-        "token": "eyJh...."
-      },
-      "subscriptionId": "0282....",
-      "tenantId": "7061...."
+        "accessToken": "ya29.c....",
+        "expiry": "2023-10-07T03:17:40Z" ,
+        "project": 123456789,
+        "tokenType": "Bearer"
     },
     "secrets": {
       "api-key": "my-api-key",


### PR DESCRIPTION
GCP secret manager provider page had sample example output of Azure's. Fixing that. 