### PR TITLE
add instructions for installing dev CLI

### DIFF
--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -555,13 +555,15 @@ You can specify a specific version with [Chocolatey package manager](https://cho
 
 {{% /chooser %}}
 
-In addition to insalling a specific version, the latest dev version can also be installed automatically.  This version contains the latest changes that have been merged to the main branch.
+## Installing dev releases
+
+In addition to installing a specific version, the latest dev version can also be installed automatically.  This version contains the latest changes that have been merged to the main branch.
 
 {{% chooser os "macos,windows,linux" %}}
 
 {{% choosable os macos %}}
 
-### Installation script
+### macOS Installation Script
 
 ```bash
 $ curl -fsSL https://get.pulumi.com | sh -s -- --version dev
@@ -571,7 +573,7 @@ $ curl -fsSL https://get.pulumi.com | sh -s -- --version dev
 
 {{% choosable os linux %}}
 
-### Installation script
+### Linux Installation Script
 
 To install, run our installation script:
 
@@ -583,7 +585,7 @@ $ curl -fsSL https://get.pulumi.com | sh -s -- --version dev
 
 {{% choosable os windows %}}
 
-### Installation script
+### Windows Installation Script
 
 1. Open a new command prompt window (**WIN+R**: `cmd.exe`):
 

--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -557,7 +557,7 @@ You can specify a specific version with [Chocolatey package manager](https://cho
 
 ## Installing dev releases
 
-In addition to installing a specific version, the latest dev version can also be installed automatically.  This version contains the latest changes that have been merged to the main branch.
+In addition to installing a specific version, the latest dev version can also be installed automatically.  This version contains the latest changes that have been merged to the main development branch.
 
 {{% chooser os "macos,windows,linux" %}}
 

--- a/themes/default/content/docs/install/_index.md
+++ b/themes/default/content/docs/install/_index.md
@@ -555,6 +555,48 @@ You can specify a specific version with [Chocolatey package manager](https://cho
 
 {{% /chooser %}}
 
+In addition to insalling a specific version, the latest dev version can also be installed automatically.  This version contains the latest changes that have been merged to the main branch.
+
+{{% chooser os "macos,windows,linux" %}}
+
+{{% choosable os macos %}}
+
+### Installation script
+
+```bash
+$ curl -fsSL https://get.pulumi.com | sh -s -- --version dev
+```
+
+{{% /choosable %}}
+
+{{% choosable os linux %}}
+
+### Installation script
+
+To install, run our installation script:
+
+```bash
+$ curl -fsSL https://get.pulumi.com | sh -s -- --version dev
+```
+
+{{% /choosable %}}
+
+{{% choosable os windows %}}
+
+### Installation script
+
+1. Open a new command prompt window (**WIN+R**: `cmd.exe`):
+
+1. Run our installation script:
+
+```powershell
+> @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1')) -version dev" && SET "PATH=%PATH%;%USERPROFILE%\.pulumi\bin"
+```
+
+{{% /choosable %}}
+
+{{% /chooser %}}
+
 ## Uninstalling Pulumi
 
 To uninstall Pulumi, use your installation method's command of choice. If you installed Pulumi manually, delete the `pulumi` directory that you created. Afterwards, remove the `.pulumi` folder from your home directory which contains plugins and other cached metadata.


### PR DESCRIPTION
## Description

Add instructions for installing the dev version of the pulumi CLI to our installation page.  This helps make it more discoverable and may get more people to use it and report bugs early.

Part of https://github.com/pulumi/docs/issues/11100

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
