### PR TITLE
Fix python markdown display

### DIFF
--- a/themes/default/content/docs/clouds/kubernetes/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/review-project.md
@@ -36,7 +36,13 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,python,go,csharp,java" %}}
+{{% choosable language python %}}
+
+- `__main__.py` is the Pulumi program that defines your stack resources.
+
+{{% /choosable %}}
+
+{{% choosable language "javascript,typescript,go,csharp,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.


### PR DESCRIPTION
- Fixes #3730
- Correctly displays the python filename `__main__.py` in a markdown bulleted item by adding a `choosable` for `python`. 
