### PR TITLE
Add a bit of padding to the top of the home-page hero

### DIFF
--- a/themes/default/layouts/index.html
+++ b/themes/default/layouts/index.html
@@ -2,7 +2,7 @@
     <header class="home-page-hero shadow">
         <div class="home-page-hero-background">
             <div class="flex">
-                <div class="w-full p-6 home-page-hero-text">
+                <div class="w-full p-6 home-page-hero-text lg:pt-14">
                     <h1 class="flex flex-col items-center">
                         <span class="inline-block mb-3 text-center" data-text="{{ index (.Params.hero.title) 0 }}">{{ index (.Params.hero.title) 0 }}</span>
                         <span class="rainbow-text inline-block text-center" data-text="{{ index (.Params.hero.title) 1 }}">{{ index (.Params.hero.title) 1 }}</span>


### PR DESCRIPTION
Adds a bit of padding to even things out. Before:

![image](https://github.com/pulumi/pulumi-hugo/assets/274700/c671e3e1-a503-49b7-8fc8-6405125326e5)

After:

![image](https://github.com/pulumi/pulumi-hugo/assets/274700/f502c3a6-bd0b-4f75-99f4-af0842248d71)
