### PR TITLE
Delete themes/default/static/programs/aws-simulated-server-interpolat…

### DIFF
--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,5 +1,0 @@
-module aws-simulated-server-interpolate-go
-
-go 1.20
-
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0


### PR DESCRIPTION
This seems to have snuck back in somehow. (It shouldn't be here and is currently breaking the tests.)
