### PR TITLE
Fix CSS background color to be more readable for code listings with highlighted lines

### DIFF
--- a/themes/default/theme/src/scss/_chroma.scss
+++ b/themes/default/theme/src/scss/_chroma.scss
@@ -6,7 +6,7 @@
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #474747 }
+/* LineHighlight */ .chroma .hl { background-color: #4d3675 }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
 /* Line */ .chroma .line { display: flex; }

--- a/themes/default/theme/src/scss/_chroma.scss
+++ b/themes/default/theme/src/scss/_chroma.scss
@@ -6,7 +6,7 @@
 /* LineLink */ .chroma .lnlinks { outline: none; text-decoration: none; color: inherit }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
-/* LineHighlight */ .chroma .hl { background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { background-color: #474747 }
 /* LineNumbersTable */ .chroma .lnt { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #64686c }
 /* LineNumbers */ .chroma .ln { white-space: pre; -webkit-user-select: none; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #6e7681 }
 /* Line */ .chroma .line { display: flex; }


### PR DESCRIPTION
This makes a small change to the CSS for code blocks that have highlighted lines. I ran the bundler to update the `bundle.css` file and also changed it in the source `.scss` file.

A code block like this:

```typescript {hl_lines=[2]}
import * as aws from "@pulumi/aws";
import * as childProcess from "child_process";
```

Will currently render with this background color, which is hard to read:

<img width="626" alt="Screenshot 2024-05-13 at 1 39 19 PM" src="https://github.com/pulumi/pulumi-hugo/assets/478164/f3e64863-129a-43f5-be26-7560e912b981">


After this change it will look like this:

<img width="627" alt="Screenshot 2024-05-13 at 1 39 05 PM" src="https://github.com/pulumi/pulumi-hugo/assets/478164/d305c828-acb6-493b-8144-123f6d4954a2">

