### PR TITLE
Adds docs for Pulumi ESC 1Password provider

### DIFF
--- a/themes/default/content/docs/esc/providers/1password-secrets.md
+++ b/themes/default/content/docs/esc/providers/1password-secrets.md
@@ -1,0 +1,68 @@
+---
+title_tag: 1password-secrets Pulumi ESC Provider
+meta_desc: The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Environment.
+title: 1password-secrets
+h1: 1password-secrets
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+    pulumiesc:
+        identifier: 1password-secrets
+        parent: esc-providers
+        weight: 1
+aliases:
+- /docs/pulumi-cloud/esc/providers/1password-secrets/
+---
+
+The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Environment. The provider will return a map of names to Secrets.
+
+{{% notes type="warning" %}}
+This provider is currently in **preview**.
+{{% /notes %}}
+
+## Example
+
+```yaml
+  1password:
+    login:
+      fn::open::1password-login:
+        address: https://127.0.0.1:8200/
+        jwt:
+          role: example-role
+    secrets:
+      fn::open::1password-secrets:
+        login: ${1password.login}
+        read:
+          api-key:
+            path: api-key
+          app-secret:
+            path: app-secret
+```
+
+
+## Inputs
+
+| Property | Type                                                   | Description                               |
+|----------|--------------------------------------------------------|-------------------------------------------|
+| `login`  | [1PasswordSecretsLogin](#1passwordsecretslogin)        | Credentials used to log in to 1Password.  |
+| `get`    | map[string][1PasswordSecretsGet](#1passwordsecretsget) | The secrets to get.                       |
+
+### 1PasswordSecretsLogin
+
+| Property              | Type   | Description                                                                   |
+|-----------------------|--------|-------------------------------------------------------------------------------|
+| `serviceAccountToken` | string | The service account token to use for authentication..                         |
+
+### 1PasswordSecretsGet
+
+| Property | Type   | Description                                  |
+|----------|--------|----------------------------------------------|
+| `ref `   | string | A [reference to a secret](https://developer.1password.com/docs/cli/secrets-reference-syntax) of the form `op://vault-name/item-name/[section-name/]field-name` to read from 1Password.  |
+
+<!-- map[string][1PasswordSecretsGetRef](#1passwordsecretsgetref) -->
+<!-- ### 1PasswordSecretsGetRef -->
+
+### Outputs
+
+| Property | Type   | Description                        |
+|----------|--------|------------------------------------|
+| N/A      | object | A map from names to secret values. |

--- a/themes/default/content/docs/esc/providers/1password-secrets.md
+++ b/themes/default/content/docs/esc/providers/1password-secrets.md
@@ -23,21 +23,25 @@ This provider is currently in **preview**.
 
 ```yaml
   1password:
-    login:
-      fn::open::1password-login:
-        address: https://127.0.0.1:8200/
-        jwt:
-          role: example-role
     secrets:
       fn::open::1password-secrets:
-        login: ${1password.login}
-        read:
-          api-key:
-            path: api-key
-          app-secret:
-            path: app-secret
+        login:
+          serviceAccountToken:
+            fn::secret: "ops_123ABC"
+        get:
+          email_section_example:
+            ref: "op://Management/PagerDuty/Admin/email"
+          anna_sans_section_example:
+            ref: "op://dev/Stripe/publishable-key"
+          olaf_attr_example:
+            ref: "op://development/GitHub/Security/one-time password?attribute=otp"
+          sven_ssh_example:
+            ref: "op://Private/ssh keys/ssh key/private key?ssh-format=openssh"
+          nokk_whitespace_example:
+            ref: "op://development/aws/Access Keys/access_key_id"
+          gale_unique_id_example:
+            ref: "op://prod/yj3jfj2vzsbiwqabprflnl27lm/password"
 ```
-
 
 ## Inputs
 
@@ -56,10 +60,7 @@ This provider is currently in **preview**.
 
 | Property | Type   | Description                                  |
 |----------|--------|----------------------------------------------|
-| `ref `   | string | A [reference to a secret](https://developer.1password.com/docs/cli/secrets-reference-syntax) of the form `op://vault-name/item-name/[section-name/]field-name` to read from 1Password.  |
-
-<!-- map[string][1PasswordSecretsGetRef](#1passwordsecretsgetref) -->
-<!-- ### 1PasswordSecretsGetRef -->
+| `ref`    | string | A [reference to a secret](https://developer.1password.com/docs/cli/secrets-reference-syntax) of the form `op://vault-name/item-name/[section-name/]field-name` to read from 1Password.  |
 
 ### Outputs
 

--- a/themes/default/content/docs/esc/providers/_index.md
+++ b/themes/default/content/docs/esc/providers/_index.md
@@ -16,14 +16,15 @@ Pulumi ESC providers enable you to dynamically import secrets and configuration 
 
 To learn how to set up and use each provider, follow the links below. To learn how to configure OpenID Connect (OIDC) for the providers that support it, see [OpenID Connect integration](/docs/pulumi-cloud/oidc/) in the Pulumi Cloud documentation.
 
-| Provider                                                         | Description                                                                                                                   |
-|------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| [aws-login](/docs/pulumi-cloud/esc/providers/aws-login/)         | The `aws-login` provider enables you to log in to your AWS account using OpenID Connect or static credentials.                |
-| [aws-secrets](/docs/pulumi-cloud/esc/providers/aws-secrets/)     | The `aws-secrets` provider enables you to dynamically import Secrets from AWS Secrets Manager into your Environment.          |
-| [azure-login](/docs/pulumi-cloud/esc/providers/azure-login/)     | The `azure-login` provider enables you to log in to Azure using OpenID Connect or static credentials.                         |
-| [azure-secrets](/docs/pulumi-cloud/esc/providers/azure-secrets/) | The `azure-secrets` provider enables you to dynamically import Secrets from Azure Key Vault into your Environment.            |
-| [gcp-login](/docs/pulumi-cloud/esc/providers/gcp-login/)         | The `gcp-login` provider enables you to log in to Google Cloud using OpenID Connect or static credentials.                    |
-| [gcp-secrets](/docs/pulumi-cloud/esc/providers/gcp-secrets/)     | The `gcp-secrets` provider enables you to dynamically import Secrets from Google Cloud Secrets Manager into your Environment. |
-| [pulumi-stacks](/docs/pulumi-cloud/esc/providers/pulumi-stacks/) | The `pulumi-stacks` provider enables you to import Stack outputs from Pulumi into your Environment.                           |
-| [vault-login](/docs/pulumi-cloud/esc/providers/vault-login/)     | The `vault-login` provider enables you to log in to HashiCorp Vault using OpenID Connect or static credentials.               |
-| [vault-secrets](/docs/pulumi-cloud/esc/providers/vault-secrets/) | The `vault-secrets` provider enables you to dynamically import Secrets from HashiCorp Vault into your Environment.            |
+| Provider                                                                 | Description                                                                                                                   |
+|--------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| [1password-secrets](/docs/pulumi-cloud/esc/providers/1password-secrets/) | The `1password-secrets` provider enables you to dynamically import Secrets from 1Password into your Environment.              |
+| [aws-login](/docs/pulumi-cloud/esc/providers/aws-login/)                 | The `aws-login` provider enables you to log in to your AWS account using OpenID Connect or static credentials.                |
+| [aws-secrets](/docs/pulumi-cloud/esc/providers/aws-secrets/)             | The `aws-secrets` provider enables you to dynamically import Secrets from AWS Secrets Manager into your Environment.          |
+| [azure-login](/docs/pulumi-cloud/esc/providers/azure-login/)             | The `azure-login` provider enables you to log in to Azure using OpenID Connect or static credentials.                         |
+| [azure-secrets](/docs/pulumi-cloud/esc/providers/azure-secrets/)         | The `azure-secrets` provider enables you to dynamically import Secrets from Azure Key Vault into your Environment.            |
+| [gcp-login](/docs/pulumi-cloud/esc/providers/gcp-login/)                 | The `gcp-login` provider enables you to log in to Google Cloud using OpenID Connect or static credentials.                    |
+| [gcp-secrets](/docs/pulumi-cloud/esc/providers/gcp-secrets/)             | The `gcp-secrets` provider enables you to dynamically import Secrets from Google Cloud Secrets Manager into your Environment. |
+| [pulumi-stacks](/docs/pulumi-cloud/esc/providers/pulumi-stacks/)         | The `pulumi-stacks` provider enables you to import Stack outputs from Pulumi into your Environment.                           |
+| [vault-login](/docs/pulumi-cloud/esc/providers/vault-login/)             | The `vault-login` provider enables you to log in to HashiCorp Vault using OpenID Connect or static credentials.               |
+| [vault-secrets](/docs/pulumi-cloud/esc/providers/vault-secrets/)         | The `vault-secrets` provider enables you to dynamically import Secrets from HashiCorp Vault into your Environment.            |

--- a/themes/default/content/docs/esc/reference.md
+++ b/themes/default/content/docs/esc/reference.md
@@ -109,18 +109,27 @@ values:
   # sources using a variety of providers. This configuration will be loaded when the
   # environment is opened.
   # ---------------------------------------------------------------------------------------
-  # 1Password Provide example
+
+  # 1Password Provider examples
   1password:
     secrets:
-      fn::open::aws-secrets:
-        region: us-west-1
-        login: ${aws.login}
+      fn::open::1password-secrets:
+        login:
+          serviceAccountToken:
+            fn::secret: "ops_123ABC"
         get:
-          api-key:
-            secretId: api-key
-          app-secret:
-            secretId: app-secret
-
+          email_section_example:
+            ref: "op://Management/PagerDuty/Admin/email"
+          anna_sans_section_example:
+            ref: "op://dev/Stripe/publishable-key"
+          olaf_attr_example:
+            ref: "op://development/GitHub/Security/one-time password?attribute=otp"
+          sven_ssh_example:
+            ref: "op://Private/ssh keys/ssh key/private key?ssh-format=openssh"
+          nokk_whitespace_example:
+            ref: "op://development/aws/Access Keys/access_key_id"
+          gale_unique_id_example:
+            ref: "op://prod/yj3jfj2vzsbiwqabprflnl27lm/password"
 
   # AWS Provider examples
   aws:

--- a/themes/default/content/docs/esc/reference.md
+++ b/themes/default/content/docs/esc/reference.md
@@ -109,6 +109,18 @@ values:
   # sources using a variety of providers. This configuration will be loaded when the
   # environment is opened.
   # ---------------------------------------------------------------------------------------
+  # 1Password Provide example
+  1password:
+    secrets:
+      fn::open::aws-secrets:
+        region: us-west-1
+        login: ${aws.login}
+        get:
+          api-key:
+            secretId: api-key
+          app-secret:
+            secretId: app-secret
+
 
   # AWS Provider examples
   aws:


### PR DESCRIPTION
## Description

This updates the syntax reference page and adds a new Pulumi ESC provider page, 1Password. The syntax of the examples was tested using the `zephyr` Pulumi Org.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.


Closes https://github.com/pulumi/pulumi-hugo/issues/4047