### PR TITLE
Add GitHub icon to the example-program partial also

### DIFF
--- a/themes/default/layouts/partials/example-program.html
+++ b/themes/default/layouts/partials/example-program.html
@@ -9,9 +9,8 @@
 {{ end }}
 
 {{ range $i, $language := split $languages "," }}
-    <div class="w-full">
+    <div class="example-program w-full">
         <pulumi-choosable type="language" values="{{ $language }}">
-            <div>
                 {{ $program := "" }}
                 {{ $depfile := "" }}
                 {{ $deplang := "" }}
@@ -48,8 +47,15 @@
                     <div data-program-path="{{ $path }}" data-program-language="{{ $language }}" data-program-file="{{ $program }}" data-program-depfile="{{ $depfile }}">
                         {{ highlight $code $language }}
                     </div>
+                    <div class="example-program-footer bg-white">
+                        <pulumi-tooltip>
+                            <a href="https://github.com/pulumi/pulumi-hugo/tree/{{ site.Params.contentRepositoryBaseBranch }}/{{ getenv "REPO_THEME_PATH" }}static/programs/{{ $path }}-{{ $language }}" target="_blank">
+                                <i class="fab fa-github"></i>
+                            </a>
+                            <span slot="content">Open this example on GitHub</span>
+                        </pulumi-tooltip>
+                    </div>
                 {{ end }}
-            </div>
         </pulumi-choosable>
     </div>
 {{ end }}


### PR DESCRIPTION
Forgot to add this in #3720! It adds the GitHub icon to any `example-program`s we show on marketing pages as well (via the `example-program` _partial_):

![image](https://github.com/pulumi/pulumi-hugo/assets/274700/2048c0cf-218d-4582-83be-4570c97709da)

