### PR TITLE
Fix Go example for resource aliases

### DIFF
--- a/themes/default/content/docs/concepts/options/aliases.md
+++ b/themes/default/content/docs/concepts/options/aliases.md
@@ -50,7 +50,9 @@ db = Database('db',
 
 ```go
 db, err := NewDatabase(ctx, "db", &DatabaseArgs{ /*...*/ },
-    pulumi.Aliases(pulumi.Alias{Name: pulumi.String("old-name-for-db")}))
+    pulumi.Aliases([]pulumi.Alias{
+        {Name: pulumi.String("old-name-for-db")},
+    }))
 ```
 
 {{% /choosable %}}
@@ -120,9 +122,9 @@ db = Database('db',
 
 ```go
 db, err := NewDatabase(ctx, "db", &DatabaseArgs{ /*...*/ },
-    pulumi.Aliases([]pulumi.Alias{pulumi.Alias{
-        URN: pulumi.URN("urn:pulumi:stackname::projectname::aws:rds/database:Database::old-name-for-db"),
-    }})
+    pulumi.Aliases([]pulumi.Alias{
+        {URN: pulumi.URN("urn:pulumi:stackname::projectname::aws:rds/database:Database::old-name-for-db")},
+    }))
 )
 ```
 


### PR DESCRIPTION
## Description

Elide redundant type name for the array element for both examples on the page and add missing parenthesis for second example.



## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
