### PR TITLE
Fix typo in esc blog post

### DIFF
--- a/themes/default/content/blog/environments-secrets-configurations-management/index.md
+++ b/themes/default/content/blog/environments-secrets-configurations-management/index.md
@@ -230,7 +230,7 @@ Now, we can use this directly within our Pulumi IaC project by modifying its sta
 
 ```yaml
 # Pulumi.staging.yaml
-environments:
+environment:
   - shopping-service-staging
 ```
 


### PR DESCRIPTION
## Description

The ESC post was using referencing `environments` instead of `environment` in the IaC integration section. This PR fixes up the typo.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
