### PR TITLE
Upgrade example programs, remove persistent empty one

### DIFF
--- a/themes/default/static/programs/aws-acm-certificate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-acm-certificate-go/go.mod.txt
@@ -3,6 +3,6 @@ module aws-acm-certificate-go
 go 1.21
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-ec2-instance-with-sg-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-instance-with-sg-go/go.mod.txt
@@ -1,8 +1,10 @@
 module aws-ec2-instance-with-sg-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-sg-nginx-server-go/go.mod.txt
@@ -1,8 +1,10 @@
 module aws-ec2-sg-nginx-server-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-ec2-vpc-resources-go/go.mod.txt
+++ b/themes/default/static/programs/aws-ec2-vpc-resources-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
+++ b/themes/default/static/programs/aws-eks-cluster-go/go.mod.txt
@@ -1,9 +1,11 @@
 module aws-eks-cluster-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi-eks/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi-eks/sdk/v2 v2.3.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-iam-role-instanceprofile-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iam-role-instanceprofile-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-iam-role-policyattachment-managedpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iam-role-policyattachment-managedpolicy-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-iam-user-group-grouppolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iam-user-group-grouppolicy-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-iam-user-userpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iam-user-userpolicy-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
+++ b/themes/default/static/programs/aws-iampolicy-jsonparse-go/go.mod.txt
@@ -4,4 +4,4 @@ go 1.21
 
 toolchain go1.22.1
 
-require github.com/pulumi/pulumi/sdk/v3 v3.108.1
+require github.com/pulumi/pulumi/sdk/v3 v3.116.1

--- a/themes/default/static/programs/aws-import-export-pulumi-config-go/go.mod.txt
+++ b/themes/default/static/programs/aws-import-export-pulumi-config-go/go.mod.txt
@@ -1,5 +1,7 @@
 module aws-import-export-pulumi-config-go
 
-go 1.20
+go 1.21
 
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0
+toolchain go1.21.9
+
+require github.com/pulumi/pulumi/sdk/v3 v3.116.1

--- a/themes/default/static/programs/aws-lambda-stepfunctions-jsonhelper-go/go.mod.txt
+++ b/themes/default/static/programs/aws-lambda-stepfunctions-jsonhelper-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-s3-bucket-resources-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3-bucket-resources-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-s3-bucketpolicy-jsonstringify-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3-bucketpolicy-jsonstringify-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-s3bucket-bucketobject-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3bucket-bucketobject-interpolate-go/go.mod.txt
@@ -4,5 +4,5 @@ go 1.21
 
 require (
 	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-s3bucket-bucketpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3bucket-bucketpolicy-go/go.mod.txt
@@ -3,6 +3,6 @@ module aws-s3bucket-bucketpolicy-go
 go 1.21
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v4 v4.38.1
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-s3websitebucket-oai-bucketpolicy-go/go.mod.txt
+++ b/themes/default/static/programs/aws-s3websitebucket-oai-bucketpolicy-go/go.mod.txt
@@ -5,6 +5,6 @@ go 1.21
 toolchain go1.22.1
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.24.0
-	github.com/pulumi/pulumi/sdk/v3 v3.108.1
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/aws-simulated-dbserver-database-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-dbserver-database-go/go.mod.txt
@@ -1,5 +1,7 @@
 module aws-simulated-dbserver-database-go
 
-go 1.20
+go 1.21
 
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0
+toolchain go1.21.9
+
+require github.com/pulumi/pulumi/sdk/v3 v3.116.1

--- a/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
+++ b/themes/default/static/programs/aws-simulated-server-interpolate-go/go.mod.txt
@@ -1,5 +1,0 @@
-module aws-simulated-server-interpolate-go
-
-go 1.20
-
-require github.com/pulumi/pulumi/sdk/v3 v3.102.0

--- a/themes/default/static/programs/awsx-apigateway-api-keys-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-api-keys-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-api-keys-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-auth-cognito-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-auth-cognito-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-auth-lambda-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-auth-lambda-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-custom-domain-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-custom-domain-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-auth-cognito-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-http-proxy-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-http-proxy-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-http-proxy-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-lambda-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-lambda-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-apigateway-lambda-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-openapi-full-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-openapi-full-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-openapi-full-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-openapi-route-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-openapi-route-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-openapi-route-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-s3-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-s3-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-s3-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-apigateway-validation-types-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-apigateway-validation-types-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-apigateway-validation-types-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.1.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws-apigateway/sdk/v2 v2.4.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-eks-deployment-service-go/go.mod.txt
@@ -1,10 +1,12 @@
 module awsx-ecr-eks-deployment-service-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi-eks/sdk/v2 v2.0.0
-	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.6.1
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi-eks/sdk/v2 v2.3.0
+	github.com/pulumi/pulumi-kubernetes/sdk/v4 v4.11.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-image-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-ecr-image-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-ecr-repository-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-ecr-repository-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-multi-listener-redirect-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-elb-multi-listener-redirect-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-private-subnet-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-elb-private-subnet-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-vpc-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-elb-vpc-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-elb-web-listener-go/go.mod.txt
@@ -1,8 +1,10 @@
 module myproject
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-ec2-instances-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-load-balanced-ec2-instances-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-ecr-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-load-balanced-fargate-nginx-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-load-balanced-fargate-nginx-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-azs-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-azs-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-cidr-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-cidr-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-default-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-default-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-fargate-service-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-vpc-fargate-service-yaml
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-nat-gateways-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-nat-gateways-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-security-groups-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-vpc-security-groups-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-sg-ec2-go/go.mod.txt
@@ -1,9 +1,11 @@
 module awsx-vpc-sg-ec2-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.17.0
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.35.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )

--- a/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
+++ b/themes/default/static/programs/awsx-vpc-subnets-go/go.mod.txt
@@ -1,8 +1,10 @@
 module awsx-vpc-subnets-go
 
-go 1.20
+go 1.21
+
+toolchain go1.21.9
 
 require (
-	github.com/pulumi/pulumi-awsx/sdk/v2 v2.4.0
-	github.com/pulumi/pulumi/sdk/v3 v3.100.0
+	github.com/pulumi/pulumi-awsx/sdk/v2 v2.10.0
+	github.com/pulumi/pulumi/sdk/v3 v3.116.1
 )


### PR DESCRIPTION
Removes an empty directory that's been causing [a workflow failure](https://github.com/pulumi/pulumi-hugo/actions/runs/9092131713/job/24988176767#step:10:7450) and runs `make upgrade-programs` to bring all Go examples current.