### PR TITLE
Add ESC aliases

### DIFF
--- a/themes/default/content/docs/esc/_index.md
+++ b/themes/default/content/docs/esc/_index.md
@@ -10,7 +10,6 @@ menu:
     identifier: esc
     weight: 5
 aliases:
-  - /docs/esc/
   - /docs/pulumi-cloud/esc/
 ---
 
@@ -18,7 +17,7 @@ Pulumi ESC (Environments, Secrets, and Configuration) allows teams to tackle sec
 
 Pulumi ESC enables teams to aggregate secrets and configuration from many sources into a composable collection called an [environment](/docs/concepts/environments/). Teams can then consume those configuration and secrets from a variety of different infrastructure and application services.  Pulumi ESC works hand-in-hand with Pulumi IaC to simplify configuration management, as well as a standalone CLI and API for other use cases apart from Pulumi IaC.
 
-Pulumi ESC is offered as a fully managed cloud service in [Pulumi Cloud](/docs/pulumi-cloud/) (and Pulumi Cloud Self-hosted in the near future). The [pulumi/esc project](https://github.com/pulumi/esc) is open source, and contains the evaluation engine for environments, the esc CLI, and in the future, the extensible plugins for source and target integrations.  
+Pulumi ESC is offered as a fully managed cloud service in [Pulumi Cloud](/docs/pulumi-cloud/) (and Pulumi Cloud Self-hosted in the near future). The [pulumi/esc project](https://github.com/pulumi/esc) is open source, and contains the evaluation engine for environments, the esc CLI, and in the future, the extensible plugins for source and target integrations.
 
 ![Pulumi ESC ecosystem](img/pulumi_esc.png)
 

--- a/themes/default/content/docs/esc/faq.md
+++ b/themes/default/content/docs/esc/faq.md
@@ -8,6 +8,8 @@ menu:
   pulumiesc:
     weight: 6
     identifier: faq
+aliases:
+  - /docs/pulumi-cloud/esc/faq
 ---
 
 ## Is it safe to use Pulumi ESC for my production stacks?

--- a/themes/default/content/docs/esc/reference.md
+++ b/themes/default/content/docs/esc/reference.md
@@ -7,6 +7,8 @@ menu:
   pulumiesc:
     identifier: reference
     weight: 4
+aliases:
+  - /docs/pulumi-cloud/esc/reference
 ---
 
 ```yaml
@@ -189,7 +191,7 @@ values:
   # reference this environment during `pulumi up/preview/refresh/destroy`
   pulumiConfig:
     aws:region: us-west-2
-  
+
   # Configuration nested under the 'files' key is used to export as files to the environment
   # when using 'esc open --shell', 'esc run', or `pulumi up/preview/refresh/destroy`
   files:


### PR DESCRIPTION
In #3828 we moved ESC to the top level, but missed adding redirects for a couple of pages. This should fix 'em up.