### PR TITLE
Update gcp.md - modify subject claim documentation for clarity

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
@@ -70,7 +70,9 @@ The below sections show examples that correspond to each OIDC-supported service.
 
 #### Pulumi Deployments
 
-Because Google's federated credentials do not allow wildcards in the subject identifier, requiring an exact match on an OIDC token's subject claim, this process must be repeated for each permutation of the subject claim that is possible for a stack. For example, in order to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
+To enable valid operations on a specific stack, Google federated credentials require an exact match on the OIDC token subject claim. Unfortunately, the subject identifier does *not* allow wildcards. Therefore, you must create credentials for each permutation of the subject claim that is possible for the stack.
+
+For example, to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
 
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:preview:scope:write`
 * `pulumi:deploy:org:contoso:project:core:stack:dev:operation:update:scope:write`

--- a/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
@@ -70,7 +70,7 @@ The below sections show examples that correspond to each OIDC-supported service.
 
 #### Pulumi Deployments
 
-To enable valid operations on a specific stack, Google federated credentials require an exact match on the OIDC token subject claim. Unfortunately, the subject identifier does *not* allow wildcards. Therefore, you must create credentials for each permutation of the subject claim that is possible for the stack.
+To enable valid operations on a specific stack, Google federated credentials require an exact match on the OIDC token subject claim. Unfortunately, the subject identifier does *not* currently allow wildcards. Therefore, you must create credentials for each permutation of the subject claim that is possible for the stack.
 
 For example, to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
 

--- a/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/gcp.md
@@ -70,9 +70,12 @@ The below sections show examples that correspond to each OIDC-supported service.
 
 #### Pulumi Deployments
 
-The below is an example of a valid subject claim for the `dev` stack of the `contoso` organization:
+Because Google's federated credentials do not allow wildcards in the subject identifier, requiring an exact match on an OIDC token's subject claim, this process must be repeated for each permutation of the subject claim that is possible for a stack. For example, in order to enable all of the valid operations on a stack named `dev` of the `core` project in the `contoso` organization, you would need to create credentials for each of the following subject identifiers:
 
-* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:*:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:preview:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:update:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:refresh:scope:write`
+* `pulumi:deploy:org:contoso:project:core:stack:dev:operation:destroy:scope:write`
 
 #### Pulumi ESC
 


### PR DESCRIPTION
## Description
I just spent several days trying to get this Google Cloud OIDC connection working with Pulumi Deployments. I believe the issue was trying to use a wildcard in the subject identifier as specified in this doc. After a/b testing with the subjects:
- `pulumi:deploy:org:ORG_NAME:project:PROJ_NAME:stack:STACK_NAME:operation:*:scope:write` 
- `pulumi:deploy:org:ORG_NAME:project:PROJ_NAME:stack:STACK_NAME:operation:update:scope:write`
<br>
I was only able to get the one without a wildcard to work. 

I saw the [Azure page documentation](https://www.pulumi.com/docs/pulumi-cloud/oidc/azure/#pulumi-deployments) regarding explict subject use, and roughly copied that over here. 

## Checklist:

- [ X ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ X ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ X ] I have manually confirmed that all new links work.
- [ X ] I added aliases (i.e., redirects) for all filename changes.
- [ X ] If making css changes, I rebuilt the bundle.
