### PR TITLE
Note that Python 3.12 is not yet supported

### DIFF
--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -19,7 +19,7 @@ aliases:
 Pulumi supports writing your infrastructure as code in the Python language running on any [supported version](https://devguide.python.org/versions/#versions).
 
 {{% notes type="warning" %}}
-Python 3.12 is not yet supported due to an upstream issue in the `grpcio` package that the `pulumi` PyPi package depends on. See [pulumi/pulumi#14258](https://github.com/pulumi/pulumi/issues/14258).
+Python 3.12 is not yet supported. See [pulumi/pulumi#14258](https://github.com/pulumi/pulumi/issues/14258) for details.
 {{% /notes %}}
 
 {{< install-python >}}

--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -18,6 +18,10 @@ aliases:
 
 Pulumi supports writing your infrastructure as code in the Python language running on any [supported version](https://devguide.python.org/versions/#versions).
 
+{{% notes type="warning" %}}
+Python 3.12 is not yet supported due to an upstream issue in the `grpcio` package that the `pulumi` PyPi package depends on. See [pulumi/pulumi#14258](https://github.com/pulumi/pulumi/issues/14258).
+{{% /notes %}}
+
 {{< install-python >}}
 
 ## Pulumi Programming Model


### PR DESCRIPTION
## Description

There is an upstream issue that is currently preventing us from being able to support Python 3.12. Add a note about this in the docs until we're able to support Python 3.12.

Part of https://github.com/pulumi/home/issues/3259 (internal)

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
