### PR TITLE
Remove test artifacts after each test

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -89,6 +89,9 @@ pushd "$programs_dir"
 
         # Destroy and remove.
         pulumi -C "$project" destroy --yes --remove
+
+        # Clean up artifacts.
+        git clean -fdX -e '!go.mod' .
     done
 popd
 
@@ -97,6 +100,6 @@ suffix_gomods
 
 # Log out of local mode.
 if [[ "$mode" == "preview" ]]; then
-    export PULUMI_CONFIG_PASSPHRASE="foo"
+    unset PULUMI_CONFIG_PASSPHRASE
     pulumi logout --local
 fi


### PR DESCRIPTION
We seem to be exceeding available disk on the GHA runners (causing the tests to fail), so this change adds a cleanup step after each test run.

Fixes https://github.com/pulumi/pulumi-hugo/issues/3737
May also fix https://github.com/pulumi/pulumi-hugo-private/issues/184