### PR TITLE
Correct python logging call in logging.md

### DIFF
--- a/themes/default/content/docs/concepts/logging.md
+++ b/themes/default/content/docs/concepts/logging.md
@@ -40,11 +40,11 @@ pulumi.log.error("fatal error")
 {{% choosable language python %}}
 
 ```python
-log.info("message")
-log.info("message", resource)
-log.debug("hidden by default")
-log.warn("warning")
-log.error("fatal error")
+pulumi.info("message")
+pulumi.info("message", resource)
+pulumi.debug("hidden by default")
+pulumi.warn("warning")
+pulumi.error("fatal error")
 ```
 
 {{% /choosable %}}


### PR DESCRIPTION
## Description

The current python logging example does only work if you do `import pulumi as log`. 

This PR corrects that and make it compatible with the quickstart tutorial and other examples in this documentation by relying on `import pulumi`.



## Checklist:

- [X] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [X] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [X] I have manually confirmed that all new links work.
- [X] I added aliases (i.e., redirects) for all filename changes.
- [X] If making css changes, I rebuilt the bundle.
