### PR TITLE
Use  for a client-side redirect

### DIFF
--- a/themes/default/content/docs/concepts/inputs-outputs/outputs-and-strings.md
+++ b/themes/default/content/docs/concepts/inputs-outputs/outputs-and-strings.md
@@ -1,8 +1,3 @@
 ---
-title: "Working with Outputs and Strings"
-meta_desc: Learn how to use string interpolation with Outputs in Pulumi.
-aliases:
-  - /docs/concepts/inputs-outputs/outputs-and-strings/
+redirect_to: /docs/concepts/inputs-outputs/all/#using-string-interpolation
 ---
-
-<meta http-equiv="refresh" content="0; URL='/docs/concepts/inputs-outputs/all/#using-string-interpolation'">


### PR DESCRIPTION
Fixes https://github.com/pulumi/docs/issues/11041.

Nothing was particularly _wrong_ here -- it's just that the leading quotes were running afoul of our link-translation tool, and in fixing that, I realized we could just use `redirect_to`, which effectively does the same thing as manually adding a `meta` tag to the content of the page (albeit in a uniform way across the site).