### PR TITLE
Open Python SDK docs in a new tab

### DIFF
--- a/themes/default/layouts/partials/docs/main-nav.html
+++ b/themes/default/layouts/partials/docs/main-nav.html
@@ -69,6 +69,7 @@
                             {{ if or (eq .URL "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v3/go/pulumi")
                                 (eq .URL "https://github.com/pulumi/pulumi-java/tree/main/sdk/java")
                                 (eq .URL "https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.html")
+                                (eq .URL "https://www.pulumi.com/docs/reference/pkg/python/pulumi/")
                             }}
                                 <a href="{{ .URL }}" target="_blank" data-track="toc-{{ .Name | urlize }}">{{ .Name }}</a>
                             {{ else }}


### PR DESCRIPTION
Similar to .NET (and Go and Java), open Python SDK docs in a new tab, since it's a different style from the rest of the site.

This will work when https://github.com/pulumi/docs/pull/10279 is merged & published, which changes the menu link for Python SDK docs to this particular URL.