### PR TITLE
Remove some lint warnings

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,6 @@ yarn-error.log
 themes/default/theme
 themes/default/assets
 themes/default/layouts
+# Don't check csharp build products
+themes/default/static/programs/*/bin/*
+themes/default/static/programs/*/obj/*


### PR DESCRIPTION


## Description

Running `make lint` shouldn't warn on files that are produced by the CSharp build process. Add those paths to the `.prettierrc` file

- [X] `make lint` runs clean without warnings or errors

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
