### PR TITLE
Fix python markdown display (for all clouds)

### DIFF
--- a/themes/default/content/docs/clouds/aws/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/aws/get-started/review-project.md
@@ -41,7 +41,13 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,python,go,java" %}}
+{{% choosable language python %}}
+
+- `__main__.py` is the Pulumi program that defines your stack resources.
+
+{{% /choosable %}}
+
+{{% choosable language "javascript,typescript,go,csharp,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.

--- a/themes/default/content/docs/clouds/azure/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/azure/get-started/review-project.md
@@ -36,7 +36,13 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,python,go,csharp,java" %}}
+{{% choosable language python %}}
+
+- `__main__.py` is the Pulumi program that defines your stack resources.
+
+{{% /choosable %}}
+
+{{% choosable language "javascript,typescript,go,csharp,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.

--- a/themes/default/content/docs/clouds/gcp/get-started/review-project.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/review-project.md
@@ -36,7 +36,13 @@ Let's review some of the generated project files:
 
 {{% /choosable %}}
 
-{{% choosable language "javascript,typescript,python,go,csharp,java" %}}
+{{% choosable language python %}}
+
+- `__main__.py` is the Pulumi program that defines your stack resources.
+
+{{% /choosable %}}
+
+{{% choosable language "javascript,typescript,go,csharp,java" %}}
 
 <!-- The wrapping spans are infortunately necessary here; without them, the renderer gets confused and generates invalid markup. -->
 - <span>{{< langfile >}}</span> is the Pulumi program that defines your stack resources.


### PR DESCRIPTION
- Correctly displays the python filename `__main__.py` in a markdown bulleted item by adding a `choosable` for `python`.  This is updated across all the cloud getting started/review project pages.
