### PR TITLE
fix(concepts): use `id` attribute for security group

### DIFF
--- a/themes/default/content/docs/concepts/_index.md
+++ b/themes/default/content/docs/concepts/_index.md
@@ -63,7 +63,7 @@ Programs reside in a *project*, which is a directory that contains source code f
 
 To illustrate these concepts, the following program shows how to create an AWS EC2 security group named `web-sg` with a single ingress rule and a `t2.micro`-sized EC2 instance using that security group.
 
-To use the security group, the EC2 resource requires the security group's ID. Pulumi enables this through the output property `name` on the security group resource. Pulumi understands dependencies between resources and uses the relationships between resources to maximize parallelism and ensures correct ordering when a stack is instantiated.
+To use the security group, the EC2 resource requires the security group's ID. Pulumi enables this through the output property `id` on the security group resource. Pulumi understands dependencies between resources and uses the relationships between resources to maximize parallelism and ensures correct ordering when a stack is instantiated.
 
 Finally, the server's resulting IP address and DNS name are exported as stack outputs so that their values can be accessed through either a CLI command or by another stack.
 

--- a/themes/default/static/programs/aws-ec2-instance-with-sg-csharp/Program.cs
+++ b/themes/default/static/programs/aws-ec2-instance-with-sg-csharp/Program.cs
@@ -1,4 +1,4 @@
-﻿using Pulumi;
+using Pulumi;
 using Pulumi.Aws.Ec2;
 using Pulumi.Aws.Ec2.Inputs;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ return await Deployment.RunAsync(() =>
     var server = new Instance("web-server", new InstanceArgs {
         Ami = "ami-0319ef1a70c93d5c8",
         InstanceType = "t2.micro",
-        VpcSecurityGroupIds = { group.Name }
+        VpcSecurityGroupIds = { group.Id }
     });
 
     return new Dictionary<string, object?>


### PR DESCRIPTION
## Description

Uses `id` attribute in explanatory text and in the C# example code rather than `name`.

Fixes #3999

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
