### PR TITLE
update request change issue link

### DIFF
--- a/config/_default/config.yml
+++ b/config/_default/config.yml
@@ -105,7 +105,7 @@ markup:
 
 params:
   canonicalURL: https://www.pulumi.com
-  contentRepositoryURL: https://github.com/pulumi/pulumi-hugo
+  contentRepositoryURL: https://github.com/pulumi/docs
   contentRepositoryBaseBranch: master
   registryRepositoryURL: https://github.com/pulumi/registry
   registryRepositoryBaseBranch: master

--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,0 +1,5 @@
+module aws-simulated-server-interpolate-go
+
+go 1.20
+
+require github.com/pulumi/pulumi/sdk/v3 v3.102.0

--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,5 +1,0 @@
-module aws-simulated-server-interpolate-go
-
-go 1.20
-
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0


### PR DESCRIPTION
## Description

Updates "Request a change" link to open issues in docs instead of pulumi-hugo, since we are moving everything there.

I updated the contentRepositoryURL prop to do this. [This](https://github.com/pulumi/pulumi-hugo/blob/master/themes/default/layouts/partials/docs/table-of-contents.html#L77) is the only place I have found it being referenced, i.e. in the TOC for the request a change link.