### PR TITLE
Add an alias for the TF migration post

### DIFF
--- a/themes/default/content/pricing/_index.md
+++ b/themes/default/content/pricing/_index.md
@@ -6,4 +6,6 @@ layout: pricing
 menu:
     header:
         weight: 2
+aliases:
+    - /blog/tf-migration-offer
 ---


### PR DESCRIPTION
In #3979, we removed a blog post for an offer that no longer exists, but we forgot to redirect to a new location. This change redirects requests for that page to the pricing page, which mentions that TF migration is available at Enterprise and above.

[Internal discussion](https://pulumi.slack.com/archives/CCBFCGU94/p1709143875085719?thread_ts=1709143472.696799&cid=CCBFCGU94).
