### PR TITLE
Fix example programs, bring the tests back to green

### DIFF
--- a/scripts/programs/test.sh
+++ b/scripts/programs/test.sh
@@ -26,13 +26,26 @@ else
 fi
 
 pushd "$programs_dir"
+    found_first_program=false
+
     for dir in */; do
         project="$(basename $dir)"
 
         # Optionally test only selected examples by setting an ONLY_TEST="<example-path>"
         # environment variable (e.g., ONLY_TEST="awsx-ecr-repository").
-        if [[ ! -z "$ONLY_TEST" && "$dir" != "$ONLY_TEST"* ]]; then
+        if [[ ! -z "$ONLY_TEST" && "$project" != "$ONLY_TEST"* ]]; then
             continue
+        fi
+
+        # Optionally test only from the specified example forward by setting ONLY_TEST_FROM="<example-path>".
+        if [[ ! -z "$ONLY_TEST_FROM" ]]; then
+            if [[ "$project" == "$ONLY_TEST_FROM"* && "$found_first_program" == false ]]; then
+                found_first_program=true
+            fi
+
+            if [ "$found_first_program" == false ]; then
+                continue
+            fi
         fi
 
         # Skip programs we know don't compile.

--- a/themes/default/static/programs/aws-acm-certificate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-acm-certificate-go/go.mod.txt
@@ -3,6 +3,6 @@ module aws-acm-certificate-go
 go 1.21
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-ec2-instance-with-sg-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-instance-with-sg-go/go.mod.txt
@@ -4,5 +4,5 @@ go 1.20
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
@@ -1,6 +1,8 @@
 module aws-ec2-sg-nginx-server-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/aws-ec2-vpc-resources-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-vpc-resources-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
+++ b/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
@@ -1,6 +1,8 @@
 module aws-eks-cluster-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
+++ b/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi-eks/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi-eks/sdk/v2 v2.3.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
@@ -4,4 +4,4 @@ go 1.21
 
 toolchain go1.22.1
 
-require github.com/pulumi/pulumi/sdk/v3 v3.108.1
+require github.com/pulumi/pulumi/sdk/v3 v3.112.0

--- a/themes/default/static/programs/aws-import-export-pulumi-config-go/go.mod.txt
+++ b/themes/default/static/programs/aws-import-export-pulumi-config-go/go.mod.txt
@@ -2,4 +2,4 @@ module aws-import-export-pulumi-config-go
 
 go 1.20
 
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0
+require github.com/pulumi/pulumi/sdk/v3 v3.112.0

--- a/themes/default/static/programs/aws-lambda-stepfunctions-jsonhelper-go/go.mod.txt
+++ b/themes/default/static/programs/aws-lambda-stepfunctions-jsonhelper-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-s3-bucket-resources-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3-bucket-resources-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-s3-bucketpolicy-jsonstringify-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3-bucketpolicy-jsonstringify-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-s3bucket-bucketobject-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3bucket-bucketobject-interpolate-go/go.mod.txt
@@ -4,5 +4,5 @@ go 1.21
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-s3bucket-bucketpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3bucket-bucketpolicy-go/go.mod.txt
@@ -3,6 +3,6 @@ module aws-s3bucket-bucketpolicy-go
 go 1.21
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-s3bucket-bucketpolicy-java/src/main/java/myproject/App.java
+++ b/themes/default/static/programs/aws-s3bucket-bucketpolicy-java/src/main/java/myproject/App.java
@@ -1,26 +1,29 @@
+package myproject;
+
 import com.pulumi.Pulumi;
-import com.pulumi.core.Output;
 import com.pulumi.aws.s3.Bucket;
 import com.pulumi.aws.s3.BucketPolicy;
-import com.pulumi.aws.s3.inputs.BucketPolicyPolicyArgs;
-import java.util.Map;
+import com.pulumi.aws.s3.BucketPolicyArgs;
+import static com.pulumi.codegen.internal.Serialization.*;
 
 public class App {
     public static void main(String[] args) {
         Pulumi.run(ctx -> {
             var bucket = new Bucket("myBucket");
 
-            var bucketArn = bucket.arn();
-            var policyDocument = bucketArn.apply(arn -> String.format("""
-                {
-                  "Version": "2012-10-17",
-                  "Statement": [{
-                    "Effect": "Allow",
-                    "Principal": {"Service": "lambda.amazonaws.com"},
-                    "Action": ["s3:PutObject", "s3:PutObjectAcl"],
-                    "Resource": "%s/*"
-                  }]
-                }""", arn));
+            var policyDocument = bucket.arn().applyValue(arn -> serializeJson(
+                jsonObject(
+                    jsonProperty("Version", "2012-10-17"),
+                    jsonProperty("Statement", jsonArray(jsonObject(
+                        jsonProperty("Effect", "Allow"),
+                        jsonProperty("Action", jsonArray("s3:PutObject", "s3:PutObjectAcl")),
+                        jsonProperty("Principal", jsonObject(
+                            jsonProperty("Service", "lambda.amazonaws.com")
+                        )),
+                        jsonProperty("Resource", arn + "/*")
+                    )))
+                )
+            ));
 
             var bucketPolicy = new BucketPolicy("myBucketPolicy", BucketPolicyArgs.builder()
                 .bucket(bucket.id())

--- a/themes/default/static/programs/aws-s3bucket-bucketpolicy-python/__main__.py
+++ b/themes/default/static/programs/aws-s3bucket-bucketpolicy-python/__main__.py
@@ -6,22 +6,29 @@ import json
 s3_bucket = aws.s3.Bucket("myBucket")
 
 # IAM Policy Document that allows the Lambda service to write to the S3 bucket
-s3_bucket_policy_document = s3_bucket.arn.apply(lambda arn: json.dumps({
-    "Version": "2012-10-17",
-    "Statement": [{
-        "Effect": "Allow",
-        "Principal": {"Service": "lambda.amazonaws.com"},
-        "Action": ["s3:PutObject", "s3:PutObjectAcl"],
-        "Resource": f"{arn}/*"
-    }]
-}))
+s3_bucket_policy_document = s3_bucket.arn.apply(
+    lambda arn: json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": ["s3:PutObject", "s3:PutObjectAcl"],
+                    "Resource": f"{arn}/*",
+                }
+            ],
+        }
+    )
+)
 
 # Attach the policy to the bucket
-s3_bucket_policy = aws.s3.BucketPolicy("myBucketPolicy",
+s3_bucket_policy = aws.s3.BucketPolicy(
+    "myBucketPolicy",
     bucket=s3_bucket.id,
     policy=s3_bucket_policy_document,
 )
 
 # Export the names and ARNs of the created resources
-pulumi.export('bucket_name', s3_bucket.id)
-pulumi.export('bucket_arn', s3_bucket.arn)
+pulumi.export("bucket_name", s3_bucket.id)
+pulumi.export("bucket_arn", s3_bucket.arn)

--- a/themes/default/static/programs/aws-s3bucket-bucketpolicy-yaml/Pulumi.yaml
+++ b/themes/default/static/programs/aws-s3bucket-bucketpolicy-yaml/Pulumi.yaml
@@ -11,19 +11,17 @@ resources:
     properties:
       bucket: ${myBucket.id}
       policy:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: "Allow"
-            Principal:
-              Service: "lambda.amazonaws.com"
-            Action:
-              - "s3:PutObject"
-              - "s3:PutObjectAcl"
-            Resource:
-              Fn::Sub: "${myBucket.arn}/*"
+        fn::toJSON:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service: "lambda.amazonaws.com"
+              Action:
+                - "s3:PutObject"
+                - "s3:PutObjectAcl"
+              Resource: "${myBucket.arn}/*"
 
 outputs:
-  bucket_name:
-    value: ${myBucket.id}
-  bucket_arn:
-    value: ${myBucket.arn}
+  bucket_name: ${myBucket.id}
+  bucket_arn: ${myBucket.arn}

--- a/themes/default/static/programs/aws-s3websitebucket-oai-bucketpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3websitebucket-oai-bucketpolicy-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/aws-simulated-dbserver-database-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-dbserver-database-go/go.mod.txt
@@ -2,4 +2,4 @@ module aws-simulated-dbserver-database-go
 
 go 1.20
 
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0
+require github.com/pulumi/pulumi/sdk/v3 v3.112.0

--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,5 +1,0 @@
-module aws-simulated-server-interpolate-go
-
-go 1.20
-
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0

--- a/themes/default/static/programs/awsx-apigateway-api-keys-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-api-keys-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-api-keys-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-auth-cognito-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-auth-cognito-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-auth-lambda-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-auth-lambda-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-custom-domain-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-custom-domain-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-http-proxy-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-http-proxy-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-http-proxy-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-lambda-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-lambda-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-lambda-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-openapi-full-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-openapi-full-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-openapi-full-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-openapi-route-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-openapi-route-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-openapi-route-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-s3-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-s3-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-s3-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-apigateway-validation-types-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-validation-types-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-validation-types-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
@@ -1,10 +1,12 @@
 module awsx-ecr-eks-deployment-service-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi-eks/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.6.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi-eks/sdk/v2 v2.3.0
+	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.9.1
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-ecr-image-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-ecr-repository-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-elb-multi-listener-redirect-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-elb-private-subnet-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-elb-vpc-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
@@ -1,6 +1,8 @@
 module myproject
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-load-balanced-ec2-instances-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-azs-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-cidr-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-default-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-fargate-service-yaml
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-nat-gateways-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0

--- a/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-security-groups-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-sg-ec2-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0

--- a/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.29.1
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.6.0
+	github.com/pulumi/pulumi/sdk/v3 v3.112.0
 )

--- a/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
@@ -1,6 +1,8 @@
 module awsx-vpc-subnets-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0


### PR DESCRIPTION
Makes some additional fixes for failures I noticed when running the tests for #4157. 

Should make all the tests 🟢 again. (Also bumps all the Go programs by running `make upgrade-programs`.)

Fixes #4160.
Fixes #4077. (This has also been failing for several weeks.)