### PR TITLE
Add install alias to root of web site

### DIFF
--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -13,6 +13,7 @@ aliases:
 - /get-started/install/
 - /docs/reference/install/
 - /docs/get-started/install/
+- /install/
 
 search:
    boost: true


### PR DESCRIPTION
## Description

Redirects `pulumi.com/install` to `pulumi.com/docs/install` for easier access to installation instructions

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
