### PR TITLE
Fix C# JsonDeserialize example

### DIFF
--- a/themes/default/static/programs/aws-iampolicy-jsonparse-csharp/Program.cs
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-csharp/Program.cs
@@ -1,44 +1,45 @@
-﻿using Pulumi;
-using Pulumi.Aws.S3;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using Pulumi;
 
 return await Deployment.RunAsync(() =>
 {
-    var jsonIAMPolicy = Output.Create(@"
-            {
-                ""Version"": ""2012-10-17"",
-                ""Statement"": [
-                    {
-                        ""Sid"": ""VisualEditor0"",
-                        ""Effect"": ""Allow"",
-                        ""Action"": [
-                            ""s3:ListAllMyBuckets"",
-                            ""s3:GetBucketLocation""
-                        ],
-                        ""Resource"": ""*""
-                    },
-                    {
-                        ""Sid"": ""VisualEditor1"",
-                        ""Effect"": ""Allow"",
-                        ""Action"": [
-                            ""s3:*""
-                        ],
-                        ""Resource"": ""arn:aws:s3:::my-bucket""
-                    }
-                ]
-            }
-        ");
-    
-    var policyWithNoStatements = Pulumi.Output.JsonDeserialize<IAMPolicy>(jsonIAMPolicy).Apply(policy =>
-    {
-        // delete the policy statements.
-        policy.Statement = Pulumi.Output.Create(new List<StatementEntry> { });
-        return policy;
-    })
+    var jsonIAMPolicy = Output.Create(
+        @"
+        {
+            ""Version"": ""2012-10-17"",
+            ""Statement"": [
+                {
+                    ""Sid"": ""VisualEditor0"",
+                    ""Effect"": ""Allow"",
+                    ""Action"": [
+                        ""s3:ListAllMyBuckets"",
+                        ""s3:GetBucketLocation""
+                    ],
+                    ""Resource"": ""*""
+                },
+                {
+                    ""Sid"": ""VisualEditor1"",
+                    ""Effect"": ""Allow"",
+                    ""Action"": [
+                        ""s3:*""
+                    ],
+                    ""Resource"": ""arn:aws:s3:::my-bucket""
+                }
+            ]
+        }
+    "
+    );
 
-    // Export the name of the bucket
-    return new Dictionary<string, object?>
-    {
-        ["policy"] = policyWithNoStatements
-    };
+    // Parse the Output<string> into a C# Dictionary.
+    var policyWithNoStatements = Output
+        .JsonDeserialize<Dictionary<string, object?>>(jsonIAMPolicy)
+        .Apply(policy =>
+        {
+            // Empty the policy's Statements list.
+            policy["Statement"] = Output.Create(new List<Dictionary<string, object?>> { });
+            return policy;
+        });
+
+    // Export the modified policy.
+    return new Dictionary<string, object?> { ["policy"] = policyWithNoStatements, };
 });

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
@@ -4,7 +4,4 @@ go 1.21
 
 toolchain go1.22.1
 
-require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
-)
+require github.com/pulumi/pulumi/sdk/v3 v3.108.1

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-go/main.go
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-go/main.go
@@ -6,6 +6,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+
 		jsonIAMPolicy := pulumi.ToOutput(`{
 		    "Version": "2012-10-17",
 		    "Statement": [
@@ -27,14 +28,17 @@ func main() {
 		    ]
 		}`).(pulumi.StringInput)
 
+		// Parse the string output.
 		policyWithNoStatements := pulumi.JSONUnmarshal(jsonIAMPolicy).ApplyT(
 			func(v interface{}) (interface{}, error) {
 
-				// delete the policy statements
+				// Empty the policy's Statements list.
 				v.(map[string]interface{})["Statement"] = []pulumi.ArrayOutput{}
 				return v, nil
-			})
+			},
+		)
 
+		// Export the modified policy.
 		ctx.Export("policy", policyWithNoStatements)
 		return nil
 	})

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-javascript/index.js
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-javascript/index.js
@@ -22,10 +22,12 @@ const jsonIAMPolicy = pulumi.output(`{
     ]
 }`);
 
+// Parse the string output.
 const policyWithNoStatements = pulumi.jsonParse(jsonIAMPolicy).apply(policy => {
-    // delete the policy statements
+    // Empty the policy's Statements list.
     policy.Statement = [];
     return policy;
 });
 
+// Export the modified policy.
 exports.policy = policyWithNoStatements;

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-python/__main__.py
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-python/__main__.py
@@ -1,6 +1,7 @@
 import pulumi
 
-json_iam_policy = pulumi.Output.from_input('''
+json_iam_policy = pulumi.Output.from_input(
+    """
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -21,14 +22,20 @@ json_iam_policy = pulumi.Output.from_input('''
         }
     ]
 }
-''')
+"""
+)
+
 
 def update_policy(policy):
-    # delete the policy statements
-    policy.update({'Statement': []})
+    # Empty the policy's Statements list.
+    policy.update({"Statement": []})
     return policy
 
-policy_with_no_statements = \
-    pulumi.Output.json_loads(json_iam_policy).apply(update_policy)
-    
+
+# Parse the string output.
+policy_with_no_statements = pulumi.Output.json_loads(json_iam_policy).apply(
+    lambda policy: update_policy
+)
+
+# Export the modified policy.
 pulumi.export("policy", policy_with_no_statements)

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-typescript/index.ts
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-typescript/index.ts
@@ -21,10 +21,12 @@ const jsonIAMPolicy = pulumi.output(`{
     ]
 }`);
 
+// Parse the string output.
 const policyWithNoStatements: pulumi.Output<object> = pulumi.jsonParse(jsonIAMPolicy).apply(policy => {
-    // delete the policy statements
+    // Empty the policy's Statements list.
     policy.Statement = [];
     return policy;
 });
 
+// Export the modified policy.
 export const policy = policyWithNoStatements;


### PR DESCRIPTION
Fixes the C# example by using plain Dictionary types instead, and adds a bit of clarity (hopefully!) to the comments about what's going on in the code. (Also runs black, Prettier, Csharpier for formatting.)