### PR TITLE
Fix ownershipControls definition and add fmt to go imports

### DIFF
--- a/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
@@ -276,7 +276,13 @@ bucket_object = s3.BucketObject(
 {{% choosable language go %}}
 
 ```go
-_, err = s3.NewBucketOwnershipControls(ctx, "ownership-controls", &s3.BucketOwnershipControlsArgs{
+import (
+	"fmt"
+	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+ownershipControls, err := s3.NewBucketOwnershipControls(ctx, "ownership-controls", &s3.BucketOwnershipControlsArgs{
     Bucket: bucket.ID(),
     Rule: &s3.BucketOwnershipControlsRuleArgs{
         ObjectOwnership: pulumi.String("ObjectWriter"),
@@ -301,6 +307,7 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
 }, pulumi.DependsOn([]pulumi.Resource{
 			publicAccessBlock,
+			ownershipControls,
 }))
 if err != nil {
     return err
@@ -449,12 +456,6 @@ pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_
 {{% choosable language go %}}
 
 ```go
-import (
-  "fmt"
-  "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
-)
-
 ctx.Export("bucketEndpoint", bucket.WebsiteEndpoint.ApplyT(func(websiteEndpoint string) (string, error) {
     return fmt.Sprintf("http://%v", websiteEndpoint), nil
 }).(pulumi.StringOutput))

--- a/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
+++ b/themes/default/content/docs/clouds/aws/get-started/deploy-changes.md
@@ -301,7 +301,6 @@ _, err = s3.NewBucketObject(ctx, "index.html", &s3.BucketObjectArgs{
     Acl:         pulumi.String("public-read"),
 }, pulumi.DependsOn([]pulumi.Resource{
 			publicAccessBlock,
-			ownershipControls,
 }))
 if err != nil {
     return err
@@ -450,6 +449,12 @@ pulumi.export('bucket_endpoint', pulumi.Output.concat('http://', bucket.website_
 {{% choosable language go %}}
 
 ```go
+import (
+  "fmt"
+  "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
 ctx.Export("bucketEndpoint", bucket.WebsiteEndpoint.ApplyT(func(websiteEndpoint string) (string, error) {
     return fmt.Sprintf("http://%v", websiteEndpoint), nil
 }).(pulumi.StringOutput))


### PR DESCRIPTION
## Description
While I was following the guide I stumble upon the following error:
```
./main.go:47:8: undefined: ownershipControls
./main.go:54:16: undefined: fmt
```

~~I was able to successfully create the infrastructure by adding the missing fmt library and removing the ownershipControls dependency.~~ 
- This could be fixed by adding the missing fmt library and set correctly the ownershipControls variable definition. 
## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md). N/A
- [ ] I have manually confirmed that all new links work. N/A
- [ ] I added aliases (i.e., redirects) for all filename changes. N/A
- [ ] If making css changes, I rebuilt the bundle. N/A
