### PR TITLE
Temporarily redirect some deleted content

### DIFF
--- a/themes/default/content/resources/exploring-the-intersection-of-cluster-api-and-infrastructure-as-code.md
+++ b/themes/default/content/resources/exploring-the-intersection-of-cluster-api-and-infrastructure-as-code.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /resources/from-zero-to-production-in-kubernetes/
+---

--- a/themes/default/content/resources/nginx-deploy-kubernetes-and-the-kitchen-sink.md
+++ b/themes/default/content/resources/nginx-deploy-kubernetes-and-the-kitchen-sink.md
@@ -1,0 +1,3 @@
+---
+redirect_to:  /resources/from-zero-to-production-in-kubernetes/
+---

--- a/themes/default/content/resources/winning-the-product-agility-jackpot.md
+++ b/themes/default/content/resources/winning-the-product-agility-jackpot.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /resources/automating-infrastructure-as-code-workflows-with-pulumi/
+---


### PR DESCRIPTION
We deleted a number of outdated pages recently, but several are still being linked to from external sources (email, etc.). This change adds a few redirects to handle those while we await a more complete restoration and proper de-listing of the pages that were removed.

Fixes https://github.com/pulumi/marketing/issues/983.
