### PR TITLE
fix: callback function docs not available

### DIFF
--- a/themes/default/content/docs/clouds/aws/guides/lambda.md
+++ b/themes/default/content/docs/clouds/aws/guides/lambda.md
@@ -162,9 +162,6 @@ docsBucket.onObjectCreated("docsHandler", new aws.lambda.CallbackFunction("docsH
 });
 ```
 
-For more information about the properties available on `CallbackFunction`, refer to the [API documentation](
-/registry/packages/aws/api-docs/lambda).
-
 ### Register an Event Handler by Creating a Lambda Function Resource
 
 It is possible to create and register serverless event handlers by allocating `aws.lambda.Function` objects


### PR DESCRIPTION
## Description

The `CallbackFunction` is a node only function which means that it does not have any general documentation. The link that is provided to find more information does not have any information on the `CallbackFunction`. Since we do not publish any language specific docs, I don't think there is any better place to point the user to.

fixes https://github.com/pulumi/pulumi-aws/issues/2035

## Checklist:

- [X] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- ~[ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).~
- ~[ ] I have manually confirmed that all new links work.~
- ~[ ] I added aliases (i.e., redirects) for all filename changes.~
- ~[ ] If making css changes, I rebuilt the bundle.~
