### PR TITLE
Remove workshop from resources

### DIFF
--- a/themes/default/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
+++ b/themes/default/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
@@ -8,7 +8,7 @@ meta_image: /images/resources/kubernetes-platform-amazon-eks-josh-carlos.png
 featured: false
 
 # Webinars with unlisted as true will not be shown on the webinar list
-unlisted: false
+unlisted: true
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.

--- a/themes/default/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
+++ b/themes/default/content/resources/building-a-kubernetes-platform-in-amazon-eks/index.md
@@ -12,7 +12,7 @@ unlisted: false
 
 # Gated webinars will have a registration form and the user will need
 # to fill out the form before viewing.
-gated: true
+gated: false
 
 # The layout of the landing page.
 type: webinars


### PR DESCRIPTION
## Description

The "Building a Kubernetes Platform in AWS EKS with Pulumi" workshop will not be hosted. It needs to be removed from resources.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
