### PR TITLE
Remove broken link to community-engineering page.

### DIFF
--- a/themes/default/layouts/community/community-engineering/single.html
+++ b/themes/default/layouts/community/community-engineering/single.html
@@ -13,10 +13,6 @@
                 <h2 class="mb-1">{{ $personData.name }}</h2>
                 <div class="text-sm text-gray-700 mb-1">
                     <span class="">{{ $personData.title }}</span>
-                    <span>
-                        <span class="hidden md:inline">&bull; </span>
-                        <a class="block md:inline text-blue-500 underline" href="{{ relref . "/community/community-engineering" }}">See all community engineers</a>
-                    </span>
                 </div>
                 {{ partial "widgets/social-icons.html" (dict "social" $personData.social)}}
                 <div class="my-8 text-left">

--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,0 +1,5 @@
+module aws-simulated-server-interpolate-go
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.102.0


### PR DESCRIPTION
## Description

The docs build is failing due to this broken relref link that is trying to link to `/community/community-engineering`. This appears to be a top level page that I'm guessing would list out all the community engineers. This page seems to no longer exist. So I'm removing the link for now, to unblock the build  and we can decide if we want to bring that page back later and then we can add back the link.