### PR TITLE
Fix typo update-plans.md

### DIFF
--- a/themes/default/content/docs/concepts/update-plans.md
+++ b/themes/default/content/docs/concepts/update-plans.md
@@ -43,7 +43,7 @@ simply records `unknown`.
 
 The next most common issue is creating resources inside an [`apply`
 function](/docs/concepts/inputs-outputs/#apply). If the value for the apply is
-unknown at preview time than the entire apply function will not run. This results in the plan not recording
+unknown at preview time, then the apply function will not run. This results in the plan not recording
 anything for the resources created inside the apply and reporting an error at update time when they try to
 create. This mostly comes up in the context of needing to create a resource for every item in an array, we
 have [an issue on GitHub](https://github.com/pulumi/pulumi/issues/4834) tracking support for this.


### PR DESCRIPTION
"than" was incorrectly used instead of "then". Also made a couple of other grammatical improvements.

## Description

## Checklist:

- [x] I have reviewed the [style guide](https://github.com/pulumi/pulumi-hugo/blob/master/STYLE-GUIDE.md).
- [x] If blogging, I have reviewed the [blogging guide](https://github.com/pulumi/pulumi-hugo/blob/master/BLOGGING.md).
- [x] I have manually confirmed that all new links work.
- [x] I added aliases (i.e., redirects) for all filename changes.
- [x] If making css changes, I rebuilt the bundle.
