### PR TITLE
Rename AWS Native Cloud Control provider

### DIFF
--- a/themes/default/content/blog/announcing-aws-native/index.md
+++ b/themes/default/content/blog/announcing-aws-native/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Announcing the Pulumi AWS Native Cloud Control Provider, Powered by the AWS Cloud Control API"
+title: "Announcing the Pulumi AWS Native Provider, Powered by the AWS Cloud Control API"
 date: 2021-09-30
-meta_desc: "New Pulumi AWS Native Cloud Control Provider offers same-day support for all new AWS features, building on the AWS Cloud Control API"
+meta_desc: "New Pulumi AWS Native Provider offers same-day support for all new AWS features, building on the AWS Cloud Control API"
 meta_image: aws_native_launch.png
 allow_long_title: True
 authors:
@@ -14,15 +14,15 @@ tags:
 When first announced this provider was called "AWS Native" during its preview but was renamed to "AWS Native Cloud Control" when made generally available.
 {{% /notes %}}
 
-We are excited to announce the release of the new [AWS Native Cloud Control](/registry/packages/aws-native/) provider for Pulumi, which is available today in preview. AWS is the most-used cloud provider across the Pulumi ecosystem, and with the new AWS Native Cloud Control provider, we are focused on delivering the best possible support for the AWS platform to all Pulumi users.
+We are excited to announce the release of the new [AWS Native](/registry/packages/aws-native/) provider for Pulumi, which is available today in preview. AWS is the most-used cloud provider across the Pulumi ecosystem, and with the new AWS Native provider, we are focused on delivering the best possible support for the AWS platform to all Pulumi users.
 
-Pulumi Native Providers like AWS Native Cloud Control are a new type of Pulumi Package that give you the most complete and consistent interface for the modern cloud. Pulumi native providers bring the full power of the top cloud providers to the Pulumi Cloud Engineering Platform, with faster updates and more complete coverage than any other infrastructure as code offering.
+Pulumi Native Providers like AWS Native are a new type of Pulumi Package that give you the most complete and consistent interface for the modern cloud. Pulumi native providers bring the full power of the top cloud providers to the Pulumi Cloud Engineering Platform, with faster updates and more complete coverage than any other infrastructure as code offering.
 
-The AWS Native Cloud Control provider offers same-day support for all new AWS features and releases covered by the newly released [AWS Cloud Control API](https://aws.amazon.com/blogs/aws/announcing-aws-cloud-control-api), which typically supports new AWS features on the day of launch. By building on the AWS Cloud Control API, the AWS Native Cloud Control provider offers a robust, reliable and well-defined resource model for AWS that’s available to Pulumi users in all Pulumi languages, including TypeScript, Python, Go and C#.  By leveraging the AWS Cloud Control API, the AWS Native Cloud Control provider builds on the work done by service teams at AWS to define the resource model for their services. This ensures a rock solid provisioning lifecycle for resources deployed with the AWS Native Cloud Control provider.
+The AWS Native provider offers same-day support for all new AWS features and releases covered by the newly released [AWS Cloud Control API](https://aws.amazon.com/blogs/aws/announcing-aws-cloud-control-api), which typically supports new AWS features on the day of launch. By building on the AWS Cloud Control API, the AWS Native provider offers a robust, reliable and well-defined resource model for AWS that’s available to Pulumi users in all Pulumi languages, including TypeScript, Python, Go and C#.  By leveraging the AWS Cloud Control API, the AWS Native provider builds on the work done by service teams at AWS to define the resource model for their services. This ensures a rock solid provisioning lifecycle for resources deployed with the AWS Native provider.
 
 <!--more-->
 
-This release also includes a new tool for migrating existing CloudFormation templates into Pulumi programs in your favorite language, powered by the new AWS Native Cloud Control provider and AWS Cloud Control API, as well as the ability to deploy any 3rd party resources in the CloudFormation Registry, including resources from Atlassian, Datadog, Densify, Dynatrace, Fortinet, New Relic, and Spot by NetApp.
+This release also includes a new tool for migrating existing CloudFormation templates into Pulumi programs in your favorite language, powered by the new AWS Native provider and AWS Cloud Control API, as well as the ability to deploy any 3rd party resources in the CloudFormation Registry, including resources from Atlassian, Datadog, Densify, Dynatrace, Fortinet, New Relic, and Spot by NetApp.
 
 {{% notes type="info" %}}
 To learn how AWS built the Cloud Control API, and many other great topics, [watch the replay of Cloud Engineering Summit 2021](/cloud-engineering-summit/replay/) with speakers from each of the major cloud providers as well as 40+ leaders and practitioners from across the industry.
@@ -32,11 +32,11 @@ To learn how AWS built the Cloud Control API, and many other great topics, [watc
 
 ## API Coverage
 
-Resources available in the Pulumi AWS Native Cloud Control provider are based on the resources defined in the [AWS CloudFormation Registry](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html). Today, hundreds of AWS resources are available from this registry via Cloud Control API and the Pulumi AWS Native Cloud Control provider. This list will continue to grow as additional resources are added to the AWS Cloud Control API. In addition, all new features and services that are released by AWS will be supported in AWS Native Cloud Control, typically on the same day as the release.
+Resources available in the Pulumi AWS Native provider are based on the resources defined in the [AWS CloudFormation Registry](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html). Today, hundreds of AWS resources are available from this registry via Cloud Control API and the Pulumi AWS Native provider. This list will continue to grow as additional resources are added to the AWS Cloud Control API. In addition, all new features and services that are released by AWS will be supported in AWS Native, typically on the same day as the release.
 
-The Pulumi AWS Native Cloud Control provider can be used in combination with the classic Pulumi AWS provider, as well as the 60+ additional Pulumi resource providers which cover a wide variety of other cloud and SaaS platforms.  While in preview, the Pulumi AWS Native Cloud Control provider may not yet have support for every feature of AWS that you need in your Pulumi applications, but can always be used along with the classic Pulumi AWS provider to cover both existing use cases and brand new supported features.
+The Pulumi AWS Native provider can be used in combination with the classic Pulumi AWS provider, as well as the 60+ additional Pulumi resource providers which cover a wide variety of other cloud and SaaS platforms.  While in preview, the Pulumi AWS Native provider may not yet have support for every feature of AWS that you need in your Pulumi applications, but can always be used along with the classic Pulumi AWS provider to cover both existing use cases and brand new supported features.
 
-In this example, we can see how the new AWS S3 Object Lambda feature can be used via the AWS Native Cloud Control provider, with access to the full API defined by the S3 team at AWS:
+In this example, we can see how the new AWS S3 Object Lambda feature can be used via the AWS Native provider, with access to the full API defined by the S3 team at AWS:
 
 {{< chooser language "typescript,python,csharp,go" >}}
 
@@ -176,21 +176,21 @@ func main() {
 
 ## Always Up-To-Date
 
-The Pulumi AWS Native Cloud Control provider is built automatically from the resources and specifications provided by the CloudFormation Registry.  Those specifications are updated frequently whenever new resources and features are shipped by service teams at AWS. The AWS Native Cloud Control provider is rebuilt and released nightly directly from the latest specifications, ensuring that Pulumi users have access to rich Pulumi SDKs for working with new features the same day they are added to Cloud Control API, typically on the day of launch.
+The Pulumi AWS Native provider is built automatically from the resources and specifications provided by the CloudFormation Registry.  Those specifications are updated frequently whenever new resources and features are shipped by service teams at AWS. The AWS Native provider is rebuilt and released nightly directly from the latest specifications, ensuring that Pulumi users have access to rich Pulumi SDKs for working with new features the same day they are added to Cloud Control API, typically on the day of launch.
 
 ## Interoperability with CloudFormation
 
-Although the AWS Native Cloud Control provider leverages the CloudFormation Registry and AWS Cloud Control API, it does not depend on deploying CloudFormation templates. You can write your programs in Pulumi, and Pulumi is responsible for managing the lifecycle and deployment of all resources in your stack. You get the same lightning-fast deployments you expect with Pulumi, along with the same rich infrastructure as code fundamentals like secrets, aliases, components, testing, policy, management console, and more.  There is no CloudFormation stack artifact in the AWS console, since the resource definitions and deployment are handled entirely by Pulumi".
+Although the AWS Native provider leverages the CloudFormation Registry and AWS Cloud Control API, it does not depend on deploying CloudFormation templates. You can write your programs in Pulumi, and Pulumi is responsible for managing the lifecycle and deployment of all resources in your stack. You get the same lightning-fast deployments you expect with Pulumi, along with the same rich infrastructure as code fundamentals like secrets, aliases, components, testing, policy, management console, and more.  There is no CloudFormation stack artifact in the AWS console, since the resource definitions and deployment are handled entirely by Pulumi".
 
 <!-- < gif of a fast deployment > -->
 
-Along with the release of the new AWS Native Cloud Control provider, we’ve also released cf2pulumi, a tool for migrating your existing CloudFormation templates to Pulumi programs in your favorite languages. cf2pulumi is available as both a web-based converter at [https://www.pulumi.com/cf2pulumi/](https://www.pulumi.com/cf2pulumi/), and as a [CLI tool](https://github.com/pulumi/pulumi-aws-native/tree/master/provider/cmd/cf2pulumi).
+Along with the release of the new AWS Native provider, we’ve also released cf2pulumi, a tool for migrating your existing CloudFormation templates to Pulumi programs in your favorite languages. cf2pulumi is available as both a web-based converter at [https://www.pulumi.com/cf2pulumi/](https://www.pulumi.com/cf2pulumi/), and as a [CLI tool](https://github.com/pulumi/pulumi-aws-native/tree/master/provider/cmd/cf2pulumi).
 
 [![cf2pulumi](cf2pulumi.png)](https://www.pulumi.com/cf2pulumi/)
 
 ## Access to 3rd Party Resources from the CloudFormation Registry
 
-In addition to all of the AWS resources available in AWS Native Cloud Control, we are also making it possible to create any of the 3rd-party resources available in the CloudFormation Registry, including resources from Atlassian, MongoDB, Snyk, and Spot by NetApp. You can read more about the 3rd party resources available in the CloudFormation registry in the [AWS launch post](https://aws.amazon.com/blogs/aws/introducing-a-public-registry-for-aws-cloudformation/) from earlier this year. The `aws.ExtensionResource` resource can be used to construct any 3rd party resource based on its resource type name. In the following example, we create a MongoDB Atlas project via the AWS Native Cloud Control provider:
+In addition to all of the AWS resources available in AWS Native, we are also making it possible to create any of the 3rd-party resources available in the CloudFormation Registry, including resources from Atlassian, MongoDB, Snyk, and Spot by NetApp. You can read more about the 3rd party resources available in the CloudFormation registry in the [AWS launch post](https://aws.amazon.com/blogs/aws/introducing-a-public-registry-for-aws-cloudformation/) from earlier this year. The `aws.ExtensionResource` resource can be used to construct any 3rd party resource based on its resource type name. In the following example, we create a MongoDB Atlas project via the AWS Native provider:
 
 {{< chooser language "typescript,python,csharp,go" >}}
 
@@ -257,9 +257,9 @@ _, err = aws.ExtensionResource(ctx, "atlas-project", &aws.ExtensionResourceArgs{
 
 ## Conclusion
 
-Pulumi’s Native Providers offer the very best support for each of the major cloud providers. Since we launched our first native provider, users have been asking when they could get access to a truly native provider for AWS, with same-day support for new features, high quality, and the familiar APIs documented by AWS service teams. To deliver this, we’ve worked with the AWS Cloud Control API team to ensure that we can provide a great experience for AWS users of Pulumi, and we’re extremely excited by what this will enable for AWS developers. Today’s release is just a starting point. We are working on increased resource coverage, higher-level APIs, and integrations with additional AWS services that will be delivered over the coming months as we prepare AWS Native Cloud Control for general availability next year.
+Pulumi’s Native Providers offer the very best support for each of the major cloud providers. Since we launched our first native provider, users have been asking when they could get access to a truly native provider for AWS, with same-day support for new features, high quality, and the familiar APIs documented by AWS service teams. To deliver this, we’ve worked with the AWS Cloud Control API team to ensure that we can provide a great experience for AWS users of Pulumi, and we’re extremely excited by what this will enable for AWS developers. Today’s release is just a starting point. We are working on increased resource coverage, higher-level APIs, and integrations with additional AWS services that will be delivered over the coming months as we prepare AWS Native for general availability next year.
 
-Get started with the AWS Native Cloud Control provider today:
+Get started with the AWS Native provider today:
 
 * [Docs](https://www.pulumi.com/registry/packages/aws-native/)
 * [Examples](https://github.com/pulumi/examples)

--- a/themes/default/content/blog/announcing-aws-native/index.md
+++ b/themes/default/content/blog/announcing-aws-native/index.md
@@ -1,7 +1,7 @@
 ---
-title: "Announcing the Pulumi AWS Native Provider, Powered by the AWS Cloud Control API"
+title: "Announcing the Pulumi AWS Native Cloud Control Provider, Powered by the AWS Cloud Control API"
 date: 2021-09-30
-meta_desc: "New Pulumi AWS Native Provider offers same-day support for all new AWS features, building on the AWS Cloud Control API"
+meta_desc: "New Pulumi AWS Native Cloud Control Provider offers same-day support for all new AWS features, building on the AWS Cloud Control API"
 meta_image: aws_native_launch.png
 allow_long_title: True
 authors:
@@ -10,15 +10,19 @@ tags:
    - aws
 ---
 
-We are excited to announce the release of the new [AWS Native](/registry/packages/aws-native/) provider for Pulumi, which is available today in preview. AWS is the most-used cloud provider across the Pulumi ecosystem, and with the new AWS Native provider, we are focused on delivering the best possible support for the AWS platform to all Pulumi users.
+{{% notes type="info" %}}
+When first announced this provider was called "AWS Native" during its preview but was renamed to "AWS Native Cloud Control" when made generally available.
+{{% /notes %}}
 
-Pulumi Native Providers like AWS Native are a new type of Pulumi Package that give you the most complete and consistent interface for the modern cloud. Pulumi native providers bring the full power of the top cloud providers to the Pulumi Cloud Engineering Platform, with faster updates and more complete coverage than any other infrastructure as code offering.
+We are excited to announce the release of the new [AWS Native Cloud Control](/registry/packages/aws-native/) provider for Pulumi, which is available today in preview. AWS is the most-used cloud provider across the Pulumi ecosystem, and with the new AWS Native Cloud Control provider, we are focused on delivering the best possible support for the AWS platform to all Pulumi users.
 
-The AWS Native provider offers same-day support for all new AWS features and releases covered by the newly released [AWS Cloud Control API](https://aws.amazon.com/blogs/aws/announcing-aws-cloud-control-api), which typically supports new AWS features on the day of launch. By building on the AWS Cloud Control API, the AWS Native provider offers a robust, reliable and well-defined resource model for AWS that’s available to Pulumi users in all Pulumi languages, including TypeScript, Python, Go and C#.  By leveraging the AWS Cloud Control API, the AWS Native provider builds on the work done by service teams at AWS to define the resource model for their services. This ensures a rock solid provisioning lifecycle for resources deployed with the AWS Native provider.
+Pulumi Native Providers like AWS Native Cloud Control are a new type of Pulumi Package that give you the most complete and consistent interface for the modern cloud. Pulumi native providers bring the full power of the top cloud providers to the Pulumi Cloud Engineering Platform, with faster updates and more complete coverage than any other infrastructure as code offering.
+
+The AWS Native Cloud Control provider offers same-day support for all new AWS features and releases covered by the newly released [AWS Cloud Control API](https://aws.amazon.com/blogs/aws/announcing-aws-cloud-control-api), which typically supports new AWS features on the day of launch. By building on the AWS Cloud Control API, the AWS Native Cloud Control provider offers a robust, reliable and well-defined resource model for AWS that’s available to Pulumi users in all Pulumi languages, including TypeScript, Python, Go and C#.  By leveraging the AWS Cloud Control API, the AWS Native Cloud Control provider builds on the work done by service teams at AWS to define the resource model for their services. This ensures a rock solid provisioning lifecycle for resources deployed with the AWS Native Cloud Control provider.
 
 <!--more-->
 
-This release also includes a new tool for migrating existing CloudFormation templates into Pulumi programs in your favorite language, powered by the new AWS Native provider and AWS Cloud Control API, as well as the ability to deploy any 3rd party resources in the CloudFormation Registry, including resources from Atlassian, Datadog, Densify, Dynatrace, Fortinet, New Relic, and Spot by NetApp.
+This release also includes a new tool for migrating existing CloudFormation templates into Pulumi programs in your favorite language, powered by the new AWS Native Cloud Control provider and AWS Cloud Control API, as well as the ability to deploy any 3rd party resources in the CloudFormation Registry, including resources from Atlassian, Datadog, Densify, Dynatrace, Fortinet, New Relic, and Spot by NetApp.
 
 {{% notes type="info" %}}
 To learn how AWS built the Cloud Control API, and many other great topics, [watch the replay of Cloud Engineering Summit 2021](/cloud-engineering-summit/replay/) with speakers from each of the major cloud providers as well as 40+ leaders and practitioners from across the industry.
@@ -28,11 +32,11 @@ To learn how AWS built the Cloud Control API, and many other great topics, [watc
 
 ## API Coverage
 
-Resources available in the Pulumi AWS Native provider are based on the resources defined in the [AWS CloudFormation Registry](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html). Today, hundreds of AWS resources are available from this registry via Cloud Control API and the Pulumi AWS Native provider. This list will continue to grow as additional resources are added to the AWS Cloud Control API. In addition, all new features and services that are released by AWS will be supported in AWS Native, typically on the same day as the release.
+Resources available in the Pulumi AWS Native Cloud Control provider are based on the resources defined in the [AWS CloudFormation Registry](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/registry.html). Today, hundreds of AWS resources are available from this registry via Cloud Control API and the Pulumi AWS Native Cloud Control provider. This list will continue to grow as additional resources are added to the AWS Cloud Control API. In addition, all new features and services that are released by AWS will be supported in AWS Native Cloud Control, typically on the same day as the release.
 
-The Pulumi AWS Native provider can be used in combination with the classic Pulumi AWS provider, as well as the 60+ additional Pulumi resource providers which cover a wide variety of other cloud and SaaS platforms.  While in preview, the Pulumi AWS Native provider may not yet have support for every feature of AWS that you need in your Pulumi applications, but can always be used along with the classic Pulumi AWS provider to cover both existing use cases and brand new supported features.
+The Pulumi AWS Native Cloud Control provider can be used in combination with the classic Pulumi AWS provider, as well as the 60+ additional Pulumi resource providers which cover a wide variety of other cloud and SaaS platforms.  While in preview, the Pulumi AWS Native Cloud Control provider may not yet have support for every feature of AWS that you need in your Pulumi applications, but can always be used along with the classic Pulumi AWS provider to cover both existing use cases and brand new supported features.
 
-In this example, we can see how the new AWS S3 Object Lambda feature can be used via the AWS Native provider, with access to the full API defined by the S3 team at AWS:
+In this example, we can see how the new AWS S3 Object Lambda feature can be used via the AWS Native Cloud Control provider, with access to the full API defined by the S3 team at AWS:
 
 {{< chooser language "typescript,python,csharp,go" >}}
 
@@ -172,21 +176,21 @@ func main() {
 
 ## Always Up-To-Date
 
-The Pulumi AWS Native provider is built automatically from the resources and specifications provided by the CloudFormation Registry.  Those specifications are updated frequently whenever new resources and features are shipped by service teams at AWS. The AWS Native provider is rebuilt and released nightly directly from the latest specifications, ensuring that Pulumi users have access to rich Pulumi SDKs for working with new features the same day they are added to Cloud Control API, typically on the day of launch.
+The Pulumi AWS Native Cloud Control provider is built automatically from the resources and specifications provided by the CloudFormation Registry.  Those specifications are updated frequently whenever new resources and features are shipped by service teams at AWS. The AWS Native Cloud Control provider is rebuilt and released nightly directly from the latest specifications, ensuring that Pulumi users have access to rich Pulumi SDKs for working with new features the same day they are added to Cloud Control API, typically on the day of launch.
 
 ## Interoperability with CloudFormation
 
-Although the AWS Native provider leverages the CloudFormation Registry and AWS Cloud Control API, it does not depend on deploying CloudFormation templates. You can write your programs in Pulumi, and Pulumi is responsible for managing the lifecycle and deployment of all resources in your stack. You get the same lightning-fast deployments you expect with Pulumi, along with the same rich infrastructure as code fundamentals like secrets, aliases, components, testing, policy, management console, and more.  There is no CloudFormation stack artifact in the AWS console, since the resource definitions and deployment are handled entirely by Pulumi".
+Although the AWS Native Cloud Control provider leverages the CloudFormation Registry and AWS Cloud Control API, it does not depend on deploying CloudFormation templates. You can write your programs in Pulumi, and Pulumi is responsible for managing the lifecycle and deployment of all resources in your stack. You get the same lightning-fast deployments you expect with Pulumi, along with the same rich infrastructure as code fundamentals like secrets, aliases, components, testing, policy, management console, and more.  There is no CloudFormation stack artifact in the AWS console, since the resource definitions and deployment are handled entirely by Pulumi".
 
 <!-- < gif of a fast deployment > -->
 
-Along with the release of the new AWS Native provider, we’ve also released cf2pulumi, a tool for migrating your existing CloudFormation templates to Pulumi programs in your favorite languages. cf2pulumi is available as both a web-based converter at [https://www.pulumi.com/cf2pulumi/](https://www.pulumi.com/cf2pulumi/), and as a [CLI tool](https://github.com/pulumi/pulumi-aws-native/tree/master/provider/cmd/cf2pulumi).
+Along with the release of the new AWS Native Cloud Control provider, we’ve also released cf2pulumi, a tool for migrating your existing CloudFormation templates to Pulumi programs in your favorite languages. cf2pulumi is available as both a web-based converter at [https://www.pulumi.com/cf2pulumi/](https://www.pulumi.com/cf2pulumi/), and as a [CLI tool](https://github.com/pulumi/pulumi-aws-native/tree/master/provider/cmd/cf2pulumi).
 
 [![cf2pulumi](cf2pulumi.png)](https://www.pulumi.com/cf2pulumi/)
 
 ## Access to 3rd Party Resources from the CloudFormation Registry
 
-In addition to all of the AWS resources available in AWS Native, we are also making it possible to create any of the 3rd-party resources available in the CloudFormation Registry, including resources from Atlassian, MongoDB, Snyk, and Spot by NetApp. You can read more about the 3rd party resources available in the CloudFormation registry in the [AWS launch post](https://aws.amazon.com/blogs/aws/introducing-a-public-registry-for-aws-cloudformation/) from earlier this year. The `aws.ExtensionResource` resource can be used to construct any 3rd party resource based on its resource type name. In the following example, we create a MongoDB Atlas project via the AWS Native provider:
+In addition to all of the AWS resources available in AWS Native Cloud Control, we are also making it possible to create any of the 3rd-party resources available in the CloudFormation Registry, including resources from Atlassian, MongoDB, Snyk, and Spot by NetApp. You can read more about the 3rd party resources available in the CloudFormation registry in the [AWS launch post](https://aws.amazon.com/blogs/aws/introducing-a-public-registry-for-aws-cloudformation/) from earlier this year. The `aws.ExtensionResource` resource can be used to construct any 3rd party resource based on its resource type name. In the following example, we create a MongoDB Atlas project via the AWS Native Cloud Control provider:
 
 {{< chooser language "typescript,python,csharp,go" >}}
 
@@ -253,9 +257,9 @@ _, err = aws.ExtensionResource(ctx, "atlas-project", &aws.ExtensionResourceArgs{
 
 ## Conclusion
 
-Pulumi’s Native Providers offer the very best support for each of the major cloud providers. Since we launched our first native provider, users have been asking when they could get access to a truly native provider for AWS, with same-day support for new features, high quality, and the familiar APIs documented by AWS service teams. To deliver this, we’ve worked with the AWS Cloud Control API team to ensure that we can provide a great experience for AWS users of Pulumi, and we’re extremely excited by what this will enable for AWS developers. Today’s release is just a starting point. We are working on increased resource coverage, higher-level APIs, and integrations with additional AWS services that will be delivered over the coming months as we prepare AWS Native for general availability next year.
+Pulumi’s Native Providers offer the very best support for each of the major cloud providers. Since we launched our first native provider, users have been asking when they could get access to a truly native provider for AWS, with same-day support for new features, high quality, and the familiar APIs documented by AWS service teams. To deliver this, we’ve worked with the AWS Cloud Control API team to ensure that we can provide a great experience for AWS users of Pulumi, and we’re extremely excited by what this will enable for AWS developers. Today’s release is just a starting point. We are working on increased resource coverage, higher-level APIs, and integrations with additional AWS services that will be delivered over the coming months as we prepare AWS Native Cloud Control for general availability next year.
 
-Get started with the AWS Native provider today:
+Get started with the AWS Native Cloud Control provider today:
 
 * [Docs](https://www.pulumi.com/registry/packages/aws-native/)
 * [Examples](https://github.com/pulumi/examples)

--- a/themes/default/content/docs/clouds/aws/_index.md
+++ b/themes/default/content/docs/clouds/aws/_index.md
@@ -14,7 +14,7 @@ get_started_guide:
   link: get-started/
   icon: aws
 providers:
-  description: Provision hundreds of AWS cloud resources with either the AWS Classic or AWS Native provider. The AWS Native provider is in preview status, with same-day access to AWS resources available in the AWS Cloud Control API.  While AWS Classic remains fully supported, try AWS Native if you need AWS resources not available in the classic version.
+  description: Provision hundreds of AWS cloud resources with either the AWS Classic or AWS Native Cloud Control provider. The AWS Native Cloud Control provider is in preview status, with same-day access to AWS resources available in the AWS Cloud Control API.  While AWS Classic remains fully supported, try AWS Native Cloud Control if you need AWS resources not available in the classic version.
   provider_list:
   - display_name: AWS Classic
     recommended: true
@@ -31,7 +31,7 @@ providers:
     - display_name: How-to guides
       icon: question-small-black
       url: aws/how-to-guides/
-  - display_name: AWS Native
+  - display_name: AWS Native Cloud Control
     public_preview: true
     content_links:
     - display_name: Overview

--- a/themes/default/content/docs/clouds/aws/_index.md
+++ b/themes/default/content/docs/clouds/aws/_index.md
@@ -32,7 +32,6 @@ providers:
       icon: question-small-black
       url: aws/how-to-guides/
   - display_name: AWS Native Cloud Control
-    public_preview: true
     content_links:
     - display_name: Overview
       icon: page-small-black

--- a/themes/default/content/docs/clouds/gcp/_index.md
+++ b/themes/default/content/docs/clouds/gcp/_index.md
@@ -17,7 +17,7 @@ providers:
   description: The Google Cloud Classic provider can provision many Google Cloud resources. Use the Google Cloud Native provider for same-day access to Google Cloud resources.
   provider_list:
   - display_name: Google Cloud Classic
-    description: The AWS Classic provider can provision many AWS cloud resources. Use the AWS Native provider for same-day access to all AWS resources.
+    description: The Google Cloud Classic provider can provision many AWS cloud resources. Use the Google Cloud Native provider for same-day access to all AWS resources.
     recommended: true
     content_links:
     - display_name: Overview

--- a/themes/default/content/docs/concepts/vs/cloud-template-transpilers/aws-cdk/_index.md
+++ b/themes/default/content/docs/concepts/vs/cloud-template-transpilers/aws-cdk/_index.md
@@ -49,7 +49,7 @@ The following table summarizes some additional similarities and differences betw
 | ------- | ------ | -------------- |
 | [Language Support](#language) | TypeScript, JavaScript, Python, Go, C#, F#, VB.NET, Java, YAML | Python, TypeScript, JavaScript, Go (developer preview), C#, Java |
 | [State Management](#state) | Managed by Pulumi Cloud or with self-managed options | Managed by the AWS CloudFormation service |
-| [Provider Support](#providers) | Supports all major cloud providers, including 100% same-day coverage of new resources with AWS Native | AWS only |
+| [Provider Support](#providers) | Supports all major cloud providers, including 100% same-day coverage of new resources with AWS Native Cloud Control | AWS only |
 | [Cloud Native Support](#cloud-native) | Richly typed support for the full cloud-native ecosystem and Kubernetes | AWS only |
 | [Dynamic Provider Support](#dynamic-providers) | Yes | Limited |
 | [OSS License](#license) | Apache License 2.0 | Apache License 2.0 (only applies to the CDK framework, and not the deployment engine) |

--- a/themes/default/content/docs/using-pulumi/crossguard/compliance-ready-policies.md
+++ b/themes/default/content/docs/using-pulumi/crossguard/compliance-ready-policies.md
@@ -49,7 +49,7 @@ Supported Compliance Ready Policy packages are:
 
 * `@pulumi/compliance-policy-manager` (**Required**) Policy Manager is used to manage Compliance Ready Policies.
 * `@pulumi/aws-compliance-policies` Set of Compliance Ready Policies for Amazon Web Services, for both
-  AWS Native and AWS Classic providers.
+  AWS Native Cloud Control and AWS Classic providers.
 * `@pulumi/azure-compliance-policies` Set of Compliance Ready Policies for Microsoft Azure, for both Azure
   Native and Azure Classic providers.
 * `@pulumi/google-compliance-policies` Set of Compliance Ready Policies for Google Cloud Platform, for

--- a/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
+++ b/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
@@ -42,7 +42,7 @@ To get started, click the link for the boilerplate repository template that you 
 
 You should name your repository (and thus, your Pulumi Package) using the following guidelines:
 
-- The name should start with `pulumi-`, like our [`pulumi-aws-native`](/registry/packages/aws-native) AWS Cloud Control Native Provider and our [`pulumi-eks`](/registry/packages/eks) Component for AWS Elastic Kubernetes Service (EKS)
+- The name should start with `pulumi-`, like our [`pulumi-aws-native`](/registry/packages/aws-native) AWS Native Cloud Control Provider and our [`pulumi-eks`](/registry/packages/eks) Component for AWS Elastic Kubernetes Service (EKS)
 - If you're naming a **native provider**, use the cloud provider's name and the suffix `-native`, like our [`pulumi-azure-native`](/registry/packages/azure-native) Azure Native Provider
 - If you're naming a **bridged provider**, re-use the Terraform provider's name but replace the `terraform-provider-` prefix with `pulumi-`
 - If you're naming a **component**, name your package using both the cloud provider whose resources you're building on top of and the resources, like our [`pulumi-aws-apigateway`](/registry/packages/aws-apigateway) Component for AWS API Gateway

--- a/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
+++ b/themes/default/content/docs/using-pulumi/pulumi-packages/how-to-author.md
@@ -42,7 +42,7 @@ To get started, click the link for the boilerplate repository template that you 
 
 You should name your repository (and thus, your Pulumi Package) using the following guidelines:
 
-- The name should start with `pulumi-`, like our [`pulumi-aws-native`](/registry/packages/aws-native) AWS Native Provider and our [`pulumi-eks`](/registry/packages/eks) Component for AWS Elastic Kubernetes Service (EKS)
+- The name should start with `pulumi-`, like our [`pulumi-aws-native`](/registry/packages/aws-native) AWS Cloud Control Native Provider and our [`pulumi-eks`](/registry/packages/eks) Component for AWS Elastic Kubernetes Service (EKS)
 - If you're naming a **native provider**, use the cloud provider's name and the suffix `-native`, like our [`pulumi-azure-native`](/registry/packages/azure-native) Azure Native Provider
 - If you're naming a **bridged provider**, re-use the Terraform provider's name but replace the `terraform-provider-` prefix with `pulumi-`
 - If you're naming a **component**, name your package using both the cloud provider whose resources you're building on top of and the resources, like our [`pulumi-aws-apigateway`](/registry/packages/aws-apigateway) Component for AWS API Gateway

--- a/themes/default/layouts/partials/docs/special-pages/cloud-overview.html
+++ b/themes/default/layouts/partials/docs/special-pages/cloud-overview.html
@@ -36,10 +36,10 @@
                             {{ $display_name := $provider.display_name }}
                             {{ $first_half_name := $provider.display_name }}
                             {{ $second_half_name := "" }}
-                            {{ if strings.Contains $display_name "Classic" }}
+                            {{ if strings.HasSuffix $display_name "Classic" }}
                                 {{ $first_half_name = strings.TrimRight "Classic" $display_name }}
                                 {{ $second_half_name = "Classic" }}
-                            {{ else if strings.Contains $display_name "Native" }}
+                            {{ else if strings.HasSuffix $display_name "Native" }}
                                 {{ $first_half_name = strings.TrimRight "Native" $display_name }}
                                 {{ $second_half_name = " Native" }}
                             {{ end }}

--- a/themes/default/layouts/partner/aws.html
+++ b/themes/default/layouts/partner/aws.html
@@ -104,7 +104,7 @@
                 <div class="w-full xl:w-1/2 text-left px-10 flex flex-col justify-center">
                     <h5>Full Coverage of AWS</h5>
                     <p>
-                        You can deploy the entire breadth of AWS services with Pulumi’s AWS Classic Provider and Native Provider SDKs. The newly released AWS Native Provider
+                        You can deploy the entire breadth of AWS services with Pulumi’s AWS Classic Provider and Native Provider SDKs. The newly released AWS Native Cloud Control Provider
                         (Preview) uses the AWS Cloud Control API to provide direct integration with AWS resource models and same-day updates for newly released AWS features.
                     </p>
 


### PR DESCRIPTION
## Description

Ready for the GA which includes a rename, update the docs and the original launch blog post to use the new name.

Also, fix accidental reference inthe GCP docs.

Related to:
- https://github.com/pulumi/pulumi-aws-native/issues/1226

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
