### PR TITLE
Update robots.txt to reference sitemap indexes

### DIFF
--- a/themes/default/layouts/robots.txt
+++ b/themes/default/layouts/robots.txt
@@ -9,5 +9,6 @@ Disallow: /docs/search/$
 # Disallow azure-native-v1. See https://github.com/pulumi/registry/issues/2879 for details.
 Disallow: /registry/packages/azure-native-v1
 
-Sitemap: https://www.pulumi.com/sitemap.xml
+Sitemap: https://www.pulumi.com/sitemap-index.xml
+Sitemap: https://www.pulumi.com/ai/sitemap-index.xml
 Host: www.pulumi.com


### PR DESCRIPTION
Updates the robots.txt file to refer to our sitemap index files. (All of these sitemaps and indexes have already been submitted to Google and are fully indexed; this change just codifies this in the proper canonical location.)

Fixes #3938.
