### PR TITLE
Fix the location in the portal where to find default stack permissions.

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/projects-and-stacks.md
+++ b/themes/default/content/docs/pulumi-cloud/projects-and-stacks.md
@@ -38,7 +38,7 @@ The Pulumi Cloud provides fine-grained access controls for stacks. Stack permiss
 based on the member's role within the organization and their team membership.
 Additionally, any member who creates a stack is granted admin permissions on that stack.
 
-Organization admins can control the stack default permissions at the organization level from **Settings** > **General**.
+Organization admins can control the stack default permissions at the organization level from **Settings** > **Access Management**.
 There are four types of stack permissions: `None`, `Read`, `Write`, and `Admin`.
 [Team permissions](/docs/pulumi-cloud/access-management/teams#team-permissions) will expand these default permissions.
 


### PR DESCRIPTION
## Description

Fix the location in the portal where to find default stack permissions. It is under `Access Management` rather than `General`.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
