### PR TITLE
Add typings to the Components doc

### DIFF
--- a/themes/default/content/docs/concepts/resources/components.md
+++ b/themes/default/content/docs/concepts/resources/components.md
@@ -45,7 +45,7 @@ class MyComponent extends pulumi.ComponentResource {
 
 ```typescript
 class MyComponent extends pulumi.ComponentResource {
-    constructor(name, opts) {
+    constructor(name: string, opts: pulumi.ComponentResourceOptions) {
         super("pkg:index:MyComponent", name, {}, opts);
     }
 }


### PR DESCRIPTION
After running `pulumi new typescript` and pasting the snippet as it exists today into `index.ts`, the compiler complains about `name` and `opts` being untyped. This fixes that.

Fixes #3907.