### PR TITLE
Add changelog link to install page.

### DIFF
--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -96,7 +96,7 @@ The latest version of Pulumi is {{< latest-version >}}. For older versions, see 
 
 Windows 8 and later are supported.
 
-The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/). For a list of features, bug fixes, and more see the [CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md)
+The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/). For a list of features, bug fixes, and more see the [CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md).
 
 {{< get-started-note >}}
 

--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -48,7 +48,7 @@ $ brew install pulumi/tap/pulumi
 
 macOS Sierra (10.12) or later is required.
 
-The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/).
+The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/). For a list of features, bug fixes, and more see the [CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md).
 
 {{< get-started-note >}}
 
@@ -71,7 +71,7 @@ $ curl -fsSL https://get.pulumi.com | sh
 </div>
 </div>
 
-The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/).
+The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/). For a list of features, bug fixes, and more see the [CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md).
 
 {{< get-started-note >}}
 
@@ -96,7 +96,7 @@ The latest version of Pulumi is {{< latest-version >}}. For older versions, see 
 
 Windows 8 and later are supported.
 
-The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/).
+The latest version of Pulumi is {{< latest-version >}}. For older versions, see [Available Versions](/docs/install/versions/). For a list of features, bug fixes, and more see the [CHANGELOG](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md)
 
 {{< get-started-note >}}
 


### PR DESCRIPTION
## Description

Fixes #3772
Updates the Pulumi CLI install page to include a link to the changelog.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
