### PR TITLE
Remove note about Python 3.12 not being supported

### DIFF
--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -18,10 +18,6 @@ aliases:
 
 Pulumi supports writing your infrastructure as code in the Python language running on any [supported version](https://devguide.python.org/versions/#versions).
 
-{{% notes type="warning" %}}
-Python 3.12 is not yet supported. See [pulumi/pulumi#14258](https://github.com/pulumi/pulumi/issues/14258) for details.
-{{% /notes %}}
-
 {{< install-python >}}
 
 ## Pulumi Programming Model


### PR DESCRIPTION
Python 3.12 is now supported with the v3.103.0 release of the Pulumi Python SDK (https://pypi.org/project/pulumi/).

Ref: https://github.com/pulumi/pulumi/pull/15190