### PR TITLE
Fix ESC context options

### DIFF
--- a/themes/default/content/docs/esc/environments.md
+++ b/themes/default/content/docs/esc/environments.md
@@ -218,8 +218,8 @@ It can be accessed through the `context` attribute with the following options:
 
 * `context.rootEnvironment.name`: the name of the root environment being evaluated
 * `context.currentEnvironment.name`: the name of the current environment being evaluated
-* `context.user.login`: the user login identifier
-* `context.organization.login`: the organization login identifier
+* `context.pulumi.user.login`: the user login identifier
+* `context.pulumi.organization.login`: the organization login identifier
 
 ## Editing environments
 


### PR DESCRIPTION
Two of the provided context options were missing the `pulumi` part of the path.

## Description

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
