### PR TITLE
add instructions for installing dev releases of SDKs

### DIFF
--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -259,7 +259,7 @@ SDK reference documentation, organized by language.
 
 ## Dev Versions
 
-Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  To use them you can use the `--prerelease` flag.  For example `dotnet add package Pulumi --prerelease`.
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main development branch.  To use them you can use the `--prerelease` flag.  For example `dotnet add package Pulumi --prerelease`.
 
 ### Standard Packages
 

--- a/themes/default/content/docs/languages-sdks/dotnet/_index.md
+++ b/themes/default/content/docs/languages-sdks/dotnet/_index.md
@@ -257,6 +257,10 @@ If you don't use Azure DevOps or GitHub Actions, Pulumi also supports a number o
 
 SDK reference documentation, organized by language.
 
+## Dev Versions
+
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  To use them you can use the `--prerelease` flag.  For example `dotnet add package Pulumi --prerelease`.
+
 ### Standard Packages
 
 In addition to the standard packages the [Pulumi Registry](/registry/) houses 100+ .NET packages.

--- a/themes/default/content/docs/languages-sdks/go/_index.md
+++ b/themes/default/content/docs/languages-sdks/go/_index.md
@@ -58,7 +58,7 @@ In addition to the standard packages the [Pulumi Registry](/registry/) houses 10
 
 ## Dev Versions
 
-Unlike other languages there's no specific packaging for Go.  You can always install the latest version from the main branch using the regular `go get` tooling.  For example `go get github.com/pulumi/pulumi/sdk/v3@master`.
+You can install the latest pre-release version from the main branch using the regular `go get` tooling.  For example `go get github.com/pulumi/pulumi/sdk/v3@master`.
 
 ### Standard Packages
 

--- a/themes/default/content/docs/languages-sdks/go/_index.md
+++ b/themes/default/content/docs/languages-sdks/go/_index.md
@@ -58,7 +58,7 @@ In addition to the standard packages the [Pulumi Registry](/registry/) houses 10
 
 ## Dev Versions
 
-You can install the latest pre-release version from the main branch using the regular `go get` tooling.  For example `go get github.com/pulumi/pulumi/sdk/v3@master`.
+You can install the latest pre-release version from the main development branch using the regular `go get` tooling.  For example `go get github.com/pulumi/pulumi/sdk/v3@master`.
 
 ### Standard Packages
 

--- a/themes/default/content/docs/languages-sdks/go/_index.md
+++ b/themes/default/content/docs/languages-sdks/go/_index.md
@@ -56,6 +56,10 @@ The Pulumi programming model includes a core concept of `Input` and `Output` val
 
 In addition to the standard packages the [Pulumi Registry](/registry/) houses 100+ Go packages.
 
+## Dev Versions
+
+Unlike other languages there's no specific packaging for Go.  You can always install the latest version from the main branch using the regular `go get` tooling.  For example `go get github.com/pulumi/pulumi/sdk/v3@master`.
+
 ### Standard Packages
 
 <dl class="tabular">

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -283,7 +283,7 @@ need to upgrade.
 
 ## Dev Versions
 
-Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  If you would like to install them, you can use the `dev` tag to do so.  For example using `npm` you can use `npm add @pulumi/pulumi@dev`, and similarly for `yarn` `yarn add @pulumi/pulumi@dev`.
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main development branch.  If you would like to install them, you can use the `dev` tag to do so.  For example using `npm` you can use `npm add @pulumi/pulumi@dev`, and similarly for `yarn` `yarn add @pulumi/pulumi@dev`.
 
 ## Package Documentation
 

--- a/themes/default/content/docs/languages-sdks/javascript/_index.md
+++ b/themes/default/content/docs/languages-sdks/javascript/_index.md
@@ -281,6 +281,10 @@ For instance, if `@pulumi/random` v4.8.2 contained a fix you rely on, use this i
 When you use a version of `@pulumi/random` in your consuming project which is too old, NPM will warn you that you
 need to upgrade.
 
+## Dev Versions
+
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  If you would like to install them, you can use the `dev` tag to do so.  For example using `npm` you can use `npm add @pulumi/pulumi@dev`, and similarly for `yarn` `yarn add @pulumi/pulumi@dev`.
+
 ## Package Documentation
 
 In addition to the standard and cloud-agnostic packages the [Pulumi Registry](/registry/) houses 100+ Node.js packages.

--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -138,7 +138,6 @@ $ venv/bin/pip install -r requirements.txt
 
 Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  If you would like to install them, you can use the `--pre` flag to do so.  For example `pip install --pre -r requirements.txt`.
 
-
 ## Package Documentation
 
 In addition to the standard packages the [Pulumi Registry](/registry/) houses 100+ Python packages.

--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -134,6 +134,11 @@ $ venv/bin/pip install -r requirements.txt
 
 {{< /chooser >}}
 
+### Dev Versions
+
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  If you would like to install them, you can use the `--pre` flag to do so.  For example `pip install --pre -r requirements.txt`.
+
+
 ## Package Documentation
 
 In addition to the standard packages the [Pulumi Registry](/registry/) houses 100+ Python packages.

--- a/themes/default/content/docs/languages-sdks/python/_index.md
+++ b/themes/default/content/docs/languages-sdks/python/_index.md
@@ -136,7 +136,7 @@ $ venv/bin/pip install -r requirements.txt
 
 ### Dev Versions
 
-Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main branch.  If you would like to install them, you can use the `--pre` flag to do so.  For example `pip install --pre -r requirements.txt`.
+Pulumi SDKs also publish pre-release versions, that include all the latest changes from the main development branch.  If you would like to install them, you can use the `--pre` flag to do so.  For example `pip install --pre -r requirements.txt`.
 
 ## Package Documentation
 


### PR DESCRIPTION
## Description

Similar to how we are adding instruction for installing the dev channel CLI, we want to do the same for the SDKs.  This feels a little more awkward, since the pages don't give super clear instructions how to install our SDKs in the first place.  Any suggestions where to place this are welcome!

Part of https://github.com/pulumi/docs/issues/11100

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
