### PR TITLE
Proposing Modification to the Subject Claim Examples for AWS OIDC

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/oidc/aws.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/aws.md
@@ -66,8 +66,10 @@ In the following example, the role may only be assumed by stacks within the `Cor
 
 ```json
 "Condition": {
+  "StringEquals": {
+    "api.pulumi.com/oidc:aud": "contoso"
+  },
   "StringLike": {
-    "api.pulumi.com/oidc:aud": "contoso",
     "api.pulumi.com/oidc:sub": "pulumi:deploy:org:contoso:project:Core:*"
   }
 }
@@ -79,7 +81,7 @@ In the following example, the role may only be assumed by the `development` envi
 
 ```json
 "Condition": {
-  "StringLike": {
+  "StringEquals": {
     "api.pulumi.com/oidc:aud": "contoso",
     "api.pulumi.com/oidc:sub": "pulumi:environments:org:contoso:env:development"
   }
@@ -88,7 +90,8 @@ In the following example, the role may only be assumed by the `development` envi
 
 {{< notes type="warning" >}}
 
-If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's value sent to Azure from Pulumi.
+If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's value sent to AWS from Pulumi.
+
 
 Use 'subjectAttributes' to customize the subject identifier to work with Pulumi IaC. Alternatively, you can use this syntax: `pulumi:environments:org:contoso:env:<yaml>` when configuring the subject claim in your cloud provider account. Make sure to replace `contoso` with the name of your Pulumi organization and use the literal value of `<yaml>` as shown.
 

--- a/themes/default/content/docs/pulumi-cloud/oidc/aws.md
+++ b/themes/default/content/docs/pulumi-cloud/oidc/aws.md
@@ -92,7 +92,6 @@ In the following example, the role may only be assumed by the `development` envi
 
 If you are integrating Pulumi ESC with Pulumi IaC, the default subject identifier of the ESC environment will not work at this time. There is a [known issue](https://github.com/pulumi/pulumi/issues/14509) with the subject identifier's value sent to AWS from Pulumi.
 
-
 Use 'subjectAttributes' to customize the subject identifier to work with Pulumi IaC. Alternatively, you can use this syntax: `pulumi:environments:org:contoso:env:<yaml>` when configuring the subject claim in your cloud provider account. Make sure to replace `contoso` with the name of your Pulumi organization and use the literal value of `<yaml>` as shown.
 
 {{< /notes >}}


### PR DESCRIPTION
## Description
I'm looking to ensure that the `aud` claim strictly matches the organization name. I propose using the `StringEquals` condition rather than the `StringLike` condition to enforce this strict match.

In the event a user decides to remove or not specify a subject, and the `StringLike` condition remains for the audience, then the door is open for a malicious actor (who has knowledge of the role ARN) to assume the AWS OIDC role. For example, a malicious actor could create a Pulumi org called *contoso-malicious*, which can be leveraged to assume a role in the *contoso* org.

Also, I am changing reference from Azure to AWS in the warning note.

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
