### PR TITLE
Fix indentation in yaml reference for explicit providers

### DIFF
--- a/themes/default/content/docs/languages-sdks/yaml/yaml-language-reference.md
+++ b/themes/default/content/docs/languages-sdks/yaml/yaml-language-reference.md
@@ -135,7 +135,8 @@ resources:
 To create an explicit provider instance, preferably with a specific version, use the [`resources`](#resources) section and prefix the name of the provider with `pulumi:providers` which will the value of the `type` property.
 
 ```yaml
-provider:
+resources:
+  provider:
     type: pulumi:providers:azure
     options:
       version: 5.1.0

--- a/themes/default/content/docs/languages-sdks/yaml/yaml-language-reference.md
+++ b/themes/default/content/docs/languages-sdks/yaml/yaml-language-reference.md
@@ -132,7 +132,7 @@ resources:
 
 #### Explicit provider
 
-To create an explicit provider instance, preferably with a specific version, use the [`resources`](#resources) section and prefix the name of the provider with `pulumi:providers` which will the value of the `type` property.
+To create an explicit provider instance, preferably with a specific version, use the [`resources`](#resources) section. For the `type` property, prefix the name of the provider with `pulumi:providers`.
 
 ```yaml
 resources:


### PR DESCRIPTION
## Description
Small fix in the yaml reference - was missing the resources declaration.

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
