### PR TITLE
Fix missing video

### DIFF
--- a/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
+++ b/themes/default/content/resources/from-zero-to-production-in-kubernetes/index.md
@@ -49,7 +49,7 @@ main:
     # Webinar title.
     title: "From Zero to Production in Kubernetes"
     # URL for embedding a URL for ungated webinars.
-    youtube_url: #"https://www.youtube.com/embed/l8Ha60IJ6m8?si=AiKU_4MK3w3aAE_l?rel=0"
+    youtube_url: "https://www.youtube.com/embed/l8Ha60IJ6m8?si=AiKU_4MK3w3aAE_l?rel=0"
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2023-11-15T09:00:00-08:00
     # Duration of the webinar.


### PR DESCRIPTION
## Description

This PR fixes a missing video on Kubernetes workshop page (the video URL was inadvertently commented out; this PR removes the comment mark).

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
