### PR TITLE
Fix IAMReadOnlyAccess inflection in Python

### DIFF
--- a/themes/default/content/docs/clouds/aws/guides/iam.md
+++ b/themes/default/content/docs/clouds/aws/guides/iam.md
@@ -131,7 +131,7 @@ const rolePolicyAttachment = new aws.iam.RolePolicyAttachment("rpa", {
 role = ...
 role_policy_attachment = aws.iam.RolePolicyAttachment('rpa',
     role=role,
-    policy_arn=aws.iam.ManagedPolicy.IAMReadOnlyAccess,
+    policy_arn=aws.iam.ManagedPolicy.IAM_READ_ONLY_ACCESS,
 )
 ```
 


### PR DESCRIPTION
## Description

Per @toriancrane current example does not work. Fixing it to inflect the enum the way Python projection of the AWS provider actually supports at the moment.

Fixes #4184 

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
