### PR TITLE
Add a note about checking encryption salts into source control

### DIFF
--- a/themes/default/content/docs/concepts/secrets.md
+++ b/themes/default/content/docs/concepts/secrets.md
@@ -590,7 +590,7 @@ The [supported secrets providers](/docs/cli/commands/pulumi_stack_init/) are:
 After the provider has been changed, you should be able to run `pulumi preview` and see no proposed changes.  Your configuration secrets
 and state files are now encrypted using the new secrets provider.
 
-## Committing configuration to source control
+## Committing configuration to source control {# search.keywords="checking version control"}
 
 When you run `pulumi config set --secret` to generate a new Pulumi secret, the Pulumi CLI uses the stack's unique encryption key to encrypt the raw value and store the resulting ciphertext in the stack configuration file (`Pulumi.dev.yaml`, for example). If you opened this file in a text editor, you'd see that the contents would look something like this:
 
@@ -603,7 +603,7 @@ config:
 
 Decrypting this ciphertext requires the encryption key that was used to create it. For stacks managed with Pulumi Cloud, these keys are obtained automatically, but only for users with [read access](/docs/pulumi-cloud/projects-and-stacks/#stack-permissions) to the stack. For self-managed backends, the keys must be supplied by the user, either by providing the stack's current passphrase (when using the [`passphrase`](#changing-the-secrets-provider-for-a-stack) provider) or by authenticating with the stack's [encryption provider](#available-encryption-providers).
 
-It's therefore considered safe, and good practice, to check these files into source control, as doing so allows you to version your code and configuration in tandem. If you'd prefer not to check in these files, however, you can easily rebuild them, using the most recently deployed configuration, with [`pulumi config refresh`](/docs/cli/commands/pulumi_config_refresh/).
+It's therefore considered safe and good practice to check these files into source control (including the `encryptionSalt`s used with the passphrase provider), as doing so allows you to version your code and configuration in tandem. If you'd prefer not to check in these files, however, you can easily rebuild them, using the most recently deployed configuration, with [`pulumi config refresh`](/docs/cli/commands/pulumi_config_refresh/).
 
 ## Managing secrets with Pulumi ESC environments
 


### PR DESCRIPTION
Adds a note to clarify that checking these in is also safe and recommented. Also tidies up a bit of formatting and adds a few keywords to make this easier to find. ([Internal thread for reference](https://pulumi.slack.com/archives/C011EMDQ8JE/p1710371997870229).)
