### PR TITLE
add batch of April workshops to events page

### DIFF
--- a/themes/default/content/resources/getting-started-with-iac-google-cloud/index.md
+++ b/themes/default/content/resources/getting-started-with-iac-google-cloud/index.md
@@ -1,0 +1,79 @@
+---
+# Name of the event, <= 60 characters
+title: Getting Started with Infrastructure as Code on Google Cloud
+meta_desc: In this workshop, you will learn the core concepts needed to effectively deploy resources on Google Cloud with Pulumi.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: getting-started-with-iac-google-cloud
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Getting Started with Infrastructure as Code on AWS
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2024-04-24T09:00:00.000-07:00
+
+    # Duration of the webinar.
+    duration: 1 hour
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+        In this workshop, you will learn the fundamentals of infrastructure as code through guided exercises. You will be introduced to Pulumi, an infrastructure-as-code platform, where you can use familiar programming languages to provision modern cloud infrastructure.
+
+        This workshop is designed to help new users become familiar with the core concepts needed to effectively deploy resources on Google Cloud. We will guide you through the Pulumi platform with diagrams and a series of labs to help accelerate your cloud projects.
+
+    learn:
+        - The basics of the Pulumi Programming Model
+        - How to deploy resources on Google Cloud
+
+    # The webinar presenters
+    presenters:
+        - name: Diana Esteves
+          role: Solutions Architect, Pulumi
+          photo: /images/team/diana-esteves.jpg
+        - name: Jayson Smith
+          role: Sr. Cloud Customer Engineer, Google
+
+    # case-sensitive
+    tags:
+        level: Beginner # Beginner, Intermediate, Advanced
+        topics: ["Google Cloud"]
+        languages: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 69fe7896-fa8e-4812-b76e-3436363ac4a2
+    salesforce_campaign_id: 701PQ000008Z5OQYA0
+---

--- a/themes/default/content/resources/getting-started-with-iac-on-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-iac-on-aws/index.md
@@ -1,0 +1,76 @@
+---
+# Name of the event, <= 60 characters
+title: Getting Started with Infrastructure as Code on AWS
+meta_desc: In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using the Pulumi Cloud Engineering platform.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: getting-started-with-iac-on-aws
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Getting Started with Infrastructure as Code on AWS
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2024-04-04T09:00:00.000-07:00
+
+    # Duration of the webinar.
+    duration: 1 hour
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+        This workshop is designed to help users who are completely new to Pulumi become familiar with the core concepts to be effective with the Pulumi Infrastructure as Code platform. We will guide you through the Pulumi platform with diagrams and a series of hands-on exercises to help you understand the building blocks available in Pulumi
+
+    learn:
+        - The basics of the Pulumi Programming Model
+        - How to provision, update, and destroy AWS resources
+        - Build a simple serverless App with Lambda and s3 bucket
+
+    # The webinar presenters
+    presenters:
+        - name: Josh Kodroff
+          role: Sr. Solutions Architect, Pulumi
+          photo: /images/team/josh-kodroff.jpg
+
+    # case-sensitive
+    tags:
+        level: Beginner # Beginner, Intermediate, Advanced
+        topics: ["AWS"]
+        languages: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 65261ecc-933d-459b-9ac7-b1ede32410f4
+    salesforce_campaign_id: 701PQ000008KcEFYA0
+---

--- a/themes/default/content/resources/getting-started-with-infrastructure-as-code-aws/index.md
+++ b/themes/default/content/resources/getting-started-with-infrastructure-as-code-aws/index.md
@@ -1,0 +1,78 @@
+---
+# Name of the event, <= 60 characters
+title: Getting Started with Infrastructure as Code on AWS
+meta_desc: This introductory workshop is designed to help new users become familiar with the core concepts needed to deploy resources on AWS using Pulumi and Python.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: getting-started-with-infrastructure-as-code-aws
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Getting Started with Infrastructure as Code on AWS
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2024-04-18T09:00:00.000-07:00
+
+    # Duration of the webinar.
+    duration: 1 hour
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+        In this workshop, you will learn the fundamentals of Infrastructure as Code through a series of guided exercises using Pulumi’s Cloud Engineering platform. You will be introduced to Pulumi, an infrastructure as code platform, where you can use familiar programming languages to provision modern cloud infrastructure.
+
+        This workshop is designed to help users completely new to Pulumi to become familiar with the core concepts to be effective with the Pulumi Infrastructure as Code platform. We will guide you through the Pulumi platform with diagrams and a series of hands on exercises to help you understand the building blocks available in Pulumi.
+
+    learn:
+        - How to use Python with Pulumi
+        - The basics of the Pulumi Programming Model
+        - How to provision, update, and destroy AWS resources
+
+    # The webinar presenters
+    presenters:
+        - name: Diana Esteves
+          role: Solutions Architect, Pulumi
+          photo: /images/team/diana-esteves.jpg
+
+    # case-sensitive
+    tags:
+        level: Beginner # Beginner, Intermediate, Advanced
+        topics: ["AWS"]
+        languages: ["Python"]
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 5c9ccc1d-b2a0-4af9-887e-c202a57ab860
+    salesforce_campaign_id: 701PQ000008Yk5eYAC
+---

--- a/themes/default/content/resources/mastering-ci-cd-pipelines-gitlab-pulumi/index.md
+++ b/themes/default/content/resources/mastering-ci-cd-pipelines-gitlab-pulumi/index.md
@@ -1,0 +1,77 @@
+---
+# Name of the event, <= 60 characters
+title: Mastering CI/CD Pipelines with Pulumi and GitLab
+meta_desc: In this workshop, you'll learn how to use Pulumi's deep integration with GitLab to create and manage CI/CD pipelines for your infrastructure.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: mastering-ci-cd-pipelines-gitlab-pulumi
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Mastering CI/CD Pipelines with Pulumi and GitLab
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2024-04-03T09:00:00.000-07:00
+
+    # Duration of the webinar.
+    duration: 90 minutes
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+        In the ever-evolving landscape of DevOps and platform engineering, platform engineers are always seeking efficient and flexible tools to manage their cloud resources, especially when it comes to continuous integration/continuous delivery (CI/CD) pipelines.
+        
+        In this workshop, you'll learn how to use Pulumi's deep integration with GitLab to create and manage CI/CD pipelines for your infrastructure in a declarative function to empower your application and infrastructure teams to deliver safely, reproducably, and quickly.
+
+    learn:
+
+    # The webinar presenters
+    presenters:
+        - name: Josh Kodroff
+          role: Sr. Solutions Architect, Pulumi
+          photo: /images/team/josh-kodroff.jpg
+        - name: Matt Genelin
+          role: Solutions Architect, GitLab
+
+    # case-sensitive
+    tags:
+        level:  # Beginner, Intermediate, Advanced
+        topics: ["GitLab"]
+        languages: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 66338b61-db6c-472a-b4b6-f8ad4b1c9ebe
+    salesforce_campaign_id: 701PQ0000080HCPYA2
+---

--- a/themes/default/content/resources/real-world-platform-engineering-spot-netapp-pulumi/index.md
+++ b/themes/default/content/resources/real-world-platform-engineering-spot-netapp-pulumi/index.md
@@ -1,0 +1,80 @@
+---
+# Name of the event, <= 60 characters
+title: Real-World Platform Engineering - Spot by NetApp and Pulumi
+meta_desc: Explore real-world examples of how organizations can leverage the power of Pulumi and Spot to optimize their AKS workloads.
+meta_image:
+
+# A featured webinar will display first in the list.
+featured: false
+
+# Webinars with unlisted as true will not be shown on the webinar list
+unlisted: false
+
+# Gated webinars will have a registration form and the user will need
+# to fill out the form before viewing.
+gated: true
+
+# The layout of the landing page.
+type: webinars
+
+# External webinars will link to an external page instead of a webinar
+# landing/registration page. If the webinar is external you will need
+# set the 'block_external_search_index' flag to true so Google does not index
+# the webinar page created.
+external: false
+block_external_search_index: false
+
+# The url slug for the webinar landing page. If this is an external
+# webinar, use the external URL as the value here.
+url_slug: real-world-platform-engineering-spot-netapp-pulumi
+
+# Content for the left hand side section of the page.
+main:
+    # Webinar title.
+    title: Real-World Platform Engineering with Spot by NetApp and Pulumi
+
+    event_type: workshop # workshop | event
+
+    # URL for embedding a URL for ungated webinars.
+    youtube_url:
+
+    # Sortable date. The datetime Hugo will use to sort the webinars in date order.
+    sortable_date: 2024-04-10T09:00:00.000-07:00
+
+    # Duration of the webinar.
+    duration: 90 minutes
+
+    # "virtual" will be shown under "show virtual events only", otherwise shown as City, State (seattle, wa)
+    location: virtual
+
+    # Description of the webinar.
+    description: |
+        As the rush to the cloud continues, businesses need to run at the speed of innovation. This means a well-defined and efficient platform engineering approach becomes essential while balancing your cloud infrastructure’s security, compliance, and scalability.
+
+        In this webinar, presented by Spot by NetApp and Pulumi, we will explore real-world examples of how organizations can leverage the power of Pulumi and Spot to optimize their AKS workloads at launch and why continuous optimization of your AKS infrastructure is a critical part of any successful platform engineering program. Our experts will discuss best practices for managing AKS at scale and how you can simultaneously increase time-to-market and developer productivity.
+
+    learn:
+        - What Spot is and how to use it in Azure.
+        - How Spot ensures security and compliance while scaling.
+        - How Pulumi and Spot facilitates AKS usage at enterprise scale.
+
+    # The webinar presenters
+    presenters:
+        - name: Engin Diri
+          role: Sr. Community Engineer, Pulumi
+          photo: /images/team/engin-diri.jpg
+        - name: Shon Harris
+          role: Developer Relations Lead, NetApp
+
+    # case-sensitive
+    tags:
+        level: Beginner # Beginner, Intermediate, Advanced
+        topics: ["Azure", "AKS", "Spot"]
+        languages: []
+
+# The right hand side form section.
+form:
+    # HubSpot form id.
+    hubspot_form_id: 99bdfd5c-c36c-4be7-b45a-75b1cf490c45
+    salesforce_campaign_id: 701PQ000008YkQlYAK
+---

--- a/themes/default/content/resources/real-world-platform-engineering-spot-netapp-pulumi/index.md
+++ b/themes/default/content/resources/real-world-platform-engineering-spot-netapp-pulumi/index.md
@@ -1,6 +1,6 @@
 ---
 # Name of the event, <= 60 characters
-title: Real-World Platform Engineering - Spot by NetApp and Pulumi
+title: Microsoft AKS Engineering at Scale with Spot and Pulumi
 meta_desc: Explore real-world examples of how organizations can leverage the power of Pulumi and Spot to optimize their AKS workloads.
 meta_image:
 
@@ -31,7 +31,7 @@ url_slug: real-world-platform-engineering-spot-netapp-pulumi
 # Content for the left hand side section of the page.
 main:
     # Webinar title.
-    title: Real-World Platform Engineering with Spot by NetApp and Pulumi
+    title: Microsoft AKS Engineering at Scale with Spot and Pulumi
 
     event_type: workshop # workshop | event
 


### PR DESCRIPTION
## Description
redoing [this PR](https://github.com/pulumi/pulumi-hugo/pull/4048) due to extra files in the commit

added the following workshops:
https://github.com/pulumi/marketing/issues/979
https://github.com/pulumi/marketing/issues/980
https://github.com/pulumi/marketing/issues/981
https://github.com/pulumi/marketing/issues/982
https://github.com/pulumi/marketing/issues/965