### PR TITLE
Blog: adding tags, mainly for Dev portal and platform engineering

### DIFF
--- a/themes/default/content/blog/building-developer-portals/index.md
+++ b/themes/default/content/blog/building-developer-portals/index.md
@@ -37,6 +37,7 @@ tags:
 - templates
 - policy-as-code
 - backstage
+- platform_engineering
 
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md

--- a/themes/default/content/blog/building-developer-portals/index.md
+++ b/themes/default/content/blog/building-developer-portals/index.md
@@ -37,7 +37,7 @@ tags:
 - templates
 - policy-as-code
 - backstage
-- platform_engineering
+- platform-engineering
 
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md

--- a/themes/default/content/blog/developer-portal-gallery/index.md
+++ b/themes/default/content/blog/developer-portal-gallery/index.md
@@ -33,6 +33,9 @@ authors:
 # At least one tag is required. Lowercase, hyphen-delimited is recommended.
 tags:
     - features
+    - developer-portals
+    - platform_engineering
+    
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md
 # for details, and please remove these comments before submitting for review.

--- a/themes/default/content/blog/developer-portal-gallery/index.md
+++ b/themes/default/content/blog/developer-portal-gallery/index.md
@@ -34,7 +34,7 @@ authors:
 tags:
     - features
     - developer-portals
-    - platform_engineering
+    - platform-engineering
     
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md

--- a/themes/default/content/blog/developer-portal-platform-teams/index.md
+++ b/themes/default/content/blog/developer-portal-platform-teams/index.md
@@ -16,7 +16,7 @@ tags:
     - templates
     - policy-as-code
     - backstage
-    - platform_engineering
+    - platform-engineering
 ---
 
 Over the last two years, we’ve seen a huge surge in adoption of Pulumi by __Platform Teams__ -- centralized teams within a business responsible for building out core cloud infrastructure and providing tools to the rest of the organization to maximize the productivity, cost efficacy, compliance and velocity of application and service delivery throughout the organization. These teams use Pulumi to manage their own cloud infrastructure complexity, to offer best practices components to their organizations, to enforce organizational policy, and to drive infrastructure delivery automation.

--- a/themes/default/content/blog/developer-portal-platform-teams/index.md
+++ b/themes/default/content/blog/developer-portal-platform-teams/index.md
@@ -16,6 +16,7 @@ tags:
     - templates
     - policy-as-code
     - backstage
+    - platform_engineering
 ---
 
 Over the last two years, we’ve seen a huge surge in adoption of Pulumi by __Platform Teams__ -- centralized teams within a business responsible for building out core cloud infrastructure and providing tools to the rest of the organization to maximize the productivity, cost efficacy, compliance and velocity of application and service delivery throughout the organization. These teams use Pulumi to manage their own cloud infrastructure complexity, to offer best practices components to their organizations, to enforce organizational policy, and to drive infrastructure delivery automation.

--- a/themes/default/content/blog/environments-secrets-configurations-management/index.md
+++ b/themes/default/content/blog/environments-secrets-configurations-management/index.md
@@ -14,7 +14,7 @@ authors:
 tags:
     - esc
     - secrets
-    - platform_engineering
+    - platform-engineering
 
 ---
 

--- a/themes/default/content/blog/environments-secrets-configurations-management/index.md
+++ b/themes/default/content/blog/environments-secrets-configurations-management/index.md
@@ -14,6 +14,7 @@ authors:
 tags:
     - esc
     - secrets
+    - platform_engineering
 
 ---
 

--- a/themes/default/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
+++ b/themes/default/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
@@ -36,7 +36,8 @@ tags:
     - iac
     - cloud-computing
     - multi-cloud
-    - forecast
+    - finops
+    - platform_engineering
     - devops
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md

--- a/themes/default/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
+++ b/themes/default/content/blog/future-cloud-infrastructure-10-trends-shaping-2024-and-beyond/index.md
@@ -37,7 +37,7 @@ tags:
     - cloud-computing
     - multi-cloud
     - finops
-    - platform_engineering
+    - platform-engineering
     - devops
 
 # See the blogging docs at https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md

--- a/themes/default/content/blog/mlops-huggingface-llm-aws-sagemaker-python/index.md
+++ b/themes/default/content/blog/mlops-huggingface-llm-aws-sagemaker-python/index.md
@@ -71,6 +71,8 @@ We will use the `sagemaker-aws-python` [Pulumi Template] to bootstrap our Python
 
 ## Instructions
 
+{{< youtube "9rwsutZbVfI?rel=0" >}}
+
 ### 1. Login to Pulumi Cloud and initialize stack
 
 Let's begin by logging into [Pulumi Cloud]:

--- a/themes/default/content/blog/mlops-huggingface-llm-aws-sagemaker-python/index.md
+++ b/themes/default/content/blog/mlops-huggingface-llm-aws-sagemaker-python/index.md
@@ -21,7 +21,7 @@ tags:
     - python
     - SageMaker
     - huggingface
-    - platform_engineering
+    - platform-engineering
 ---
 
 [Pulumi CLI]:/docs/install/

--- a/themes/default/content/blog/remediation-policies/index.md
+++ b/themes/default/content/blog/remediation-policies/index.md
@@ -1,10 +1,15 @@
 ---
 title: "Remediation Policies: Continuous and Automatic Compliance"
 authors: ["joe-duffy"]
-tags: ["pulumi-news"]
 meta_desc: "Pulumi CrossGuard remediation policies allow you to automatically fix violations, not just report them, ensuring continuous and automatic compliance."
 date: "2023-10-20"
 meta_image: "remediation.png"
+tags:
+    - features
+    - platform_engineering
+    - policy-as-code
+    - crossguard
+
 ---
 
 Pulumi’s policy as code engine, [CrossGuard](/crossguard), is already very flexible, and can enforce custom or predefined policies across a wide variety of use cases, including security, compliance, cost, and overall best practices. CrossGuard warns or issues errors should a deployment attempt to violate a policy. Last week we announced a new extension to CrossGuard called _remediation policies_. Remediation policies don’t just check for compliance, they go ahead and actually fix the problems in place. This ensures that every deployment across your entire team conforms, no questions asked, while also not needing to pester end users to remember all of the rules as they write their infrastructure as code, such as tagging resources a specific way. In this post, we will dig deeper into remediation policies and their use cases.

--- a/themes/default/content/blog/remediation-policies/index.md
+++ b/themes/default/content/blog/remediation-policies/index.md
@@ -6,7 +6,7 @@ date: "2023-10-20"
 meta_image: "remediation.png"
 tags:
     - features
-    - platform_engineering
+    - platform-engineering
     - policy-as-code
     - crossguard
 


### PR DESCRIPTION
## Description
Multiple articles relate to developer portals & platform engineering, but they need to be tagged to be found together.

The following tags will be added for SEO purposes (since they become part of the page itself) and for easy findability via tags. 
    - developer-portals
    - platform_engineering

Update: I also added other missing tags  on other somewhat related articles 
    
## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
