### PR TITLE
Add link to the new TypeScript versioning setup to the monorepo blog

### DIFF
--- a/themes/default/content/blog/nx-monorepo/index.md
+++ b/themes/default/content/blog/nx-monorepo/index.md
@@ -79,6 +79,10 @@ By using [npm workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) w
 
 Pulumi has builtin TypeScript support and compiles your code on the fly without manual build-step, however this is currently limited to TypeScript 3.8. We are working on providing more choice here, but in the mean time Nx makes it easy to add a build-step to compile code using any version of TypeScript. For this example we are using the latest and greatest, TypeScript 5.4.
 
+{{% notes type="info" %}}
+As of [v3.113.0 of the @pulumi/pulumi NPM package](https://www.npmjs.com/package/@pulumi/pulumi) any version of TypeScript is supported natively. To select the version to use, add it as a [dependency to your package.json](/docs/languages-sdks/javascript/#typescript-versions).
+{{% /notes %}}
+
 ## Declaring Dependencies
 
 If we were to manually build and deploy the code in our monorepo, we would have to run the following steps:


### PR DESCRIPTION
## Description

Add an info note about typescript versions to the nx monorepo blog

http://pulumi-hugo-origin-pr-4189-b3809a13.s3-website.us-west-2.amazonaws.com/blog/nx-monorepo/#typescript

<img width="877" alt="Screenshot 2024-04-16 at 17 38 30" src="https://github.com/pulumi/pulumi-hugo/assets/387068/b6278818-ba79-47e3-a5b0-3059946d7b4e">


## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
