### PR TITLE
fix(fundamentals): fix incorrect filename in embedding tutorial

### DIFF
--- a/themes/default/content/learn/embedding-pulumi/building-api/index.md
+++ b/themes/default/content/learn/embedding-pulumi/building-api/index.md
@@ -24,7 +24,7 @@ The Automation API allows us to create an API for our current infrastructure. Ha
 
 Let's start out with scaffolding the code by importing the right libraries and doing a bit of conversion of our basic Pulumi commands (create, configure, refresh, destroy, and update) to code with the automation API library. We'll be working in the `infra` directory at this point.
 
-First, clear out the {{< langfile >}} file in the `infra` directory; from here on out, it's just there as a placeholder for the module itself in Python.
+First, clear out the `__main__.py` file in the `infra` directory; from here on out, it's just there as a placeholder for the module itself in Python.
 
 Next, add a file called `basic.py` into the `infra` directory with this code in it:
 

--- a/themes/default/content/learn/embedding-pulumi/getting-started/index.md
+++ b/themes/default/content/learn/embedding-pulumi/getting-started/index.md
@@ -178,7 +178,7 @@ def pulumi_program():
 
 With the Automation API, we can invoke programs that are passed inline (meaning all of the actual code that's being run is part of the automation we'll define later) or passed via a local program. "Local" in this case is local to the system running the Automation API itself, not necessarily local to your machine. Local programs are probably the most commonly used. However, inline programs are great for running tests or other smaller, atomized actions. Here, we're setting up a local program with the `pulumi_program` function, which makes the entire local program callable by the API. The function itself should be a usable, runnable Pulumi program as demonstrated here. The program itself is setting up an AWS Lambda function with the requisite roles and policies and an invocation. The exports will get fed up to our API program.
 
-In the {{< langfile >}} in the `api` directory, replace all of the contents with the following code:
+In the `__main__.py` in the `api` directory, replace all of the contents with the following code:
 
 {{< code-filename file="learn-auto-api/api/__main__.py" >}}
 


### PR DESCRIPTION
## Description

Fixes #4085 

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
