### PR TITLE
fix broken links

### DIFF
--- a/themes/default/content/blog/pulumi-release-notes-103/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-103/index.md
@@ -12,7 +12,7 @@ tags:
     - release-notes
 ---
 
-As always, we have been actively rolling out new features in response to the invaluable feedback from our ever-growing community.  We've shipped several security and usability features to [Pulumi ESC](/docs/esc) in response to feedback from our growing user base. Moreover, we've also added new enhancements to our core Platform CLI and Providers. In addition to the release notes, stay up-to-date with all things Pulumi by following the [new features blogs](/blog/tag/features) and the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md). With so much to explore, let’s dive into the major updates across Pulumi from the past two months!
+As always, we have been actively rolling out new features in response to the invaluable feedback from our ever-growing community.  We've shipped several security and usability features to [Pulumi ESC](/docs/esc) in response to feedback from our growing user base. Moreover, we've also added new enhancements to our core Platform CLI and Providers. In addition to the release notes, stay up-to-date with all things Pulumi by following the [new features blogs](/blog/tag/features) and the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi-aws-native/releases). With so much to explore, let’s dive into the major updates across Pulumi from the past two months!
 
 <!--more-->
 

--- a/themes/default/content/blog/pulumi-release-notes-85/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-85/index.md
@@ -34,7 +34,7 @@ tags:
 # for additional details, and please remove these comments before submitting for review.
 ---
 
-We have been busy shipping improvements in the last 2 months. Let's walk through the release highlights across Pulumi engineering areas from January and February. If you want to learn more between release blogs, follow the CLI improvements in the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md) and Pulumi Service features in the [new features blogs](/blog/tag/features).
+We have been busy shipping improvements in the last 2 months. Let's walk through the release highlights across Pulumi engineering areas from January and February. If you want to learn more between release blogs, follow the CLI improvements in the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi-aws-native/releases) and Pulumi Service features in the [new features blogs](/blog/tag/features).
 
 <!--more-->
 

--- a/themes/default/content/blog/pulumi-release-notes-87/index.md
+++ b/themes/default/content/blog/pulumi-release-notes-87/index.md
@@ -12,7 +12,7 @@ tags:
    - pulumi-releases
 ---
 
-We have been busy shipping improvements in the last 2 months. Let's walk through the release highlights across Pulumi engineering areas from March and April. If you want to learn more between release blogs, follow the CLI improvements in the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi/blob/master/CHANGELOG.md) and Pulumi Cloud features in the [new features blogs](/blog/tag/features).
+We have been busy shipping improvements in the last 2 months. Let's walk through the release highlights across Pulumi engineering areas from March and April. If you want to learn more between release blogs, follow the CLI improvements in the [pulumi/pulumi repo changelog](https://github.com/pulumi/pulumi-aws-native/releases) and Pulumi Cloud features in the [new features blogs](/blog/tag/features).
 
 <!--more-->
 


### PR DESCRIPTION
## Description

fix up some broken links. Changelogs no longer exist in the pulumi-aws-native repo. The changes are now itemized in the released notes so linking there.