### PR TITLE
add 1password workshop youtube link

### DIFF
--- a/themes/default/content/resources/managing-team-secrets-1password-pulumi-esc/index.md
+++ b/themes/default/content/resources/managing-team-secrets-1password-pulumi-esc/index.md
@@ -36,7 +36,7 @@ main:
     event_type: workshop # workshop | event
 
     # URL for embedding a URL for ungated webinars.
-    youtube_url: 
+    youtube_url: https://www.youtube.com/embed/8AgmP01_qnw?rel=0
 
     # Sortable date. The datetime Hugo will use to sort the webinars in date order.
     sortable_date: 2024-04-23T09:00:00.000-07:00


### PR DESCRIPTION
## Description
add 1password workshop youtube url for on-demand workshops

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
