### PR TITLE
Sync left nav + Concept cards ordering

### DIFF
--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -346,7 +346,7 @@ The following topics provide more details on the core concepts of Pulumi and how
     </div>
 </div>
 
-<!-- glossary & commpare-->
+<!-- glossary & compare-->
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/glossary"><i class="fas fa-book pr-2"></i>Glossary</a></h3>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -341,7 +341,7 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn about how to access log information for diagnostics and debugging.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/update-plans"><i class="fas fa-upload pr-2"></i>Update Plans</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/update-plans"><i class="fas fa-upload pr-2"></i>Update plans</a></h3>
         <p>Learn about how to constrain your deployments with update plans.</p>
     </div>
 </div>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -274,9 +274,10 @@ outputs:
 
 The following topics provide more details on the core concepts of Pulumi and how to use it:
 
+<!-- how & projects -->
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/how-pulumi-works"><i class="fas fa-upload pr-2"></i>How Pulumi Works</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/how-pulumi-works"><i class="fas fa-laptop-code pr-2"></i>How Pulumi works</a></h3>
         <p>Learn about how Pulumi performs deployments under the hood.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
@@ -284,29 +285,35 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn how Pulumi projects are organized and configured.</p>
     </div>
 </div>
+
+<!-- stacks & resources -->
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/stack"><i class="fas fa-cloud pr-2"></i>Stacks</a></h3>
         <p>Learn how to create and deploy stacks.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/state"><i class="fas fa-file-alt pr-2"></i>State and Backends</a></h3>
-        <p>Learn how Pulumi stores state and manages concurrency.</p>
-    </div>
-</div>
-<div class="md:flex flex-row mt-6 mb-6">
-    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources"><i class="fas fa-server pr-2"></i>Resources</a></h3>
         <p>Learn more about how to use and manage resources in your program.</p>
     </div>
+</div>
+
+<!-- resource options & inputs/outputs -->
+<div class="md:flex flex-row mt-6 mb-6">
+    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/options"><i class="fas fa-swatchbook pr-2"></i>Resource options</a></h3>
+        <p>Learn more about how to use and manage resources options in your program.</p>
+    </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs"><i class="fas fa-hdd pr-2"></i>Inputs and Outputs</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs"><i class="fas fa-file-import pr-2"></i>Inputs and Outputs</a></h3>
         <p>Learn how to use resource properties to handle dependencies between resources.</p>
     </div>
 </div>
+
+<!-- config & secrets -->
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/config"><i class="fas fa-check-square pr-2"></i>Configuration</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/config"><i class="fas fa-toolbox pr-2"></i>Configuration</a></h3>
         <p>Learn how to configure stacks for different deployment scenarios.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
@@ -314,19 +321,39 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn how to handle sensitive data and how to store secret encrypted settings in Pulumi.</p>
     </div>
 </div>
+
+<!--  esc & state backends-->
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs/assets-archives/"><i class="fas fa-stream pr-2"></i>Assets and Archives</a></h3>
-        <p>Learn how to use local or remote files with your Pulumi program.</p>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/environments"><i class="fas fa-cubes pr-2"></i>Environments (ESC)</a></h3>
+        <p>Learn how to configure various environments in Pulumi.</p>
     </div>
-    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs/function-serialization/"><i class="fas fa-terminal pr-2"></i>Function Serialization</a></h3>
-        <p>Learn how to serialize JavaScript functions into an artifact that can be used at runtime in the cloud.</p>
+     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/state"><i class="fas fa-file-alt pr-2"></i>State and Backends</a></h3>
+        <p>Learn how Pulumi stores state and manages concurrency.</p>
     </div>
 </div>
-<div>
+
+<!-- logging & update plans -->
+<div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/logging"><i class="fas fa-clipboard-list pr-2"></i>Logging</a></h3>
         <p>Learn about how to access log information for diagnostics and debugging.</p>
+    </div>
+    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/update-plans"><i class="fas fa-upload pr-2"></i>Update Plans</a></h3>
+        <p>Learn how to use update plans.</p>
+    </div>
+</div>
+
+<!-- glossary & commpare-->
+<div class="md:flex flex-row mt-6 mb-6">
+    <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/glossary"><i class="fas fa-book pr-2"></i>Glossary</a></h3>
+        <p>Look up definitions to commonly used terms.</p>
+    </div>
+    <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/vs"><i class="fas fa-table pr-2"></i>Compare</a></h3>
+        <p>Learn about how Pulumi compares to other solutions.</p>
     </div>
 </div>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -329,7 +329,7 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn how to configure your deployment environments with Pulumi ESC.</p>
     </div>
      <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/state"><i class="fas fa-file-alt pr-2"></i>State and Backends</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/state"><i class="fas fa-file-alt pr-2"></i>State and backends</a></h3>
         <p>Learn how Pulumi stores state and manages concurrency.</p>
     </div>
 </div>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -326,7 +326,7 @@ The following topics provide more details on the core concepts of Pulumi and how
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/environments"><i class="fas fa-cubes pr-2"></i>Environments (ESC)</a></h3>
-        <p>Learn how to configure various environments in Pulumi.</p>
+        <p>Learn how to configure your deployment environments with Pulumi ESC.</p>
     </div>
      <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/state"><i class="fas fa-file-alt pr-2"></i>State and Backends</a></h3>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -305,7 +305,7 @@ The following topics provide more details on the core concepts of Pulumi and how
         <p>Learn more about how to use and manage resource options in your program.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
-        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs"><i class="fas fa-file-import pr-2"></i>Inputs and Outputs</a></h3>
+        <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs"><i class="fas fa-file-import pr-2"></i>Inputs and outputs</a></h3>
         <p>Learn how to use resource properties to handle dependencies between resources.</p>
     </div>
 </div>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -294,7 +294,7 @@ The following topics provide more details on the core concepts of Pulumi and how
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/resources"><i class="fas fa-server pr-2"></i>Resources</a></h3>
-        <p>Learn more about how to use and manage resources in your program.</p>
+        <p>Learn more about how to use and manage resources in your programs.</p>
     </div>
 </div>
 

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -302,7 +302,7 @@ The following topics provide more details on the core concepts of Pulumi and how
 <div class="md:flex flex-row mt-6 mb-6">
     <div class="md:w-1/2 border-solid md:ml-4 border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/options"><i class="fas fa-swatchbook pr-2"></i>Resource options</a></h3>
-        <p>Learn more about how to use and manage resources options in your program.</p>
+        <p>Learn more about how to use and manage resource options in your program.</p>
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/inputs-outputs"><i class="fas fa-file-import pr-2"></i>Inputs and Outputs</a></h3>

--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -342,7 +342,7 @@ The following topics provide more details on the core concepts of Pulumi and how
     </div>
     <div class="md:w-1/2 border-solid border-t-2 border-gray-200">
         <h3 class="no-anchor pt-4"><a href="/docs/concepts/update-plans"><i class="fas fa-upload pr-2"></i>Update Plans</a></h3>
-        <p>Learn how to use update plans.</p>
+        <p>Learn about how to constrain your deployments with update plans.</p>
     </div>
 </div>
 

--- a/themes/default/content/docs/concepts/config.md
+++ b/themes/default/content/docs/concepts/config.md
@@ -1,7 +1,7 @@
 ---
 title_tag: "Configuration | Pulumi Concepts"
 meta_desc: This page provides an overview of how Pulumi manages cloud application configuration settings.
-title: Config
+title: Configuration
 h1: Configuration
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:

--- a/themes/default/content/docs/concepts/how-pulumi-works.md
+++ b/themes/default/content/docs/concepts/how-pulumi-works.md
@@ -6,7 +6,7 @@ h1: "How Pulumi works"
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
   concepts:
-    weight: 12
+    weight: 1
 aliases:
 - /docs/reference/how/
 - /docs/tour/basics-programs/


### PR DESCRIPTION
This PR:

- Reorders the concept cards in the Overview page to match the order in the left navigation. 
- Promotes the "How pulumi works" page as the first page under the Concepts (this is how it was in the cards).
- Fixes the duplicate wording and icons on some of the cards.