### PR TITLE
Add note wrt opening ESC secrets

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/esc/environments.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/environments.md
@@ -65,10 +65,6 @@ $ esc env set myorg/test foo bar
 
 To retrieve a single value and its definition, use `esc env get <environment-name> <key>`:
 
-{{% notes type="info" %}}
-Use [`open`](#opening-an-environment) to access secrets.
-{{% /notes %}}
-
 ```bash
 $ esc env get myorg/test foo
 
@@ -86,7 +82,15 @@ $ esc env get myorg/test foo
   • test:2:10
 ```
 
-Note that `esc env get` returns only statically defined plain-text values and definitions; it does not resolve provider-managed values or secrets. (For these, `get` returns the item definition with a value of `[unknown]`.) To resolve dynamically retrieved values or secrets, you must instead [open the environment](#opening-an-environment).
+{{% notes type="warning" %}}
+
+**Why is the value shown as `[unknown]`?**
+
+The command `esc env get` returns statically defined plain-text values and definitions. It does **not** return secrets defined in the environment nor resolves values from specified provider configuration, therefore, attempting to `get` a secret results in an `[unknown]` output.
+
+Use [`esc env open`](#opening-an-environment) to access secrets; this opens the environment and resolves dynamically retrieved values or secrets.
+
+{{% /notes %}}
 
 ### Getting all values
 

--- a/themes/default/content/docs/pulumi-cloud/esc/environments.md
+++ b/themes/default/content/docs/pulumi-cloud/esc/environments.md
@@ -65,6 +65,10 @@ $ esc env set myorg/test foo bar
 
 To retrieve a single value and its definition, use `esc env get <environment-name> <key>`:
 
+{{% notes type="info" %}}
+Use [`open`](#opening-an-environment) to access secrets.
+{{% /notes %}}
+
 ```bash
 $ esc env get myorg/test foo
 


### PR DESCRIPTION
Adds an info note to clarify that esc open is the correct command when opening a secret. 