### PR TITLE
Update reference.md - Remove cat ssh key

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/deployments/reference.md
+++ b/themes/default/content/docs/pulumi-cloud/deployments/reference.md
@@ -207,7 +207,6 @@ The following will allow you to configure a private key and allow access to GitH
 
     ```bash
     mkdir /root/.ssh && printf -- "$SSHKEY" > /root/.ssh/id_ed25519
-    cat /root/.ssh/id_ed25519
     chmod 600 /root/.ssh/id_ed25519
     ssh-keyscan github.com >> ~/.ssh/known_hosts
      cd .. && git config --global --add url.\"git@github.com:\".insteadOf \"https://github.com\"


### PR DESCRIPTION
## Description

The current docs are doing a cat on the ssh key, which means the SSH key appears on the deployment logs, this is most likely undesired from a security perspective.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
