### PR TITLE
Fix incorrect/misleading sentence in string interpolation section

### DIFF
--- a/themes/default/content/docs/concepts/inputs-outputs/all.md
+++ b/themes/default/content/docs/concepts/inputs-outputs/all.md
@@ -163,7 +163,7 @@ Server=tcp:myDbServer.database.windows.net;initial catalog=myExampleDatabase;
 
 ### Using string interpolation
 
-There is an easier way to generate a concatenated string value using multiple outputs, and that is by using interpolation. Pulumi exposes interpolation helpers that enables you to create strings that contain outputs. These interpolation methods wrap [all](/docs/concepts/inputs-outputs/all/) and [apply](/docs/concepts/inputs-outputs/apply/) with an interface that resembles your language's native string formatting functions. The example below demonstrates how to create a URL from the hostname and port output values of a web server.
+There is an easier way to generate a concatenated string value using multiple outputs, and that is by using interpolation. Pulumi exposes interpolation helpers that enables you to create strings that contain outputs. These interpolation methods wrap [all](/docs/concepts/inputs-outputs/all/) and [apply](/docs/concepts/inputs-outputs/apply/) with an interface that resembles your language's native string formatting functions. The example below demonstrates how to create an S3 URL from the bucket name and object key output values of an S3 bucket and object, respectively.
 
 {{< example-program path="aws-s3bucket-bucketobject-interpolate" >}}
 


### PR DESCRIPTION
The sentence says we'll be constructing a string regarding a web server URL but the example code constructs an S3 URL from an S3 bucket and object instead. I changed the sentence to correctly describe the code example.

## Description

## Checklist:

- [ ] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [ ] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [ ] I have manually confirmed that all new links work.
- [ ] I added aliases (i.e., redirects) for all filename changes.
- [ ] If making css changes, I rebuilt the bundle.
