### PR TITLE
Fix invalid example in ESC REST API docs

### DIFF
--- a/themes/default/content/docs/pulumi-cloud/cloud-rest-api/_index.md
+++ b/themes/default/content/docs/pulumi-cloud/cloud-rest-api/_index.md
@@ -2339,7 +2339,6 @@ curl \
   -H "Content-Type: application/json" \
   -H "Authorization: token $PULUMI_ACCESS_TOKEN" \
   --request POST \
-  --data '<yaml content>' \
   https://api.pulumi.com/api/preview/environments/{organization}/{environment}
 ```
 


### PR DESCRIPTION
The create example included an incorrect `curl` command, which included YAML content in the POST method. The API actually only supports updating the environment content in the PATCH method.

## Description

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
