### PR TITLE
Add a note about auto-naming to the geting-started guides

### DIFF
--- a/themes/default/content/docs/clouds/aws/get-started/deploy-stack.md
+++ b/themes/default/content/docs/clouds/aws/get-started/deploy-stack.md
@@ -119,6 +119,8 @@ $ pulumi stack output bucketName
 
 Running that command will print out the name of your bucket.
 
+{{< auto-naming-note resource="bucket" suffix="58ce361" >}}
+
 {{< console-note >}}
 
 Now that the bucket has been provisioned, let's modify the program to host a static website.

--- a/themes/default/content/docs/clouds/gcp/get-started/deploy-stack.md
+++ b/themes/default/content/docs/clouds/gcp/get-started/deploy-stack.md
@@ -121,6 +121,8 @@ $ pulumi stack output bucketName
 
 Running that command will print out the name of your bucket.
 
+{{< auto-naming-note resource="bucket" suffix="daa12be" >}}
+
 {{< console-note >}}
 
 Now that your bucket has been provisioned, let's modify the bucket to host a static website.

--- a/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/deploy-changes.md
@@ -23,27 +23,22 @@ $ pulumi up
 Pulumi computes the minimally disruptive change to achieve the desired state described by the program.
 
 ```
-Previewing update (dev)
-
-     Type                              Name            Plan
-     pulumi:pulumi:Stack               quickstart-dev
- +   ├─ kubernetes:apps/v1:Deployment  nginx           create
- +   ├─ kubernetes:core/v1:Service     nginx           create
- -   └─ kubernetes:apps/v1:Deployment  app-dep         delete
-
+Previewing update (dev):
+     Type                           Name            Plan
+     pulumi:pulumi:Stack            quickstart-dev
+ +   └─ kubernetes:core/v1:Service  nginx           create
 
 Outputs:
   + ip  : "10.96.0.0"
-  - name: "app-dep-b7413dae"
+  - name: "nginx-bec13562"
 
 Resources:
-    + 2 to create
-    - 1 to delete
-    3 changes. 1 unchanged
+    + 1 to create
+    2 unchanged
 
 Do you want to perform this update?  [Use arrows to move, type to filter]
-  yes
-> no
+> yes
+  no
   details
 ```
 
@@ -53,25 +48,20 @@ Pulumi will create the service since it is now defined in the program.
 
 ```
 Do you want to perform this update? yes
-Updating (dev)
-
-     Type                              Name            Status
-     pulumi:pulumi:Stack               quickstart-dev
- +   ├─ kubernetes:apps/v1:Deployment  nginx           created (3s)
- +   ├─ kubernetes:core/v1:Service     nginx           created (10s)
- -   └─ kubernetes:apps/v1:Deployment  app-dep         deleted (1s)
-
+Updating (dev):
+     Type                           Name            Status
+     pulumi:pulumi:Stack            quickstart-dev
+ +   └─ kubernetes:core/v1:Service  nginx           created (10s)
 
 Outputs:
-  + ip  : "10.103.199.118"
-  - name: "app-dep-b7413dae"
+  + ip  : "10.110.183.208"
+  - name: "nginx-bec13562"
 
 Resources:
-    + 2 created
-    - 1 deleted
-    3 changes. 1 unchanged
+    + 1 created
+    2 unchanged
 
-Duration: 23s
+Duration: 12s
 ```
 
 View the `ip` [stack output](/docs/concepts/stack#outputs) from the nginx service.

--- a/themes/default/content/docs/clouds/kubernetes/get-started/deploy-stack.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/deploy-stack.md
@@ -27,18 +27,17 @@ Previewing update (dev)
 
      Type                              Name            Plan
  +   pulumi:pulumi:Stack               quickstart-dev  create
- +   └─ kubernetes:apps/v1:Deployment  app-dep         create
-
+ +   └─ kubernetes:apps/v1:Deployment  nginx           create
 
 Outputs:
-    name: "app-dep-92efcbdf"
+    name: "nginx-516e16fd"
 
 Resources:
     + 2 to create
 
 Do you want to perform this update?  [Use arrows to move, type to filter]
-  yes
-> no
+> yes
+  no
   details
 ```
 
@@ -46,23 +45,23 @@ Select `yes` using the arrows and hit enter to create the resources in Kubernete
 
 ```bash
 Do you want to perform this update? yes
-Updating (dev)
-
+Updating (dev):
      Type                              Name            Status
  +   pulumi:pulumi:Stack               quickstart-dev  created (3s)
- +   └─ kubernetes:apps/v1:Deployment  app-dep         created (1s)
-
+ +   └─ kubernetes:apps/v1:Deployment  nginx           created (2s)
 
 Outputs:
-    name: "app-dep-b7413dae"
+    name: "nginx-bec13562"
 
 Resources:
     + 2 created
 
-Duration: 10s
+Duration: 4s
 ```
 
 The `name` of the deployment that we exported is shown as a [stack output](/docs/concepts/stack#outputs).
+
+{{< auto-naming-note resource="deployment" suffix="bec13562" >}}
 
 {{< console-note >}}
 

--- a/themes/default/content/docs/clouds/kubernetes/get-started/destroy-stack.md
+++ b/themes/default/content/docs/clouds/kubernetes/get-started/destroy-stack.md
@@ -25,23 +25,21 @@ $ pulumi destroy
 You'll be prompted to make sure you really want to delete these resources.
 
 ```bash
-Previewing destroy (dev)
-
+Previewing destroy (dev):
      Type                              Name            Plan
  -   pulumi:pulumi:Stack               quickstart-dev  delete
  -   ├─ kubernetes:core/v1:Service     nginx           delete
  -   └─ kubernetes:apps/v1:Deployment  nginx           delete
 
-
 Outputs:
-  - ip: "10.103.199.118"
+  - ip: "10.110.183.208"
 
 Resources:
     - 3 to delete
 
 Do you want to perform this destroy?  [Use arrows to move, type to filter]
-  yes
-> no
+> yes
+  no
   details
 ```
 
@@ -49,21 +47,19 @@ Select `yes` using the arrows and hit enter to delete the resources in Kubernete
 
 ```bash
 Do you want to perform this destroy? yes
-Destroying (dev)
-
+Destroying (dev):
      Type                              Name            Status
- -   pulumi:pulumi:Stack               quickstart-dev  deleted
- -   ├─ kubernetes:core/v1:Service     nginx           deleted (0.42s)
- -   └─ kubernetes:apps/v1:Deployment  nginx           deleted (2s)
-
+ -   pulumi:pulumi:Stack               quickstart-dev  deleted (0.00s)
+ -   ├─ kubernetes:core/v1:Service     nginx           deleted (0.94s)
+ -   └─ kubernetes:apps/v1:Deployment  nginx           deleted (4s)
 
 Outputs:
-  - ip: "10.103.199.118"
+  - ip: "10.110.183.208"
 
 Resources:
     - 3 deleted
 
-Duration: 5s
+Duration: 6s
 
 The resources in the stack have been deleted, but the history and configuration associated with the stack are still maintained.
 If you want to remove the stack completely, run `pulumi stack rm dev`.

--- a/themes/default/layouts/shortcodes/auto-naming-note.html
+++ b/themes/default/layouts/shortcodes/auto-naming-note.html
@@ -1,0 +1,8 @@
+{{ $resource := default "resource" (.Get "resource") }}
+{{ $suffix := default "abc123" (.Get "suffix") }}
+
+<p>
+    The extra characters you see tacked onto the {{ $resource }} name (<code>-{{ $suffix }}</code>) are the result of <em>auto-naming</em>,
+    a feature that lets you use the same resource names across multiple stacks without naming collisions. You can learn more about
+    auto-naming <a href="/docs/concepts/resources/names/#autonaming">in the Concepts docs</a>.
+</p>


### PR DESCRIPTION
Fixes #247, and does a bit of cleanup around the Kubernetes output.

